### PR TITLE
First try @ configurable menu extension - refs #451

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -63,6 +63,10 @@ a {
   text-align: right;
 }
 
+.mirador-main-menu.user-buttons {
+  padding-right: 0;
+}
+
 .mirador-main-menu li {
   cursor: pointer;
   float: left;

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -66,6 +66,11 @@ a {
 .mirador-main-menu.user-buttons {
   padding-right: 0;
 }
+.mirador-main-menu.user-logo {
+  padding-right: 0;
+  padding-left: 0;
+  float: left;
+}
 
 .mirador-main-menu li {
   cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -19,6 +19,28 @@
       Mirador({
         "id": "viewer",
         "layout": "1x1",
+        "mainMenuSettings" :
+          {"show": true,
+           "buttons" : {"bookmark" : true, "layout" : true},
+           "userButtons": [
+             /* Ordinary link */
+             {"label": "Link",
+             "attributes": {"href": "http://example.com"}},
+             /* If callback key is true, failing to include an ID attribute will *
+              *   throw an exception.                                            */
+             {"label": "Callback",
+              "attributes": {"id": "example-callback", href: "#noop"},
+              "callback": true},
+             /* Sublists are supported, but their display is not (yet) */
+             /*{"label": "Sublist",
+              "sublist": [
+                {"label": "One"},
+                {"label": "Two"}]
+             }*/
+           ]
+          },
+        //'showAddFromURLBox' : false,
+        //"saveSession":false,
         "data": [
           { "manifestUri": "http://oculus-dev.harvardx.harvard.edu/manifests/drs:48309543", "location": "Harvard University"}, // Harvard Scroll 
           { "manifestUri": "http://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/manifest.json", "location": "Stanford University"},
@@ -51,6 +73,12 @@
           { "manifestUri": "http://www.e-codices.unifr.ch/metadata/iiif/bge-cl0015/manifest.json", "location": 'e-codices'}
         ],
         "windowObjects": []
+      });
+
+      /* Callback for mainMenu configuration */
+      $(document).on('click', '#example-callback', function (e) {
+        alert("Example Callback");
+        e.preventDefault();
       });
     });
   </script>

--- a/index.html
+++ b/index.html
@@ -37,8 +37,10 @@
                 {"label": "One"},
                 {"label": "Two"}]
              }*/
-           ]
-          },
+           ],
+           "userLogo": {"label": "Harvard",
+                        "attributes": {"href": "http://harvard.edu"}}
+         },
         //'showAddFromURLBox' : false,
         //"saveSession":false,
         "data": [

--- a/js/src/viewer/mainMenu.js
+++ b/js/src/viewer/mainMenu.js
@@ -41,7 +41,8 @@
                 showBookmark : this.parent.mainMenuSettings.buttons.bookmark,
                 showLayout : this.parent.mainMenuSettings.buttons.layout,
                 showOptions: this.parent.mainMenuSettings.buttons.options,
-                userButtons: this.parent.mainMenuSettings.userButtons
+                userButtons: this.parent.mainMenuSettings.userButtons,
+                userLogo:    this.parent.mainMenuSettings.userLogo
             }));
 
             this.bindEvents();
@@ -60,6 +61,11 @@
         },
 
         template: Handlebars.compile([
+        '{{#if userLogo}}',
+          '<ul class="user-logo {{mainMenuCls}}">',
+            '{{userlogo userLogo}}',
+          '</ul>',
+        '{{/if}}',
         '<ul class="{{mainMenuCls}}">',
         '{{#if showBookmark}}',
           '<li>',
@@ -185,7 +191,13 @@
 
     Handlebars.registerHelper('userbtns', function (userButtons) {
         return new Handlebars.SafeString(
-            jQuery('<ul class="user-buttons mirador-main-menu"></ul>').append(processUserButtons(userButtons)).get(0).outerHTML
+            jQuery('<ul class="user-buttons ' + this.mainMenuCls +'"></ul>').append(processUserButtons(userButtons)).get(0).outerHTML
+        );
+    });
+
+    Handlebars.registerHelper('userlogo', function (userLogo) {
+        return new Handlebars.SafeString(
+            processUserBtn(userLogo).get(0).outerHTML
         );
     });
 

--- a/js/src/viewer/mainMenu.js
+++ b/js/src/viewer/mainMenu.js
@@ -40,7 +40,8 @@
                 mainMenuCls: this.mainMenuCls,
                 showBookmark : this.parent.mainMenuSettings.buttons.bookmark,
                 showLayout : this.parent.mainMenuSettings.buttons.layout,
-                showOptions: this.parent.mainMenuSettings.buttons.options
+                showOptions: this.parent.mainMenuSettings.buttons.options,
+                userButtons: this.parent.mainMenuSettings.userButtons
             }));
 
             this.bindEvents();
