### PR TITLE
Increase to 2.0.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Mirador",
-  "version": "0.9.0",
+  "version": "2.0.0",
   "description": "Multi-window image viewer, a web-based tool to support researcher goals",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When building the latest from master I noticed the mirador.js still said v0.9.0 at the top instead of v2.0.0.