### PR TITLE
Feature - Pin annotation

### DIFF
--- a/css/mirador-combined.css
+++ b/css/mirador-combined.css
@@ -2079,7 +2079,6 @@ text {
   border: 2px solid white;
   box-shadow: 0px 0px 5px rgba(0,0,0,0.5);
   box-sizing: border-box;
-  z-index: 2
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/css/mirador-combined.css
+++ b/css/mirador-combined.css
@@ -2079,6 +2079,7 @@ text {
   border: 2px solid white;
   box-shadow: 0px 0px 5px rgba(0,0,0,0.5);
   box-sizing: border-box;
+  z-index: 2
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1134,6 +1134,7 @@ text {
   border: 2px solid deepSkyBlue;
   box-shadow: 0px 0px 5px white; 
   box-sizing: border-box;
+  z-index: 2;
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1134,7 +1134,6 @@ text {
   border: 2px solid deepSkyBlue;
   box-shadow: 0px 0px 5px white; 
   box-sizing: border-box;
-  z-index: 2;
 }
 .annotation.selected {
   border: 3px solid orangered;

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1538,6 +1538,11 @@ div.manifest-info a.mirador-btn.mirador-icon-toc {
   max-height: 185px;
   overflow: auto;
 }
+
+.qtip-header {
+   background: #cecede;
+}
+
 .annotation-tooltip {
   padding: 12px; 
 }

--- a/js/src/annotations/annotationTooltip.js
+++ b/js/src/annotations/annotationTooltip.js
@@ -99,7 +99,7 @@
                                        '{{#each annotations}}',
                                        '<div class="annotation-display annotation-tooltip" data-anno-id="{{id}}">',
                                        '<div class="button-container">',
-                                            '<a href="#pin" class="pin"><i class="fa fa fa-circle-o fa-fw"></i>Pin</a>',
+                                         '<a href="#pin" class="pin"><i class="fa fa fa-circle-o fa-fw"></i>Pin</a>',
                                          '{{#if showEdit}}<a href="#edit" class="edit"><i class="fa fa-pencil-square-o fa-fw"></i>Edit</a>{{/if}}',
                                          '{{#if showDelete}}<a href="#delete" class="delete"><i class="fa fa-trash-o fa-fw"></i>Delete</a>{{/if}}',
                                        '</div>',

--- a/js/src/annotations/annotationTooltip.js
+++ b/js/src/annotations/annotationTooltip.js
@@ -96,10 +96,10 @@
 
     viewerTemplate: Handlebars.compile([
                                        '<div class="all-annotations">',
+                                        '<div class="qtip-header"><a href="#pin" class="pin"><i class="fa fa fa-circle-o fa-fw"></i></a></div>',
                                        '{{#each annotations}}',
                                        '<div class="annotation-display annotation-tooltip" data-anno-id="{{id}}">',
                                        '<div class="button-container">',
-                                         '<a href="#pin" class="pin"><i class="fa fa fa-circle-o fa-fw"></i>Pin</a>',
                                          '{{#if showEdit}}<a href="#edit" class="edit"><i class="fa fa-pencil-square-o fa-fw"></i>Edit</a>{{/if}}',
                                          '{{#if showDelete}}<a href="#delete" class="delete"><i class="fa fa-trash-o fa-fw"></i>Delete</a>{{/if}}',
                                        '</div>',

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -360,12 +360,14 @@
 
       jQuery('.annotation-tooltip a.pin').on("click", function(event) {
               event.preventDefault();
-              if ( api.get('hide.event') ) {
+              // Get this pin annotation API instance
+              var qtipApi = jQuery(this).parents('.qtip').qtip();
+              if ( qtipApi.get('hide.event') ) {
                       jQuery('.annotation-tooltip a.pin').html('<i class="fa fa fa-dot-circle-o fa-fw"></i>Unpin');
-                      api.set({'hide.event': false});
+                      qtipApi.set({'hide.event': false});
                   } else {
                       jQuery('.annotation-tooltip a.pin').html('<i class="fa fa fa-circle-o fa-fw"></i>Pin');
-                      api.set({'hide.event': 'mouseleave' });
+                      qtipApi.set({'hide.event': 'mouseleave' });
                   }
       });
 

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -281,7 +281,7 @@
           });
       },
     checkMousePosition: function() {
-        this.hideWindowAnnotations;
+        this.hideWindowAnnotations();
     },
 
     update: function() {
@@ -291,7 +291,7 @@
     hideAll: function() {
         // Make sure we hide the tooltips
         // before hiding the annotation overlay.
-        this.hideWindowAnnotations;
+        this.hideWindowAnnotations();
         this.osdViewer.clearOverlays();
     },
 

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -272,6 +272,11 @@
     
     checkMousePosition: function() {
       jQuery('.qtip').qtip('hide');
+        // Reset the annotations to unpinned
+        jQuery.each(this.tooltips, function(index, value) {
+            var qtipApi = value.qtip();
+            qtipApi.set({'hide.event': 'mouseleave'});
+        });
     },
 
     update: function() {

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -363,10 +363,10 @@
               // Get this pin annotation API instance
               var qtipApi = jQuery(this).parents('.qtip').qtip();
               if ( qtipApi.get('hide.event') ) {
-                      jQuery('.annotation-tooltip a.pin').html('<i class="fa fa fa-dot-circle-o fa-fw"></i>Unpin');
+                      event.target.html('<i class="fa fa fa-dot-circle-o fa-fw"></i>Unpin');
                       qtipApi.set({'hide.event': false});
                   } else {
-                      jQuery('.annotation-tooltip a.pin').html('<i class="fa fa fa-circle-o fa-fw"></i>Pin');
+                      event.target.html('<i class="fa fa fa-circle-o fa-fw"></i>Pin');
                       qtipApi.set({'hide.event': 'mouseleave' });
                   }
       });

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -65,10 +65,8 @@
               target : 'mouse',
               adjust : {
                 mouse: false,
-                  method: 'shift'
               },
               container: jQuery(_this.osdViewer.element),
-                 viewport: true
              },
              style : {
               classes : 'qtip-bootstrap'

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -64,9 +64,9 @@
              position : {
               target : 'mouse',
               adjust : {
-                mouse: false,
+                mouse: false
               },
-              container: jQuery(_this.osdViewer.element),
+              container: jQuery(_this.osdViewer.element)
              },
              style : {
               classes : 'qtip-bootstrap'
@@ -329,7 +329,7 @@
     removeAnnotationEvents: function(tooltipevent, api) {
       jQuery('.annotation-tooltip a.delete').off("click");
       jQuery('.annotation-tooltip a.edit').off("click");
-        jQuery('.annotation-tooltip a.pin').off("click");
+      jQuery('.annotation-tooltip a.pin').off("click");
       jQuery('.annotation-tooltip a.save').off("click");
       jQuery('.annotation-tooltip a.cancel').off("click");
     },
@@ -358,16 +358,16 @@
         display.remove(); //remove this annotation display from dom
       });
 
-        jQuery('.annotation-tooltip a.pin').on("click", function(event) {
-                event.preventDefault();
-                if ( api.get('hide.event') ) {
-                        jQuery('.annotation-tooltip a.pin').html('<i class="fa fa fa-dot-circle-o fa-fw"></i>Unpin');
-                        api.set({'hide.event': false});
-                    } else {
-                        jQuery('.annotation-tooltip a.pin').html('<i class="fa fa fa-circle-o fa-fw"></i>Pin');
-                        api.set({'hide.event': 'mouseleave' });
-                    }
-            });
+      jQuery('.annotation-tooltip a.pin').on("click", function(event) {
+              event.preventDefault();
+              if ( api.get('hide.event') ) {
+                      jQuery('.annotation-tooltip a.pin').html('<i class="fa fa fa-dot-circle-o fa-fw"></i>Unpin');
+                      api.set({'hide.event': false});
+                  } else {
+                      jQuery('.annotation-tooltip a.pin').html('<i class="fa fa fa-circle-o fa-fw"></i>Pin');
+                      api.set({'hide.event': 'mouseleave' });
+                  }
+      });
 
       jQuery('.annotation-tooltip a.edit').on("click", function(event) {
         event.preventDefault();

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -284,7 +284,12 @@
     },
 
     hideAll: function() {
-      this.osdViewer.clearOverlays();
+        // Make sure we disable the tooltips
+        // before hiding the annotation overlay.
+        jQuery.each(this.tooltips, function(index, value) {
+            value.qtip('disable', true);
+        });
+        this.osdViewer.clearOverlays();
     },
 
     getElements: function() {

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -342,7 +342,7 @@
     removeAnnotationEvents: function(tooltipevent, api) {
       jQuery('.annotation-tooltip a.delete').off("click");
       jQuery('.annotation-tooltip a.edit').off("click");
-      jQuery('.annotation-tooltip a.pin').off("click");
+        jQuery('.qtip-header a.pin').off("click");
       jQuery('.annotation-tooltip a.save').off("click");
       jQuery('.annotation-tooltip a.cancel').off("click");
     },
@@ -371,15 +371,15 @@
         display.remove(); //remove this annotation display from dom
       });
 
-      jQuery('.annotation-tooltip a.pin').on("click", function(event) {
+        jQuery('.qtip-header a.pin').on("click", function(event) {
               event.preventDefault();
               // Get this pin annotation API instance
               var qtipApi = jQuery(this).parents('.qtip').qtip();
               if ( qtipApi.get('hide.event') ) {
-                      event.target.innerHTML = '<i class="fa fa fa-dot-circle-o fa-fw"></i>Unpin';
+                      jQuery(event.target).attr('class', 'fa fa fa-dot-circle-o fa-fw');
                       qtipApi.set({'hide.event': false});
                   } else {
-                      event.target.innerHTML = '<i class="fa fa fa-circle-o fa-fw"></i>Pin';
+                      jQuery(event.target).attr('class', 'fa fa fa-circle-o fa-fw');
                       qtipApi.set({'hide.event': 'mouseleave' });
                   }
       });

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -363,10 +363,10 @@
               // Get this pin annotation API instance
               var qtipApi = jQuery(this).parents('.qtip').qtip();
               if ( qtipApi.get('hide.event') ) {
-                      event.target.html('<i class="fa fa fa-dot-circle-o fa-fw"></i>Unpin');
+                      event.target.innerHTML = '<i class="fa fa fa-dot-circle-o fa-fw"></i>Unpin';
                       qtipApi.set({'hide.event': false});
                   } else {
-                      event.target.html('<i class="fa fa fa-circle-o fa-fw"></i>Pin');
+                      event.target.innerHTML = '<i class="fa fa fa-circle-o fa-fw"></i>Pin';
                       qtipApi.set({'hide.event': 'mouseleave' });
                   }
       });

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -269,14 +269,19 @@
       });
 
     },
