### PR TITLE
Annotations z-index not set - set to 2: above OSD, below panels.

### DIFF
--- a/css/mirador-combined.css
+++ b/css/mirador-combined.css
@@ -2079,6 +2079,7 @@ text {
   border: 2px solid white;
   box-shadow: 0px 0px 5px rgba(0,0,0,0.5);
   box-sizing: border-box;
+  z-index: 2
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1134,6 +1134,7 @@ text {
   border: 2px solid deepSkyBlue;
   box-shadow: 0px 0px 5px white; 
   box-sizing: border-box;
+  z-index: 2;
 }
 .annotation.selected {
   border: 3px solid orangered;


### PR DESCRIPTION
On Chrome and Firefox it seems that the annotations are not visible, setting their z-index to 2 will make them visible over OSD and invisible below panels, like the info one. I could be the only one with this issue, or maybe not!