@@ -81,7 +82,107 @@
             '</a>',
           '</li>',
         '{{/if}}',
-        '</ul>'
-      ].join(''))
+        '</ul>',
+        '{{#if userButtons}}',
+          '{{userbtns userButtons}}',
+        '{{/if}}'
+        ].join('')),
     };
+
+    /* Helper methods for processing userButtons provided in configuration */
+
+    /*    Processes userButtons configuration setting   *
+     ****************************************************
+     * userButtons, if present, should be an array      *
+     *                                                  *
+     * Its elements should be objects, which can        *
+     * have the following attributes:                   *
+     *                                                  *
+     *   label: text label assigned to the link         *
+     *          created. (required)                     *
+     *   attributes: HTML attributes to add to the      *
+     *          button.  If there is a "callback"       *
+     *          attribute for the button, this MUST     *
+     *          exist and MUST contain an "id" value    *
+     *   li_attributes: HTML attributes to add to the   *
+     *          list item containing the button.        *
+     *   sublist: Sublist of buttons, to be implemented *
+     *          as a dropdown via CSS/JS                *
+     *   ul_attributes: HTML attributes to add to the   *
+     *          sublist UL contained in the button.     *
+     *          Ignored if button isn't representing    *
+     *          a sublist.                              *
+     *   callback: If set to true, and attributes['id'] *
+     *          is not set, an error will be thrown     *
+     *                                                  *
+     * NOTE: sublist dropdown functionality is not yet  *
+     *       implemented                                *
+     ****************************************************/
+    var processUserButtons = function (btns) {
+        var output = [];
+        var btn;
+        var btns_len = btns.length;
+
+        for (var i = 0; i < btns_len; i++){
+            output.push(processUserBtn(btns[i]));
+        }
+        return output;
+    };
+
+    var processUserBtn = function (btn) {
+        var $li = jQuery('<li>');
+        var $a = jQuery('<a>');
+        var $sub_ul;
+
+        try {
+            /* Enclosing <li> for button */
+            if (btn.li_attributes){
+                $li.attr(btn.li_attributes);
+            }
+
+            /* Link for button. */
+            if (!btn.label) {
+                throw "userButtons must have labels";
+            }
+
+            $a.text(btn.label);
+
+            if (btn.attributes){
+                $a.attr(btn.attributes);
+            }
+
+            $li.append($a);
+
+            /* Sublist if present */
+            if (btn.sublist) {
+                $sub_ul = jQuery('<ul>');
+                if (btn.ul_attributes){
+                    $sub_ul.attr(btn.ul_attributes);
+                }
+                /* Recurse! */
+                $sub_ul.append(processUserButtons(btn.sublist));
+
+                $li.append($sub_ul);
+            }
+
+            if (btn.callback) {
+                if (!(btn.attributes && btn.attributes.id)) {
+                    throw "userButton with callback does not have attributes.id";
+                }
+            }
+
+            return $li;
+        }
+        catch (err) {
+            console && console.log && console.log(err);
+            return jQuery();
+        }
+    };
+
+    Handlebars.registerHelper('userbtns', function (userButtons) {
+        return new Handlebars.SafeString(
+            jQuery('<ul class="user-buttons mirador-main-menu"></ul>').append(processUserButtons(userButtons)).get(0).outerHTML
+        );
+    });
+
 }(Mirador));

--- a/js/src/viewer/mainMenu.js
+++ b/js/src/viewer/mainMenu.js
@@ -147,6 +147,10 @@
 
             $a.text(btn.label);
 
+            if (btn.iconClass) {
+                $a.prepend('<span class="' + btn.iconClass + '"></span> ');
+            }
+
             if (btn.attributes){
                 $a.attr(btn.attributes);
             }

--- a/spec/viewer/mainMenu.js
+++ b/spec/viewer/mainMenu.js
@@ -71,7 +71,7 @@ describe('MainMenu Class', function () {
 
   });
 