-    
+      hideWindowAnnotations: function() {
+          // Hide and fix only the annotations in this window.
+          var windowAnnotations = this.parent.element.parent().children('.mirador-osd').children('.qtip');
+
+          // Reset the annotations to unpinned and hide
+          jQuery.each(windowAnnotations, function(index, value) {
+              var qtipApi = jQuery(value).qtip();
+              qtipApi.set({'hide.event': 'mouseleave'});
+              qtipApi.hide();
+          });
+      },
     checkMousePosition: function() {
-      jQuery('.qtip').qtip('hide');
-        // Reset the annotations to unpinned
-        jQuery.each(this.tooltips, function(index, value) {
-            var qtipApi = value.qtip();
-            qtipApi.set({'hide.event': 'mouseleave'});
-        });
+        this.hideWindowAnnotations;
     },
 
     update: function() {
@@ -286,7 +291,7 @@
     hideAll: function() {
         // Make sure we hide the tooltips
         // before hiding the annotation overlay.
-        jQuery('.qtip').qtip('hide');
+        this.hideWindowAnnotations;
         this.osdViewer.clearOverlays();
     },
 

--- a/js/src/annotations/osd-canvas-renderer.js
+++ b/js/src/annotations/osd-canvas-renderer.js
@@ -284,11 +284,9 @@
     },
 
     hideAll: function() {
-        // Make sure we disable the tooltips
+        // Make sure we hide the tooltips
         // before hiding the annotation overlay.
-        jQuery.each(this.tooltips, function(index, value) {
-            value.qtip('disable', true);
-        });
+        jQuery('.qtip').qtip('hide');
         this.osdViewer.clearOverlays();
     },
 

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -595,28 +595,28 @@
         module = $.viewer.annotationEndpoint.module,
         options = $.viewer.annotationEndpoint.options;
 
