### PR TITLE
Annotations Endpoint is not correctly created for each window

### DIFF
--- a/css/mirador-combined.css
+++ b/css/mirador-combined.css
@@ -2079,7 +2079,6 @@ text {
   border: 2px solid white;
   box-shadow: 0px 0px 5px rgba(0,0,0,0.5);
   box-sizing: border-box;
-  z-index: 2
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/css/mirador-combined.css
+++ b/css/mirador-combined.css
@@ -2079,6 +2079,7 @@ text {
   border: 2px solid white;
   box-shadow: 0px 0px 5px rgba(0,0,0,0.5);
   box-sizing: border-box;
+  z-index: 2
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1134,6 +1134,7 @@ text {
   border: 2px solid deepSkyBlue;
   box-shadow: 0px 0px 5px white; 
   box-sizing: border-box;
+  z-index: 2;
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1134,7 +1134,6 @@ text {
   border: 2px solid deepSkyBlue;
   box-shadow: 0px 0px 5px white; 
   box-sizing: border-box;
-  z-index: 2;
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -595,28 +595,28 @@
         module = $.viewer.annotationEndpoint.module,
         options = $.viewer.annotationEndpoint.options;
 
-	// At this point 'endpoint' can be either null
-	// or already created. If we try and check for
+        // At this point 'endpoint' can be either null
+        // or already created. If we try and check for
         // undefined - as in 'if (endpoint)' we will
-	// crash and burn, since it's a null - not an
-	// undefined.
-	try {
-	  // If we can assign endpoint is defined,
-	  // use the search function of the endpoint
-	  // to search.
-	  endpoint = endpoint;
-	  endpoint.set('dfd', dfd);
-	  endpoint.search(_this.currentCanvasID);
-	} catch(error) {
-	  // We failed, endpoint is not assigned
-	  // yet - so we need to get the endpoint
-	  // module instance.
+        // crash and burn, since it's a null - not an
+        // undefined.
+        try {
+          // If we can assign endpoint is defined,
+          // use the search function of the endpoint
+          // to search.
+          endpoint = endpoint;
+          endpoint.set('dfd', dfd);
+          endpoint.search(_this.currentCanvasID);
+        } catch(error) {
+          // We failed, endpoint is not assigned
+          // yet - so we need to get the endpoint
+          // module instance.
           options.element = _this.element;
           options.uri = _this.currentCanvasID;
           options.dfd = dfd;
           options.windowID = _this.id;
           endpoint = new $[module](options);
-	}
+        }
 
         dfd.done(function(loaded) {
           _this.annotationsList = _this.annotationsList.concat(endpoint.annotationsList);

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -595,31 +595,21 @@
         module = $.viewer.annotationEndpoint.module,
         options = $.viewer.annotationEndpoint.options;
 
-        // At this point 'endpoint' can be either null
-        // or already created. If we try and check for
-        // undefined - as in 'if (endpoint)' we will
-        // crash and burn, since it's a null - not an
-        // undefined.
-        try {
-          // If we can assign endpoint is defined,
-          // use the search function of the endpoint
-          // to search.
-          endpoint = endpoint;
-          endpoint.set('dfd', dfd);
-          endpoint.search(_this.currentCanvasID);
-        } catch(error) {
-          // We failed, endpoint is not assigned
-          // yet - so we need to get the endpoint
-          // module instance.
+        // One annotation endpoint per window, the endpoint
+        // is a property of the instance.
+        if ( _this.endpoint && _this.endpoint != null ) {
+          _this.endpoint.set('dfd', dfd);
+          _this.endpoint.search(_this.currentCanvasID);
+        } else {
           options.element = _this.element;
           options.uri = _this.currentCanvasID;
           options.dfd = dfd;
           options.windowID = _this.id;
-          endpoint = new $[module](options);
+          _this.endpoint = new $[module](options);
         }
 
         dfd.done(function(loaded) {
-          _this.annotationsList = _this.annotationsList.concat(endpoint.annotationsList);
+          _this.annotationsList = _this.annotationsList.concat(_this.endpoint.annotationsList);
           // clear out some bad data
           _this.annotationsList = jQuery.grep(_this.annotationsList, function (value, index) {
             if (typeof value.on === "undefined") { 

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -594,17 +594,30 @@
         var dfd = jQuery.Deferred(),
         module = $.viewer.annotationEndpoint.module,
         options = $.viewer.annotationEndpoint.options;
-        if (_this.endpoint && _this.endpoint !== null) {
-          endpoint.set('dfd', dfd);
-          endpoint.search(_this.currentCanvasID);
-          // update with new search
-        } else {
+
+	// At this point 'endpoint' can be either null
+	// or already created. If we try and check for
+        // undefined - as in 'if (endpoint)' we will
+	// crash and burn, since it's a null - not an
+	// undefined.
+	try {
+	  // If we can assign endpoint is defined,
+	  // use the search function of the endpoint
+	  // to search.
+	  endpoint = endpoint;
+	  endpoint.set('dfd', dfd);
+	  endpoint.search(_this.currentCanvasID);
+	} catch(error) {
+	  // We failed, endpoint is not assigned
+	  // yet - so we need to get the endpoint
+	  // module instance.
           options.element = _this.element;
           options.uri = _this.currentCanvasID;
           options.dfd = dfd;
           options.windowID = _this.id;
           endpoint = new $[module](options);
-        }
+	}
+
         dfd.done(function(loaded) {
           _this.annotationsList = _this.annotationsList.concat(endpoint.annotationsList);
           // clear out some bad data


### PR DESCRIPTION
When an endpoint module is specified in the configuration the way it is initiated when there are multiple windows open is odd. In the current implementation the is a bit of confusion in the way _this.endpoint and endpoint are checked and populated.

For the window instance _this.endpoint is always null when first called, on the other end: endpoint is present if another window, with annotations, has been already initialised.

What happens is that the second window will create a new instance of the endpoint and assign it to the endpoint variable, things get ugly in the deferred, because when the deferred is resolved in that scope, the endpoint from which is getting annotations - via the annotationsList - is no longer the one that is resolving the deferred, but the last one created, possibly with a radically different opinion of what the annotationsList should look like, resulting in a _this.annotationsList that could be different from what is expected.

If it doesn't make sense immediately, just try and step in the code and see for different windows what the _this.endpoint and endpoint variables look like.

This first part of the fix is still using a single global annotations endpoint, I think it's very efficient. What we do is check for endpoint not being assigned - with a very counterintuitive try/catch - and create only one.  The second call to this function, from another window, will get the same endpoint and use the search function to update the annotationsList of the endpoint.

**TODO**: as it is the `search` function will overwrite the existing one, I'm not particularly happy with that because it may have some unintended consequences; I have a fix - will push it later - where I change the API contract of the search, so that it accepts  `resolve, reject` parameters and returns the list of annotations in a deferred fashion. Since it breaks the `search` contract I think we must see first who's creating annotations endpoints and what it would mean for them.
 