### PR TITLE
Fix various transition durations and small css issues

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -720,7 +720,7 @@ li.highlight {
   z-index: 4;
   overflow:hidden;
   display: none;
-  /*transition:all 0.1s ease; causes the filmstrip to be very jumpy - don't use*/
+  transition:transform 0.3s ease;
 }
 .bottomPanel.minimized {
   transform:translateY(130px);

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -720,7 +720,7 @@ li.highlight {
   z-index: 4;
   overflow:hidden;
   display: none;
-  transition:all 0.3s ease;
+  /*transition:all 0.1s ease; causes the filmstrip to be very jumpy - don't use*/
 }
 .bottomPanel.minimized {
   transform:translateY(130px);
@@ -760,7 +760,6 @@ li.highlight {
     height: 100%;
     width: 100%;
     overflow-x: scroll;
-    margin-top: 10px;
     overflow-y: hidden;
 }
 
@@ -769,7 +768,7 @@ li.highlight {
   list-style: none;
   padding: 0;
   white-space: nowrap;
-  margin-top: 4px;
+  margin-top: 10px;
   margin-bottom: 4px;
 }
 
@@ -778,7 +777,7 @@ li.highlight {
   /*float: left;*/
   /*margin: 0 0 15px 0;*/
   padding: 0px 10px 0px 10px;
-  transition: all 0.05s ease-out;
+  /*transition: all 0.03s ease-out;*/
   display: inline-block;
 }
 
@@ -1250,7 +1249,7 @@ ul.scroll-listing-thumbs li {
   box-sizing:border-box;
   margin: 0 0 15px 0;
   padding: 10px 10px 10px 10px;
-  transition: all 0.05s ease-out;
+  /*transition: all 0.05s ease-out;*/
   display: inline-block;
 }
 
@@ -1291,7 +1290,7 @@ ul.scroll-listing-thumbs li .thumb-label {
   float: left;
   margin: 0 0 15px 0;
   padding: 10px 10px 10px 10px;
-  transition: all 0.05s ease-out;
+  /*transition: all 0.05s ease-out;*/
 }
 
 .mirador-viewer ul.listing-thumbs li img {
@@ -1301,7 +1300,7 @@ ul.scroll-listing-thumbs li .thumb-label {
   margin: 0 auto;
   display: block;
   box-sizing:border-box;
-  transition: all 0.2 ease-out;
+  /*transition: all 0.2 ease-out;*/
 }
 .mirador-viewer ul.listing-thumbs li img:hover {
   border:3px solid rgba(0,191,255,0.7);

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -851,7 +851,7 @@ li.highlight {
 }
 .mirador-osd-edit-mode.selected, .mirador-osd-annotations-layer.selected {
   opacity: 1;
-  transition: none;
+  /*transition: none;*/
 }
 .mirador-osd-previous {
   position:absolute;

--- a/js/src/utils/utils.js
+++ b/js/src/utils/utils.js
@@ -171,11 +171,18 @@
       top : (win.scrollTop() * factor),
       left : (win.scrollLeft() * factor)
     };
-    viewport.bottom = (viewport.top + win.height()) * factor;
-    viewport.right = (viewport.left + win.width()) * factor;
+    viewport.bottom = (viewport.top + win.outerHeight()) * factor;
+    viewport.right = (viewport.left + win.outerWidth()) * factor;
 
-    var bounds = elem.getBoundingClientRect();
+    var el = jQuery(elem);
+    var bounds = el.offset();
+    bounds.bottom = bounds.top + el.height();
+    bounds.right = bounds.left + el.width();
+    var bounding = elem.getBoundingClientRect();
+    var position = el.position();
+    var parentOffset = el.parent().offset();
 
+    var oldTest = (!(viewport.right < bounds.left || viewport.left > bounds.right || viewport.bottom < bounds.top || viewport.top > bounds.bottom));
     return (!(viewport.right < bounds.left || viewport.left > bounds.right || viewport.bottom < bounds.top || viewport.top > bounds.bottom));
   };
 

--- a/js/src/utils/utils.js
+++ b/js/src/utils/utils.js
@@ -178,11 +178,7 @@
     var bounds = el.offset();
     bounds.bottom = bounds.top + el.height();
     bounds.right = bounds.left + el.width();
-    var bounding = elem.getBoundingClientRect();
-    var position = el.position();
-    var parentOffset = el.parent().offset();
 
-    var oldTest = (!(viewport.right < bounds.left || viewport.left > bounds.right || viewport.bottom < bounds.top || viewport.top > bounds.bottom));
     return (!(viewport.right < bounds.left || viewport.left > bounds.right || viewport.bottom < bounds.top || viewport.top > bounds.bottom));
   };
 

--- a/js/src/utils/utils.js
+++ b/js/src/utils/utils.js
@@ -174,10 +174,7 @@
     viewport.bottom = (viewport.top + win.height()) * factor;
     viewport.right = (viewport.left + win.width()) * factor;
 
-    var el = jQuery(elem);
-    var bounds = el.offset();
-    bounds.bottom = bounds.top + el.height();
-    bounds.right = bounds.left + el.width();
+    var bounds = elem.getBoundingClientRect();
 
     return (!(viewport.right < bounds.left || viewport.left > bounds.right || viewport.bottom < bounds.top || viewport.top > bounds.bottom));
   };

--- a/js/src/widgets/bookView.js
+++ b/js/src/widgets/bookView.js
@@ -87,11 +87,11 @@
     },
 
     hide: function() {
-      jQuery(this.element).hide({effect: "fade", duration: 1000, easing: "easeOutCubic"});
+      jQuery(this.element).hide({effect: "fade", duration: 300, easing: "easeOutCubic"});
     },
 
     show: function() {
-      jQuery(this.element).show({effect: "fade", duration: 1000, easing: "easeInCubic"});
+      jQuery(this.element).show({effect: "fade", duration: 300, easing: "easeInCubic"});
     },
 
     adjustWidth: function(className, hasClass) {

--- a/js/src/widgets/imageView.js
+++ b/js/src/widgets/imageView.js
@@ -89,11 +89,11 @@
     },
 
     hide: function() {
-      jQuery(this.element).hide({effect: "fade", duration: 1000, easing: "easeOutCubic"});
+      jQuery(this.element).hide({effect: "fade", duration: 300, easing: "easeOutCubic"});
     },
 
     show: function() {
-      jQuery(this.element).show({effect: "fade", duration: 1000, easing: "easeInCubic"});
+      jQuery(this.element).show({effect: "fade", duration: 300, easing: "easeInCubic"});
     },
 
     adjustWidth: function(className, hasClass) {


### PR DESCRIPTION
closes #382 
If a user went to BookView or ImageView first, and then switched to ThumbnailsView, isOnScreen would not correctly calculate which thumbnails are visible because the transition duration to hide Book/ImageView was longer than the transition to show ThumbnailsView, which was causing the thumbnail img element to have an incorrect offset.  This was much more readily apparent on small screens/iframes where clearly visible thumbnails were not having their src set.