-	// At this point 'endpoint' can be either null
-	// or already created. If we try and check for
+        // At this point 'endpoint' can be either null
+        // or already created. If we try and check for
         // undefined - as in 'if (endpoint)' we will
-	// crash and burn, since it's a null - not an
-	// undefined.
-	try {
-	  // If we can assign endpoint is defined,
-	  // use the search function of the endpoint
-	  // to search.
-	  endpoint = endpoint;
-	  endpoint.set('dfd', dfd);
-	  endpoint.search(_this.currentCanvasID);
-	} catch(error) {
-	  // We failed, endpoint is not assigned
-	  // yet - so we need to get the endpoint
-	  // module instance.
+        // crash and burn, since it's a null - not an
+        // undefined.
+        try {
+          // If we can assign endpoint is defined,
+          // use the search function of the endpoint
+          // to search.
+          endpoint = endpoint;
+          endpoint.set('dfd', dfd);
+          endpoint.search(_this.currentCanvasID);
+        } catch(error) {
+          // We failed, endpoint is not assigned
+          // yet - so we need to get the endpoint
+          // module instance.
           options.element = _this.element;
           options.uri = _this.currentCanvasID;
           options.dfd = dfd;
           options.windowID = _this.id;
           endpoint = new $[module](options);
-	}
+        }
 
         dfd.done(function(loaded) {
           _this.annotationsList = _this.annotationsList.concat(endpoint.annotationsList);

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -594,19 +594,21 @@
         var dfd = jQuery.Deferred(),
         module = $.viewer.annotationEndpoint.module,
         options = $.viewer.annotationEndpoint.options;
-        if (_this.endpoint && _this.endpoint !== null) {
-          endpoint.set('dfd', dfd);
-          endpoint.search(_this.currentCanvasID);
-          // update with new search
+        // One annotation endpoint per window, the endpoint
+        // is a property of the instance.
+        if ( _this.endpoint && _this.endpoint != null ) {
+          _this.endpoint.set('dfd', dfd);
+          _this.endpoint.search(_this.currentCanvasID);
         } else {
           options.element = _this.element;
           options.uri = _this.currentCanvasID;
           options.dfd = dfd;
           options.windowID = _this.id;
-          endpoint = new $[module](options);
+          _this.endpoint = new $[module](options);
         }
+
         dfd.done(function(loaded) {
-          _this.annotationsList = _this.annotationsList.concat(endpoint.annotationsList);
+          _this.annotationsList = _this.annotationsList.concat(_this.endpoint.annotationsList);
           // clear out some bad data
           _this.annotationsList = jQuery.grep(_this.annotationsList, function (value, index) {
             if (typeof value.on === "undefined") { 

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -594,22 +594,19 @@
         var dfd = jQuery.Deferred(),
         module = $.viewer.annotationEndpoint.module,
         options = $.viewer.annotationEndpoint.options;
-
-        // One annotation endpoint per window, the endpoint
-        // is a property of the instance.
-        if ( _this.endpoint && _this.endpoint != null ) {
-          _this.endpoint.set('dfd', dfd);
-          _this.endpoint.search(_this.currentCanvasID);
+        if (_this.endpoint && _this.endpoint !== null) {
+          endpoint.set('dfd', dfd);
+          endpoint.search(_this.currentCanvasID);
+          // update with new search
         } else {
           options.element = _this.element;
           options.uri = _this.currentCanvasID;
           options.dfd = dfd;
           options.windowID = _this.id;
-          _this.endpoint = new $[module](options);
+          endpoint = new $[module](options);
         }
-
         dfd.done(function(loaded) {
-          _this.annotationsList = _this.annotationsList.concat(_this.endpoint.annotationsList);
+          _this.annotationsList = _this.annotationsList.concat(endpoint.annotationsList);
           // clear out some bad data
           _this.annotationsList = jQuery.grep(_this.annotationsList, function (value, index) {
             if (typeof value.on === "undefined") { 

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -594,17 +594,30 @@
         var dfd = jQuery.Deferred(),
         module = $.viewer.annotationEndpoint.module,
         options = $.viewer.annotationEndpoint.options;
-        if (_this.endpoint && _this.endpoint !== null) {
-          endpoint.set('dfd', dfd);
-          endpoint.search(_this.currentCanvasID);
-          // update with new search
-        } else {
+
+	// At this point 'endpoint' can be either null
+	// or already created. If we try and check for
+        // undefined - as in 'if (endpoint)' we will
+	// crash and burn, since it's a null - not an
+	// undefined.
+	try {
+	  // If we can assign endpoint is defined,
+	  // use the search function of the endpoint
+	  // to search.
+	  endpoint = endpoint;
+	  endpoint.set('dfd', dfd);
+	  endpoint.search(_this.currentCanvasID);
+	} catch(error) {
+	  // We failed, endpoint is not assigned
+	  // yet - so we need to get the endpoint
+	  // module instance.
           options.element = _this.element;
           options.uri = _this.currentCanvasID;
           options.dfd = dfd;
           options.windowID = _this.id;
           endpoint = new $[module](options);
-        }
+	}
+
         dfd.done(function(loaded) {
           _this.annotationsList = _this.annotationsList.concat(endpoint.annotationsList);
           // clear out some bad data

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -594,6 +594,7 @@
         var dfd = jQuery.Deferred(),
         module = $.viewer.annotationEndpoint.module,
         options = $.viewer.annotationEndpoint.options;
+
         // One annotation endpoint per window, the endpoint
         // is a property of the instance.
         if ( _this.endpoint && _this.endpoint != null ) {


### PR DESCRIPTION
I think there is someone already working on this, but I had a requirement for it, so I had to create it. This is a first stab at it, not completely happy with the behaviour, but to sum it up:

- added an header to the tooltips with a 'pin' option;
- pinning the annotation will keep it open until OSD is updated, zooming or moving or an annotation is edited/removed.

Things I'm not happy about:

- removing one annotation will unpin all the annotations on the canvas; this is due to the way the canvas is updated when the annotations are changed; can't figure out an elegant way to handle this;

Comments in line with the PR code for the inner workings of this feature.
 
