### PR TITLE
Fix for #644 - userButtons cleanup

### DIFF
--- a/js/src/viewer/mainMenu.js
+++ b/js/src/viewer/mainMenu.js
@@ -112,14 +112,16 @@
      *          exist and MUST contain an "id" value    *
      *   li_attributes: HTML attributes to add to the   *
      *          list item containing the button.        *
+     *   iconClass: class or space-separated list of    *
+     *          classes. If present, an empty span with *
+     *          these classes will be prepended to the  *
+     *          content of the link element
      *   sublist: Sublist of buttons, to be implemented *
      *          as a dropdown via CSS/JS                *
      *   ul_attributes: HTML attributes to add to the   *
      *          sublist UL contained in the button.     *
      *          Ignored if button isn't representing    *
      *          a sublist.                              *
-     *   callback: If set to true, and attributes['id'] *
-     *          is not set, an error will be thrown     *
      *                                                  *
      * NOTE: sublist dropdown functionality is not yet  *
      *       implemented                                *
@@ -173,12 +175,6 @@
                 $sub_ul.append(processUserButtons(btn.sublist));
 
                 $li.append($sub_ul);
-            }
-
-            if (btn.callback) {
-                if (!(btn.attributes && btn.attributes.id)) {
-                    throw "userButton with callback does not have attributes.id";
-                }
             }
 
             return $li;

--- a/spec/viewer/mainMenu.js
+++ b/spec/viewer/mainMenu.js
@@ -100,10 +100,6 @@ describe('MainMenu Class', function () {
               "id":   "test-button"
             }
           },
-          /* Callback link - omitted if it doesn't have an id */
-          {"label": "Callback",
-           "attributes": {"href": "#noop"},
-           "callback": true},
           /* Sublists */
           {"label": "Sublist",
            "attributes": {"id": "sublist"},
@@ -135,11 +131,6 @@ describe('MainMenu Class', function () {
       expect(button.text()).toBe("Link");
       expect(button.attr('href')).toBe("http://example.com");
       expect(button.attr('id')).toBe('test-button');
-    });
-
-    it('omits links marked "callback" if they don\'t have IDs', function () {
-      expect(this.viewerDiv.find('a[href=#noop]')).not.toExist()
-      expect(console.log).toHaveBeenCalled();
     });
 
     it('creates sublists', function () {


### PR DESCRIPTION
Fixes #644 
  * Remove `callback` property support
  * Document `iconClass` support in comment