### PR TITLE
Transcription issue 624

### DIFF
--- a/js/src/widgets/annotationsLayer.js
+++ b/js/src/widgets/annotationsLayer.js
@@ -41,9 +41,7 @@
       });
 
       jQuery.subscribe('annotationsListFiltered' + this.windowId, function(_, annotations) {
-        var annos = annotations.data; // can't pass arrays via jQuery pubsub, so unwrap from object
-        console.log(jQuery.isArray(annos[0].resource));
-        // _this.annotationsList = annotations;
+        _this.annotationsList = annotations.data; // can't pass arrays via jQuery pubsub, so unwrap from object
         _this.updateRenderer();
       });
 
@@ -59,7 +57,6 @@
         visible: false,
         parent: _this
       });
-      console.log(_this.annotationsList);
       this.modeSwitch();
     },
 

--- a/js/src/widgets/annotationsLayer.js
+++ b/js/src/widgets/annotationsLayer.js
@@ -36,10 +36,17 @@
       });
 
       jQuery.subscribe('annotationListLoaded.' + _this.windowId, function(event) {
-        console.log('subscribed!');
         _this.annotationsList = _this.parent.parent.annotationsList;
         _this.updateRenderer();
       });
+
+      jQuery.subscribe('annotationsListFiltered' + this.windowId, function(_, annotations) {
+        var annos = annotations.data; // can't pass arrays via jQuery pubsub, so unwrap from object
+        console.log(jQuery.isArray(annos[0].resource));
+        // _this.annotationsList = annotations;
+        _this.updateRenderer();
+      });
+
     },
 
     createRenderer: function() {
@@ -48,9 +55,11 @@
         osd: $.OpenSeadragon,
         osdViewer: _this.viewer,
         list: _this.annotationsList, // must be passed by reference.
+        //list: _this.parent.parent.editorPanel.state.annotations,
         visible: false,
         parent: _this
       });
+      console.log(_this.annotationsList);
       this.modeSwitch();
     },
 

--- a/js/src/widgets/annotationsTab.js
+++ b/js/src/widgets/annotationsTab.js
@@ -92,9 +92,11 @@
               if(state.selectedList !== listId){
                 state.selectedList = listId;
                 state.annotationLists.forEach(function(list){ list.selected = list.annotationSource === listId ? true : false; });
+                jQuery.publish('modeChange.' + _this.windowId, 'displayAnnotations');
               }else{ // "deselect" the list
                 state.selectedList = null;
                 state.annotationLists.forEach(function(list){ list.selected = false; });
+                jQuery.publish('modeChange.' + _this.windowId, 'default'); 
               }
 
             this.state(state);

--- a/js/src/widgets/editorPanel.js
+++ b/js/src/widgets/editorPanel.js
@@ -68,6 +68,9 @@
 
               return false;
             });
+            var annos = { data: state.annotations };
+            console.log(annos);
+            jQuery.publish('annotationsListFiltered' + this.windowId, annos);
 
             state.open = open;
             this.state(state);

--- a/js/src/widgets/editorPanel.js
+++ b/js/src/widgets/editorPanel.js
@@ -69,7 +69,6 @@
               return false;
             });
             var annos = { data: state.annotations };
-            console.log(annos);
             jQuery.publish('annotationsListFiltered' + this.windowId, annos);
 
             state.open = open;

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -628,12 +628,11 @@
           });
 
           jQuery.each( _this.annotationsList, function( key, value ) {
-            //console.log( jQuery.isArray(value.resource) );
+
             if(jQuery.isArray(value.resource)){
                _this.annotationsList[key].resource = value.resource[0];
             }
           });
-          console.log(  _this.annotationsList );
 
           jQuery.publish('annotationListLoaded.' + _this.id);
         });

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -514,7 +514,6 @@
         _this.annotationsList.pop();
       }
       this.getAnnotations();
-      console.log(this.annotationsList);
       switch(this.currentImageMode) {
         case 'ImageView':
           this.toggleImageView(this.currentCanvasID);
@@ -592,7 +591,7 @@
             // indicate this is a manifest annotation - which affects the UI
             value.endpoint = "manifest";
           });
-            console.log(list);
+
           jQuery.publish('annotationListLoaded.' + _this.id);
         });
       }
@@ -603,7 +602,7 @@
         module = $.viewer.annotationEndpoint.module,
         options = $.viewer.annotationEndpoint.options;
         name = $.viewer.annotationEndpoint.name;
-        console.log("endpoint: " + _this.endpoint);
+
         // One annotation endpoint per window, the endpoint
         // is a property of the whole app instance.
         if ( _this.endpoint && _this.endpoint !== null ) {
@@ -627,9 +626,18 @@
             }
             return true;
           });
+
+          jQuery.each( _this.annotationsList, function( key, value ) {
+            //console.log( jQuery.isArray(value.resource) );
+            if(jQuery.isArray(value.resource)){
+               _this.annotationsList[key].resource = value.resource[0];
+            }
+          });
+          console.log(  _this.annotationsList );
+
           jQuery.publish('annotationListLoaded.' + _this.id);
         });
-        console.log(_this.annotationsList);
+
       }
     },
 


### PR DESCRIPTION
Fixes #624 
Highlighting now works and this is how:

1. window.getAnnotations normalizes the annotation object resource to be the same for manifest and endpoint annotations.  Endpoint annotation resources were coming in as an object in an array, but now both are objects.
2. editorPanel.openAnnotationList publishes an array of the selected annotation list (annotationsListFiltered) making it easier for other components to use without filtering by listId.  (Had to wrap array in object as jQuery pubsub doesn't support passing arrays.)
3. annotationsLayer listens for the annotationsListFiltered event and uses that filtered array as the OsdCanvasRenderer's annotationsList for rendering update