-  describe('user buttons', function () {
+  describe('user buttons/logo', function () {
     beforeEach(function () {
 
       spyOn(console, 'log');
@@ -107,6 +107,10 @@ describe('MainMenu Class', function () {
               "attributes": {"id": "sl-two"}}]
           }
         ],
+        "userLogo": {
+          "label": "Logo",
+          "attributes": {"id": "logo"}
+        }
       }
 
       this.viewerDiv = jQuery('<div>');
@@ -135,6 +139,10 @@ describe('MainMenu Class', function () {
       expect(this.viewerDiv.find('ul.user-buttons > li > #sublist')).toExist();
       expect(this.viewerDiv.find('ul.user-buttons > li > #sublist + ul > li > #sl-one')).toExist();
       expect(this.viewerDiv.find('ul.user-buttons > li > #sublist + ul > li > #sl-two')).toExist();
+    });
+
+    it('creates userLogo', function () {
+      expect(this.viewerDiv.find('ul.user-logo > li > a#logo').text()).toBe('Logo');
     });
   });
 

--- a/spec/viewer/mainMenu.js
+++ b/spec/viewer/mainMenu.js
@@ -42,7 +42,7 @@ describe('MainMenu Class', function () {
   });
 
   describe('toggling behaviour', function() {
-    
+
     beforeEach(function() {
       this.viewer = {
         toggleBookmarkPanel: jasmine.createSpy(),
@@ -62,13 +62,80 @@ describe('MainMenu Class', function () {
         mainMenuBarCls:             'menu-bar',
       });
     });
-    
+
     it("doesn't render useless elements", function () {
       expect(this.viewerDiv.find('.change-layout')).not.toExist();
     });
 
     // test other options?
 
+  });
+
+  describe('user buttons', function () {
+    beforeEach(function () {
+
+      spyOn(console, 'log');
+
+      this.viewer = {};
+
+      this.viewer.mainMenuSettings = {
+        /* Setup will fail without 'buttons' */
+        'buttons' : {
+          'bookmark' : true,
+          'layout' : false,
+          'options' : false
+        },
+        "userButtons": [
+          /* Ordinary link */
+          { "label": "Link",
+            "attributes": {
+              "href": "http://example.com",
+              "id":   "test-button"
+            }
+          },
+          /* Callback link - omitted if it doesn't have an id */
+          {"label": "Callback",
+           "attributes": {"href": "#noop"},
+           "callback": true},
+          /* Sublists */
+          {"label": "Sublist",
+           "attributes": {"id": "sublist"},
+           "sublist": [
+             {"label": "One",
+              "attributes": {"id": "sl-one"}},
+             {"label": "Two",
+              "attributes": {"id": "sl-two"}}]
+          }
+        ],
+      }
+
+      this.viewerDiv = jQuery('<div>');
+
+      this.mainMenu = new Mirador.MainMenu({
+        parent:         this.viewer,
+        appendTo:       this.viewerDiv,
+        mainMenuBarCls: 'menu-bar'
+      });
+    });
+
+    it('creates regular buttons', function () {
+      var button = this.viewerDiv.find('ul.user-buttons > li > a#test-button');
+      expect(button).toExist;
+      expect(button.text()).toBe("Link");
+      expect(button.attr('href')).toBe("http://example.com");
+      expect(button.attr('id')).toBe('test-button');
+    });
+
+    it('omits links marked "callback" if they don\'t have IDs', function () {
+      expect(this.viewerDiv.find('a[href=#noop]')).not.toExist()
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it('creates sublists', function () {
+      expect(this.viewerDiv.find('ul.user-buttons > li > #sublist')).toExist();
+      expect(this.viewerDiv.find('ul.user-buttons > li > #sublist + ul > li > #sl-one')).toExist();
+      expect(this.viewerDiv.find('ul.user-buttons > li > #sublist + ul > li > #sl-two')).toExist();
+    });
   });
 
 });


### PR DESCRIPTION
Herein is implemented an attempt at allowing users to add
menu items to the main menu in Mirador via a configuration
setting.  Plaintext links to href or that trigger callbacks
are more or less fully handled.  Sublists and explicit handling
of links with icons are the next step here.

index.html contains a basic example of each type of link, and
there is inline documentation co-located with the functions that
implement it.

Refs #451