### PR TITLE
Update French locale with metadata strings

### DIFF
--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -31,5 +31,21 @@
     "edit": "Editer",
     "delete": "Supprimer",
     "url": "URL",
-    "newObject": "Nouvel objet"
+    "newObject": "Nouvel objet",
+    "License": "Licence",
+    "Date": "Date",
+    "Location": "Localisation",
+    "Within": "Contenu dans",
+    "See Also": "Autre(s)",
+    "Repository": "Etablissement de conservation",
+    "Shelfmark": "Cote",
+    "Title": "Titre",
+    "Language": "Langue",
+    "Format": "Format",
+    "Provider": "Fournisseur",
+    "Disseminator": "Diffuseur",
+    "Source Images": "Source Images",
+    "Source Metadata": "Source Métadonnées",
+    "Logo": "Logo",
+    "Related": "Voir aussi"
 }


### PR DESCRIPTION
As a side note: capitalization on metadata labels is not well suited to French strings ([mirador.css#L1377](https://github.com/IIIF/mirador/blob/master/css/mirador.css#L1377)). E.g. "Etablissement De Conservation" looks a bit strange.