### PR TITLE
Fullscreen support for the entire viewer

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -17,6 +17,40 @@ a {
   margin:0;
 }
 
+/* Full screen
+---------------------------------------------------------------------------- */
+:-webkit-full-screen {
+  height: 100%;
+  left: 0;
+  margin: 0;
+  top: 0;
+  width: 100%;
+}
+
+:-moz-full-screen {
+  height: 100%;
+  left: 0;
+  margin: 0;
+  top: 0;
+  width: 100%;
+}
+
+:-ms-fullscreen {
+  height: 100%;
+  left: 0;
+  margin: 0;
+  top: 0;
+  width: 100%;
+}
+
+:fullscreen {
+  height: 100%;
+  left: 0;
+  margin: 0;
+  top: 0;
+  width: 100%;
+}
+
 /*----------------------------------------------------------------------------
 /* Mirador styles
 ---------------------------------------------------------------------------- 

--- a/index.html
+++ b/index.html
@@ -51,7 +51,15 @@
                  { "manifestUri": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0002/manifest.json", "location": 'e-codices'},
                  { "manifestUri": "http://www.e-codices.unifr.ch/metadata/iiif/bge-cl0015/manifest.json", "location": 'e-codices'}
              ],
-             "windowObjects": []
+            "windowObjects": [],
+            "mainMenuSettings": {
+              "show": true,
+              "buttons": {
+                "bookmark": false,
+                "layout": true,
+                "fullScreenViewer": true // enable the "Full Screen" button (fullscreen view of Mirador)
+              }
+            }
          });
      });
     </script>

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -158,6 +158,38 @@
     toggleBookmarkPanel: function() {
       this.toggleOverlay('bookmarkPanelVisible');
     },
+    
+    enterFullscreen: function() {
+      var el = this.element[0];
+      if (el.requestFullscreen) {
+        el.requestFullscreen();
+      } else if (el.mozRequestFullScreen) {
+        el.mozRequestFullScreen();
+      } else if (el.webkitRequestFullscreen) {
+        el.webkitRequestFullscreen();
+      } else if (el.msRequestFullscreen) {
+        el.msRequestFullscreen();
+      }
+    },
+
+    exitFullscreen: function() {
+      if (document.exitFullscreen) {
+        document.exitFullscreen();
+      } else if (document.mozCancelFullScreen) {
+        document.mozCancelFullScreen();
+      } else if (document.webkitExitFullscreen) {
+        document.webkitExitFullscreen();
+      }
+    },
+
+    isFullscreen: function() {
+      var $fullscreen = $(fullscreenElement());
+      return ($fullscreen.length > 0);
+    },
+
+    fullscreenElement: function() {
+      return (document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement);
+    },
 
     getManifestsData: function() {
       var _this = this;

--- a/js/src/viewer/mainMenu.js
+++ b/js/src/viewer/mainMenu.js
@@ -41,6 +41,7 @@
                 showBookmark : this.parent.mainMenuSettings.buttons.bookmark,
                 showLayout : this.parent.mainMenuSettings.buttons.layout,
                 showOptions: this.parent.mainMenuSettings.buttons.options,
+                showFullScreenViewer : this.parent.mainMenuSettings.buttons.fullScreenViewer,
                 userButtons: this.parent.mainMenuSettings.userButtons,
                 userLogo:    this.parent.mainMenuSettings.userLogo
             }));
@@ -58,6 +59,9 @@
             });
             // when options are implemented, this will need to do something
             this.element.find('.window-options').on('click', function() { });
+            this.element.find('.fullscreen-viewer').on('click', function() {
+              _this.parent.fullscreenElement() ? _this.parent.exitFullscreen() : _this.parent.enterFullscreen();
+            });
         },
 
         template: Handlebars.compile([
@@ -85,6 +89,13 @@
           '<li>',
             '<a href="javascript:;" class="change-layout" title="{{t "changeLayout"}}">',
               '<span class="icon-window-options"></span>{{t "changeLayout"}}',
+            '</a>',
+          '</li>',
+        '{{/if}}',
+        '{{#if showFullScreenViewer}}',
+          '<li>',
+            '<a href="javascript:;" class="fullscreen-viewer" title="{{t "fullScreen"}}">',
+              '<span class="fa fa-expand"></span> {{t "fullScreen"}}',
             '</a>',
           '</li>',
         '{{/if}}',

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -29,5 +29,6 @@
     "delete": "Delete",
     "url": "URL",
     "newObject": "New Object",
-    "objectMetadata": "Object Metadata"
+    "objectMetadata": "Object Metadata",
+    "fullScreen": "Full Screen"
 }

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -25,5 +25,6 @@
   	"imageView": "Vista de la Imagen",
   	"bookView": "Vista del Libro",
   	"scrollView": "Vista del rollo de papel",
-    "objectMetadata": "Metadatos"
+    "objectMetadata": "Metadatos",
+    "fullScreen": "Pantalla completa"
 }

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -29,5 +29,6 @@
     "delete": "Supprimer",
     "url": "URL",
     "newObject": "Nouvel objet",
-    "objectMetadata": "Métadonnées"
+    "objectMetadata": "Métadonnées",
+    "fullScreen": "Plein écran"
 }

--- a/locales/zh-CN/translation.json
+++ b/locales/zh-CN/translation.json
@@ -30,5 +30,6 @@
 	"cancel":			"取消",
 	"edit":				"编辑",
 	"delete":			"删除",
-	"newObject":		"建立新的物件"
+	"newObject":		"建立新的物件",
+  "fullScreen": "全屏"
 }

--- a/locales/zh-TW/translation.json
+++ b/locales/zh-TW/translation.json
@@ -30,5 +30,6 @@
 	"cancel":			"取消",
 	"edit":				"編輯",
 	"delete":			"刪除",
-	"newObject":		"建立新物件"
+	"newObject":		"建立新物件",
+  "fullScreen": "全屏"
 }

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -30,5 +30,6 @@
 	"cancel":			"取消",
 	"edit":				"编辑",
 	"delete":			"删除",
-	"newObject":		"建立新的物件"
+	"newObject":		"建立新的物件",
+  "fullScreen": "全屏"
 }


### PR DESCRIPTION
Tries to solve #671

* add HTML5 fullscreen API methods in viewer.js
* new config option "fullScreenViewer" in mainMenuSettings.buttons
* new "fullScreen" i18n key (button label)
* css pseudo-classes :fullscreen w/ vendor prefixes
* enable "fullScreenViewer" config option in Mirador initialization object