### PR TITLE
Keep QTip2 annotations in sight

### DIFF
--- a/css/mirador-combined.css
+++ b/css/mirador-combined.css
@@ -2079,6 +2079,7 @@ text {
   border: 2px solid white;
   box-shadow: 0px 0px 5px rgba(0,0,0,0.5);
   box-sizing: border-box;
+  z-index: 2
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1134,6 +1134,7 @@ text {
   border: 2px solid deepSkyBlue;
   box-shadow: 0px 0px 5px white; 
   box-sizing: border-box;
+  z-index: 2;
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -64,9 +64,11 @@
              position : {
               target : 'mouse',
               adjust : {
-                mouse: false
+                mouse: false,
+                  method: 'shift'
               },
-              container: jQuery(_this.osdViewer.element)
+              container: jQuery(_this.osdViewer.element),
+                 viewport: true
              },
              style : {
               classes : 'qtip-bootstrap'

--- a/js/src/annotations/osd-region-rect-tool.js
+++ b/js/src/annotations/osd-region-rect-tool.js
@@ -151,8 +151,11 @@
             },
             position : {
               at: 'center',
-              viewport: jQuery(window),
+              viewport: true,
               container: jQuery(_this.osdViewer.element)
+              adjust : {
+                method: 'shift'
+              }
             },
             style : {
               classes : 'qtip-bootstrap'

--- a/js/src/annotations/osd-region-rect-tool.js
+++ b/js/src/annotations/osd-region-rect-tool.js
@@ -152,7 +152,7 @@
             position : {
               at: 'center',
               viewport: true,
-              container: jQuery(_this.osdViewer.element)
+              container: jQuery(_this.osdViewer.element),
               adjust : {
                 method: 'shift'
               }


### PR DESCRIPTION
When an annotation is close to the edge of the viewer it will be displayed outside the visible screen, possibly reduced to fit. 

This change takes advantage of the viewport positioning available in QTip. The annotation will shift as needed to be displayed inside the viewport.