### PR TITLE
tabbed interface - take 2

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1,8 +1,8 @@
-body { 
-  padding: 0; 
-  margin: 0; 
-  overflow: hidden; 
-  font-size: 70%; 
+body {
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+  font-size: 70%;
 }
 a {
   color: inherit; /* blue colors for links too */
@@ -10,7 +10,7 @@ a {
 }
 
 /* jquery-ui-dialog theming/customisation (overrides to reset neutral defaults)
----------------------------------------------------------------------------- 
+----------------------------------------------------------------------------
  */
   .ui-dialog-titlebar {
     display:none;
@@ -59,7 +59,7 @@ a {
 
 /*----------------------------------------------------------------------------
 /* Mirador styles
----------------------------------------------------------------------------- 
+----------------------------------------------------------------------------
  */
 
   .mirador-viewer, .mirador-main-menu-bar, .mirador-status-bar {
@@ -213,7 +213,7 @@ a {
 }
 
 
-/* main menu select menu 
+/* main menu select menu
 ---------------------------------------------------------------------------- */
   #manifest-select-menu, #workspace-select-menu, #workspaceContainer {
     position: absolute;
@@ -621,18 +621,103 @@ li.highlight {
   box-sizing: border-box;
 }
 
+
 .sidePanel {
+    position:absolute;
+  width:280px;
+  left: 0;
+  bottom: 0;
+  top:0;
+  background-color: #efefef;
+  border-right: 1px solid lightgray;
+  box-sizing: border-box;
+  overflow: hidden;
+  transition: all 0.3s ease;
+  padding: 10px;
+  opacity:1;
+  transition: all 0.2s ease-out;
+  transform: translateX(0);
+}
+
+.sidePanel.minimized {
+    transition: all 0.2s ease-out;
+    transform: translateX(-280px);
+    opacity:0;
+    border:none;
+}
+
+.tabContentArea {
   position: relative;
   width:280px;
   height:100%;
   float: left;
   background-color: #efefef;
   border-right: 1px solid lightgray;
-  /*display: none;*/
   box-sizing: border-box;
   overflow: hidden;
-  transition: all 0s ease;
+  transition: all 0.3s ease;
 }
+
+.sidePanel .tabGroup {
+    list-style-type:none;
+    margin:0;
+    padding:0;
+}
+
+.sidePanel .tab {
+    padding: 4px 6px;
+    border-left:0;
+    border-bottom: 2px solid black;
+    display: inline-block;
+    cursor: pointer;
+    border-radius: 3px 3px 0 0;
+}
+
+.sidePanel .tab:not(.selected):hover {
+    border: 2px solid rgba(0,0,0,0.3);
+    border-bottom: 2px solid black;
+    padding:4px 4px;
+}
+
+.sidePanel .tab.selected {
+    border: 2px solid black;
+    border-bottom:0;
+    border-radius: 3px 3px 0 0;
+    margin: 0 -2px;
+}
+.annotationsPanel ul {
+    padding:0;
+    margin:0;
+ }
+.sidePanel .annotationListItem {
+    list-style-type: none;
+    border-left:0;
+    border-right:0;
+    padding:10px 10px 0 10px;
+}
+.sidePanel .annotationListItem:after {
+                 content: "";
+                 height: 1px;
+                 background: linear-gradient(to right,  rgba(0,0,0,0) 0%,rgba(147,147,147,1) 50%,rgba(0,0,0,0) 100%);
+
+                 display: block;
+                 margin-top: 10px;
+             }
+.sidePanel .annotationListItem.focused {
+    background-color: #ddd;
+    border-left: 3px solid lightBlue;
+}
+
+.sidePanel .annotationListItem:hover {
+    background-color: #ddd;
+    border-left: 3px solid lightBlue;
+}
+
+.sidePanel .annotationListItem.selected {
+    background-color: #ccc;
+    border-left: 3px solid deepskyblue;
+}
+
 .sidePanel a:hover {
   text-decoration: none;
 }
@@ -895,7 +980,7 @@ li.highlight {
 
 /* Canvas HUD
 ----------------------- */
-  .mirador-canvas-hud { 
+  .mirador-canvas-hud {
     position:absolute;
     left: 0;
     top:0;
@@ -1207,7 +1292,7 @@ text {
 }
 .annotation, .osd-select-rectangle {
   border: 2px solid deepSkyBlue;
-  box-shadow: 0px 0px 5px white; 
+  box-shadow: 0px 0px 5px white;
   box-sizing: border-box;
 }
 .annotation.selected {
@@ -1525,14 +1610,14 @@ ul.dropdown {
   margin:0;
   cursor: pointer;
   box-sizing: border-box;
-  background-color: #dddddd;  
+  background-color: #dddddd;
   padding: 10px;
   width:100%;
   text-align:left;
 }
 .dropdown li:hover {
   border-left: 3px solid deepskyblue;
-  background-color: #dddddd;  
+  background-color: #dddddd;
   padding-left: 7px;
   font-weight: bold;
 }
@@ -1584,8 +1669,8 @@ div.manifest-info a.mirador-btn.mirador-icon-toc {
   color: black;
 }
 
-.mirador-viewer a.mirador-icon-image-view.selected, 
-.mirador-viewer a.mirador-icon-thumbs-view.selected, 
+.mirador-viewer a.mirador-icon-image-view.selected,
+.mirador-viewer a.mirador-icon-thumbs-view.selected,
 .mirador-viewer a.mirador-icon-toc.selected,
 .mirador-viewer a.mirador-icon-metadata-view.selected {
   color: black;
@@ -1615,7 +1700,7 @@ div.manifest-info a.mirador-btn.mirador-icon-toc {
   overflow: auto;
 }
 .annotation-tooltip {
-  padding: 7px; 
+  padding: 7px;
 }
 .annotation-display {
   position:relative;
@@ -1683,7 +1768,7 @@ div.manifest-info a.mirador-btn.mirador-icon-toc {
   color: #222;
   border-radius: 6px;
   padding: 0 5px;
-  margin-right:5px; 
+  margin-right:5px;
   margin-bottom: 5px;
   text-align: center;
   font-size: 12;
@@ -1695,4 +1780,3 @@ div.manifest-info a.mirador-btn.mirador-icon-toc {
 .mce-edit-area iframe {
     height: 75px !important;
 }
-

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -44,6 +44,11 @@
        *   "bottomPanelVisible" : [_true_, false] whether or not to make the bottom panel visible in this window on load. This setting is dependent
        *                           on bottomPanel being true
        *   "sidePanel" : [_true_, false] whether or not to make the side panel available in this window
+       *   "sidePanelOptions" : control individual menu items in layout menu. if "displayLayout" is false, these options won't be applied
+       *     {
+       *     "toc" : [_true_, false]
+       *     "annotations" : [true, _false_]
+       *     }
        *   "sidePanelVisible" : [_true_, false] whether or not to make the side panel visible in this window on load. This setting is dependent
        *                           on sidePanel being true
        *   "overlay" : [_true_, false] whether or not to make the overlay available/visible in this window

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -258,6 +258,7 @@
         bottomPanelAvailable : options.bottomPanel,
         bottomPanelVisible : options.bottomPanelVisible,
         sidePanelAvailable : options.sidePanel,
+        sidePanelOptions : options.sidePanelOptions,
         sidePanelVisible : options.sidePanelVisible,
         overlayAvailable : options.overlay,
         annotationLayerAvailable : options.annotationLayer,

--- a/js/src/widgets/annotationsLayer.js
+++ b/js/src/widgets/annotationsLayer.js
@@ -23,7 +23,6 @@
     init: function() {
       var _this = this;
       jQuery.unsubscribe(('modeChange.' + _this.windowId));
-      jQuery.unsubscribe(('annotationListLoaded.' + _this.windowId));
 
       this.createRenderer();
       this.bindEvents();

--- a/js/src/widgets/annotationsTab.js
+++ b/js/src/widgets/annotationsTab.js
@@ -1,0 +1,202 @@
+(function($) {
+
+    $.AnnotationsTab = function(options) {
+        jQuery.extend(true, this, {
+            element:           null,
+            appendTo:          null,
+            parent:            null,
+            manifest:          null,
+            visible:           null
+        }, options);
+
+        this.init();
+    };
+
+    $.AnnotationsTab.prototype = {
+        init: function() {
+            var _this = this;
+            jQuery.unsubscribe(('modeChange.' + _this.windowId));
+            this.windowId = this.parent.id;
+
+            this.state({
+                id: 'annotationsTab',
+                visible: this.visible,
+                annotationLists: [],
+                selectedList: null,
+                empty: true,
+                focusedList: null
+            }, true);
+
+            this.listenForActions();
+            this.render(this.state());
+            this.loadTabComponents();
+            this.bindEvents();
+        },
+        state: function(state, initial) {
+            if (!arguments.length) return this.annoTabState;
+            this.annoTabState = state;
+
+            if (!initial) {
+                jQuery.publish('annotationsTabStateUpdated.' + this.windowId, this.annoTabState);
+            }
+
+            return this.annoTabState;
+        },
+        loadTabComponents: function() {
+            var _this = this;
+
+        },
+        tabStateUpdated: function(visible) {
+            var state = this.state();
+            state.visible = state.visible ? false : true;
+
+            this.state(state);
+        },
+        annotationListLoaded: function() {
+            var _this = this,
+                annotationSources = [],
+                state = this.state();
+            for(var i = 0; i < _this.parent.annotationsList.length; i++)
+            {
+
+                if(typeof _this.parent.annotationsList[i].endpoint === 'string'){
+
+                  annotationSources.push('manifest');
+
+                }else{
+
+                  annotationSources.push(_this.parent.annotationsList[i].endpoint.name);
+
+                }
+
+            }
+
+            // make unique
+            annotationSources = annotationSources.filter(function(itm,i,annotationSources){
+                return i==annotationSources.indexOf(itm);
+            });
+
+            state.annotationLists = annotationSources.map(function(annotationSource) {
+                //var s = (annotationSource === state.selectedList ? true : false);
+                return {
+                    annotationSource: annotationSource,
+                    layer: null,
+                    selected: (annotationSource === state.selectedList ? true : false),
+                    focused: false
+                };
+            });
+
+            if(state.annotationLists.length){
+              state.empty = false;
+            }
+
+            this.state(state);
+        },
+        deselectList: function(listId) {
+            var _this = this;
+            var state = this.state();
+            state.selectedList = null;
+            state.annotationLists.forEach(function(list){ list.selected = false; });
+            this.state(state);
+        },
+        selectList: function(listId) {
+            var _this = this;
+            var state = this.state();
+            state.selectedList = listId;
+            state.annotationLists.forEach(function(list){ list.selected = list.annotationSource === listId ? true : false; });
+            this.state(state);
+        },
+        focusList: function(listId) {
+            var state = this.state();
+            state.focusedList = listId;
+            state.annotationLists.forEach(function(list){ list.focused = list.annotationSource === listId ? true : false;});
+            this.state(state);
+        },
+        toggle: function() {},
+        listenForActions: function() {
+            var _this = this;
+
+            jQuery.subscribe('annotationsTabStateUpdated.' + _this.windowId, function(_, data) {
+                _this.render(data);
+            });
+
+            jQuery.subscribe('tabStateUpdated' + _this.windowId, function(_, data) {
+                _this.tabStateUpdated(data.annotationsTab);
+            });
+
+
+            jQuery.subscribe('annotationListLoaded.' + _this.windowId, function(_, data) {
+                _this.annotationListLoaded();
+            });
+
+            jQuery.subscribe('currentCanvasIDUpdated.' + _this.windowId, function(event) {
+
+              jQuery.subscribe('annotationListLoaded.' + _this.windowId, function(event) {
+                  _this.annotationListLoaded();
+              });
+
+              _this.selectList(_this.state().selectedList);
+
+            });
+
+            jQuery.subscribe('listSelected.' + _this.windowId, function(event, listId) {
+                _this.selectList(listId);
+            });
+
+            jQuery.subscribe('listDeselected.' + _this.windowId, function(event, listId) {
+                _this.deselectList(listId);
+            });
+
+        },
+        bindEvents: function() {
+            var _this = this,
+                listItems = this.element.find('.annotationListItem');
+
+            listItems.on('click', function(event) {
+                //event.stopImmediatePropagation();
+                var listClicked = jQuery(this).data('id');
+                if(_this.state().selectedList === listClicked){
+                    //_this.deselectList(listClicked);
+                    jQuery.publish('listDeselected.' + _this.windowId, listClicked);
+                }else{
+                    //_this.selectList(listClicked);
+                    jQuery.publish('listSelected.' + _this.windowId, listClicked);
+                }
+
+            });
+
+        },
+        render: function(state) {
+            var _this = this,
+                templateData = {
+                    annotationSources: state.annotationLists
+                };
+            if (!this.element) {
+                this.element = jQuery(_this.template(templateData)).appendTo(_this.appendTo);
+            } else {
+                _this.appendTo.find(".annotationsPanel").remove();
+                this.element = jQuery(_this.template(templateData)).appendTo(_this.appendTo);
+            }
+            _this.bindEvents();
+
+
+            if (state.visible) {
+                this.element.show();
+            } else {
+                this.element.hide();
+            }
+        },
+        template: Handlebars.compile([
+            '<div class="annotationsPanel">',
+            '<ul class="annotationSources">',
+            '{{#each annotationSources}}',
+            '<li class="annotationListItem {{#if this.selected}}selected{{/if}} {{#if this.focused }}focused{{/if}}" data-id="{{this.annotationSource}}">',
+                    '<span>{{this.annotationSource}}</span>',
+            '</li>',
+            '{{/each}}',
+            '</ul>',
+            '</div>',
+        ].join(''))
+    };
+
+}(Mirador));

--- a/js/src/widgets/annotationsTab.js
+++ b/js/src/widgets/annotationsTab.js
@@ -119,7 +119,7 @@
                 _this.render(data);
             });
 
-            jQuery.subscribe('tabStateUpdated' + _this.windowId, function(_, data) {
+            jQuery.subscribe('tabStateUpdated.' + _this.windowId, function(_, data) {
                 _this.tabStateUpdated(data.annotationsTab);
             });
 

--- a/js/src/widgets/annotationsTab.js
+++ b/js/src/widgets/annotationsTab.js
@@ -15,7 +15,6 @@
     $.AnnotationsTab.prototype = {
         init: function() {
             var _this = this;
-            jQuery.unsubscribe(('modeChange.' + _this.windowId));
             this.windowId = this.parent.id;
 
             this.state({

--- a/js/src/widgets/sidePanel.js
+++ b/js/src/widgets/sidePanel.js
@@ -1,0 +1,125 @@
+(function($) {
+
+    $.SidePanel= function(options) {
+        jQuery.extend(true, this, {
+            element:           null,
+            appendTo:          null,
+            parent:            null,
+            manifest:          null
+        }, options);
+
+        this.init();
+    };
+
+    $.SidePanel.prototype = {
+        init: function() {
+            var _this = this;
+            this.windowId = this.parent.id;
+
+            this.state({
+                tocTabAvailable: true,
+                annotationsTabAvailable: false,
+                layersTabAvailable: false,
+                toolsTabAvailable: false,
+                width: 280,
+                open: true
+            }, true);
+
+            this.listenForActions();
+            this.render(this.state());
+            this.bindEvents();
+
+            this.loadSidePanelComponents();
+        },
+        loadSidePanelComponents: function() {
+            var _this = this;
+
+            new $.Tabs({
+                windowId: this.parent.id,
+                appendTo: this.appendTo
+            });
+
+            new $.TableOfContents({
+                manifest: this.manifest,
+                appendTo: this.element.find('.tabContentArea'),
+                parent: this.parent,
+                panel: true,
+                canvasID: this.parent.currentCanvasID,
+                imagesList: this.parent.imagesList,
+                thumbInfo: {thumbsHeight: 80, listingCssCls: 'panel-listing-thumbs', thumbnailCls: 'panel-thumbnail-view'}
+            });
+
+            new $.AnnotationsTab({
+                manifest: _this.manifest,
+                parent: this.parent,
+                appendTo: _this.element.find('.tabContentArea')
+            });
+
+        },
+        state: function(state, initial) {
+            if (!arguments.length) return this.panelState;
+            this.panelState = state;
+
+            if (!initial) {
+                jQuery.publish('sidePanelStateUpdated' + this.windowId, this.panelState);
+            }
+
+            return this.panelState;
+        },
+        panelToggled: function() {
+            var state = this.state(),
+                open = !state.open;
+
+            state.open = open;
+            this.state(state);
+        },
+        getTemplateData: function() {
+            return {
+                annotationsTab: this.state().annotationsTab,
+                tocTab: this.state().tocTab
+            };
+        },
+        listenForActions: function() {
+            var _this = this;
+
+            jQuery.subscribe('sidePanelStateUpdated' + this.windowId, function(_, data) {
+                console.log('sidePanelToggled now');
+                console.log(data);
+                _this.render(data);
+            });
+
+            jQuery.subscribe('sidePanelResized', function() {
+            });
+
+            jQuery.subscribe('sidePanelToggled' + this.windowId, function() {
+                _this.panelToggled();
+            });
+        },
+        bindEvents: function() {
+            var _this = this;
+        },
+        render: function(renderingData) {
+            var _this = this;
+
+            if (!this.element) {
+                this.element = this.appendTo;
+                jQuery(_this.template(renderingData)).appendTo(_this.appendTo);
+                return;
+            }
+
+            if (renderingData.open) {
+                this.appendTo.removeClass('minimized');
+            } else {
+                this.appendTo.addClass('minimized');
+            }
+        },
+        template: Handlebars.compile([
+            '<div class="tabContentArea">',
+            '<ul class="tabGroup">',
+            '</ul>',
+            '</div>'
+        ].join('')),
+        toggle: function () {}
+    };
+
+}(Mirador));

--- a/js/src/widgets/sidePanel.js
+++ b/js/src/widgets/sidePanel.js
@@ -10,7 +10,8 @@
             tocTabAvailable:   false,
             annotationsTabAvailable: false,
             layersTabAvailable: false,
-            toolsTabAvailable: false
+            toolsTabAvailable: false,
+            hasStructures:     false
         }, options);
 
         this.init();
@@ -72,7 +73,8 @@
             new $.Tabs({
                 windowId: this.parent.id,
                 appendTo: this.appendTo,
-                tabs : this.panelState.tabs
+                tabs : this.panelState.tabs,
+                parent : this
             });
 
             if (this.tocTabAvailable) {
@@ -144,8 +146,6 @@
         listenForActions: function() {
             var _this = this;
             jQuery.subscribe('sidePanelStateUpdated.' + this.windowId, function(_, data) {
-                console.log('sidePanelToggled now');
-                console.log(data);
                 _this.render(data);
             });
 

--- a/js/src/widgets/tabs.js
+++ b/js/src/widgets/tabs.js
@@ -1,0 +1,95 @@
+(function($) {
+
+    $.Tabs = function(options) {
+        jQuery.extend(true, this, {
+            element:           null,
+            appendTo:          null,
+            windowId:          null
+        }, options);
+
+        this.init();
+    };
+
+    $.Tabs.prototype = {
+        init: function() {
+            var _this = this;
+
+            this.state({
+                //tabs: [{id:'tocTab', label:'Indices'}, {id:'annotationsTab', label:'Annotations'}],
+                tabs: [{id:'tocTab', label:'Indices'}],
+                selectedTabIndex: 0
+            }, true);
+
+            this.listenForActions();
+            this.render(this.state());
+            this.bindEvents();
+        },
+        state: function(state, initial) {
+            if (!arguments.length) return this.tabState;
+            this.tabState = state;
+
+           if (!initial) {
+                jQuery.publish('tabStateUpdated' + this.windowId, this.tabState);
+           }
+
+            return this.tabState;
+        },
+        tabSelected: function(index) {
+            var state = this.state();
+            state.selectedTabIndex = index;
+            this.state(state);
+        },
+        getTemplateData: function() {
+            return {
+                annotationsTab: this.state().annotationsTab,
+                tocTab: this.state().tocTab
+            };
+        },
+        listenForActions: function() {
+            var _this = this;
+
+            jQuery.subscribe('tabStateUpdated' + this.windowId, function(_, data) {
+                _this.render(data);
+            });
+
+            jQuery.subscribe('tabSelected' + this.windowId, function(_, data) {
+                _this.tabSelected(data);
+            });
+
+            jQuery.subscribe('tabFocused', function() {
+            });
+        },
+        bindEvents: function() {
+            var _this = this;
+
+            this.element.find('.tab').on('click', function(event) {
+                jQuery.publish('tabSelected' + _this.windowId, jQuery( ".tabGroup li" ).index( this ));
+            });
+        },
+        render: function(renderingData) {
+            var _this = this;
+
+            if (!this.element) {
+                if(renderingData.tabs.length == 1){ renderingData.tabs = []; } // don't show label if only one tab
+                this.element = jQuery(_this.template(renderingData)).prependTo(_this.appendTo);
+                return;
+            }
+
+            this.element.find('.tab').removeClass('selected');
+            var tabClass = '.' + renderingData.tabs[renderingData.selectedTabIndex].id;
+            this.element.find(tabClass).addClass('selected');
+
+        },
+        template: Handlebars.compile([
+          '<ul class="tabGroup">',
+            '{{#each tabs}}',
+            '<li class="tab {{this.id}} {{#unless @index}}selected{{/unless}}" data-tabId="{{this.id}}">',
+                '{{this.label}}',
+            '</li>',
+            '{{/each}}',
+          '</ul>',
+        ].join('')),
+        toggle: function () {}
+    };
+
+}(Mirador));

--- a/js/src/widgets/tabs.js
+++ b/js/src/widgets/tabs.js
@@ -15,8 +15,8 @@
             var _this = this;
 
             this.state({
-                //tabs: [{id:'tocTab', label:'Indices'}, {id:'annotationsTab', label:'Annotations'}],
-                tabs: [{id:'tocTab', label:'Indices'}],
+                tabs: [{id:'tocTab', label:'Indices'}, {id:'annotationsTab', label:'Annotations'}],
+                //tabs: [{id:'tocTab', label:'Indices'}],
                 selectedTabIndex: 0
             }, true);
 

--- a/js/src/widgets/tabs.js
+++ b/js/src/widgets/tabs.js
@@ -77,7 +77,15 @@
                     return value.options.available;
                 });
                 renderingData.tabs = tabs;
-                if(renderingData.tabs.length === 1){ renderingData.tabs = []; } // don't show button if only one tab
+                if(renderingData.tabs.length === 1){                    
+                    // TODO: temporary logic to minimize side panel if only tab is toc and toc is empty
+                    if (renderingData.tabs[0].name === 'toc' && !_this.parent.hasStructures) {
+                        jQuery.publish("sidePanelVisibilityByTab." + _this.windowId, false);
+                    }
+
+                    // don't show button if only one tab
+                    renderingData.tabs = []; 
+                } 
                 //TODO: add text if there is one label or no content within this tab
                 this.element = jQuery(_this.template(renderingData)).prependTo(_this.appendTo);
                 return;

--- a/js/src/widgets/toc.js
+++ b/js/src/widgets/toc.js
@@ -59,10 +59,18 @@
 
     },
 
-    getTplData: function() {  
+    tabStateUpdated: function(data) {
+        if (data.tabs[data.selectedTabIndex].id == 'tocTab') {
+            this.element.show();
+        } else {
+            this.element.hide();
+        }
+    },
+
+    getTplData: function() {
       var _this = this,
       ranges = _this.extractRangeTrees(_this.ranges);
-      
+
       if (ranges.length < 2) {
         ranges = ranges[0].children;
       }
@@ -102,9 +110,9 @@
         var children = jQuery.grep(flatRanges, function(child) { if (!child.within) { child.within = 'root'; } return child.within == parent.id; });
         if ( children.length ) {
           if ( parent.id === 'root') {
-            // If there are children and their parent's 
+            // If there are children and their parent's
             // id is a root, bind them to the tree object.
-            // 
+            //
             // This begins the construction of the object,
             // and all non-top-level children are now
             // bound the these base nodes set on the tree
@@ -112,26 +120,26 @@
             children.forEach(function(child) {
               child.level = 0;
             });
-            tree = children;   
+            tree = children;
           } else {
             // If the parent does not have a top-level id,
             // bind the children to the parent node in this
             // recursion level before handing it over for
-            // another spin. 
+            // another spin.
             //
-            // Because "child" is passed as 
-            // the second parameter in the next call, 
+            // Because "child" is passed as
+            // the second parameter in the next call,
             // in the next iteration "parent" will be the
             // first child bound here.
-            children.forEach(function(child) { 
+            children.forEach(function(child) {
               child.level = parent.level+1;
             });
             parent.children = children;
           }
-          // The function cannot continue to the return 
-          // statement until this line stops being called, 
+          // The function cannot continue to the return
+          // statement until this line stops being called,
           // which only happens when "children" is empty.
-          jQuery.each( children, function( index, child ){ unflatten( flatRanges, child ); } );                    
+          jQuery.each( children, function( index, child ){ unflatten( flatRanges, child ); } );
         }
         return tree;
       }
@@ -160,21 +168,21 @@
 
       // Deselect elements
       jQuery(toDeselect).removeClass('selected');
-      
+
       // Select new elements
       jQuery(toSelect).addClass('selected');
-      
+
       // Scroll to new elements
       scroll();
-      
+
       // Open new ones
       jQuery(toOpen).toggleClass('open').find('ul:first').slideFadeToggle();
       // Close old ones (find way to keep scroll position).
       jQuery(toClose).toggleClass('open').find('ul:first').slideFadeToggle(400, 'swing', scroll);
-       
+
       // Get the sum of the outer height of all elements to be removed.
       // Subtract from current parent height to retreive the new height.
-      // Scroll with respect to this. 
+      // Scroll with respect to this.
       scroll();
 
       function scroll() {
@@ -182,7 +190,7 @@
         if (head.length > 0) {
           _this.element.scrollTo(head, 400);
         }
-      } 
+      }
 
     },
 
@@ -192,10 +200,14 @@
 
       jQuery.subscribe('focusChanged', function(_, manifest, focusFrame) {
       });
-      
+
       jQuery.subscribe('cursorFrameUpdated', function(_, manifest, cursorBounds) {
       });
-        
+
+      jQuery.subscribe('tabStateUpdated' + _this.parent.id, function(_, data) {
+        _this.tabStateUpdated(data);
+      });
+
       jQuery.subscribe(('currentCanvasIDUpdated.' + _this.parent.id), function(event, canvasID) {
         if (!_this.structures) { return; }
         _this.setSelectedElements($.getRangeIDByCanvasID(_this.structures, canvasID));
@@ -205,12 +217,12 @@
       _this.element.find('.toc-link').on('click', function(event) {
         event.stopPropagation();
         // The purpose of the immediate event is to update the data on the parent
-        // by calling its "set" function. 
-        // 
-        // The parent (window) then emits an event notifying all panels of 
+        // by calling its "set" function.
+        //
+        // The parent (window) then emits an event notifying all panels of
         // the update, so they can respond in their own unique ways
-        // without window having to know anything about their DOMs or 
-        // internal structure. 
+        // without window having to know anything about their DOMs or
+        // internal structure.
         var rangeID = jQuery(this).data().rangeid,
         canvasID = jQuery.grep(_this.structures, function(item) { return item['@id'] == rangeID; })[0].canvases[0],
         isLeaf = jQuery(this).closest('li').hasClass('leaf-item');
@@ -221,17 +233,17 @@
           _this.parent.setCurrentCanvasID(canvasID);
         // }
       });
-      
+
       _this.element.find('.toc-caret').on('click', function(event) {
         event.stopPropagation();
-        
+
         var rangeID = jQuery(this).parent().data().rangeid;
-        _this.setOpenItem(rangeID); 
+        _this.setOpenItem(rangeID);
 
         // For now it's alright if this data gets lost in the fray.
         jQuery(this).closest('li').toggleClass('open').find('ul:first').slideFadeToggle();
 
-        // The parent (window) then emits an event notifying all panels of 
+        // The parent (window) then emits an event notifying all panels of
         // the update, so they can respond in their own unique ways
         // without window having to know anything about their DOMs or
         // internal structure.
@@ -302,7 +314,7 @@
         children.forEach(function(child) {
           out = out + previousTemplate(child);
         });
-        
+
         return out;
       });
 
@@ -317,13 +329,13 @@
 
     toggle: function(stateValue) {
       if (!this.structures) { stateValue = false; }
-      if (stateValue) { 
-        this.show(); 
+      if (stateValue) {
+        this.show();
       } else {
         this.hide();
       }
     },
-    
+
     hide: function() {
       jQuery(this.appendTo).hide();
       this.parent.element.find('.view-container').addClass('focus-max-width');
@@ -333,8 +345,7 @@
       jQuery(this.appendTo).show({effect: "fade", duration: 300, easing: "easeInCubic"});
       this.parent.element.find('.view-container').removeClass('focus-max-width');
     }
-    
+
   };
 
 }(Mirador));
-

--- a/js/src/widgets/toc.js
+++ b/js/src/widgets/toc.js
@@ -25,12 +25,12 @@
     init: function () {
       var _this = this;
       _this.structures = _this.manifest.getStructures();
-      if (!_this.structures || _this.structures.length === 0) {
+      /*if (!_this.structures || _this.structures.length === 0) {
         _this.hide();
         _this.parent.setTOCBoolean(false);
         return;
-      } else {
-        _this.parent.setTOCBoolean(true);
+      } else {*/
+        //_this.parent.setTOCBoolean(true);
         this.ranges = this.setRanges();
         this.element = jQuery(this.template({ ranges: this.getTplData() })).appendTo(this.appendTo);
         this.tocData = this.initTocData();
@@ -38,7 +38,7 @@
         this.element.find('.has-child ul').hide();
         this.render();
         this.bindEvents();
-      }
+      //}
     },
 
     setRanges: function() {

--- a/js/src/widgets/toc.js
+++ b/js/src/widgets/toc.js
@@ -25,8 +25,10 @@
     init: function () {
       var _this = this;
       _this.structures = _this.manifest.getStructures();
-      /*if (!_this.structures || _this.structures.length === 0) {
-        _this.hide();
+      if (!_this.structures || _this.structures.length === 0) {
+        return;
+      }
+      /*  _this.hide();
         _this.parent.setTOCBoolean(false);
         return;
       } else {*/
@@ -60,7 +62,7 @@
     },
 
     tabStateUpdated: function(data) {
-        if (data.tabs[data.selectedTabIndex].id == 'tocTab') {
+        if (data.tabs[data.selectedTabIndex].options.id == 'tocTab') {
             this.element.show();
         } else {
             this.element.hide();
@@ -204,7 +206,7 @@
       jQuery.subscribe('cursorFrameUpdated', function(_, manifest, cursorBounds) {
       });
 
-      jQuery.subscribe('tabStateUpdated' + _this.parent.id, function(_, data) {
+      jQuery.subscribe('tabStateUpdated.' + _this.parent.id, function(_, data) {
         _this.tabStateUpdated(data);
       });
 

--- a/js/src/widgets/toc.js
+++ b/js/src/widgets/toc.js
@@ -12,6 +12,7 @@
       selectedElements: [],
       openElements:     [],
       hoveredElement:   [],
+      ranges:           [],
       selectContext:    null,
       tocData: {},
       active: null
@@ -26,21 +27,16 @@
       var _this = this;
       _this.structures = _this.manifest.getStructures();
       if (!_this.structures || _this.structures.length === 0) {
-        return;
-      }
-      /*  _this.hide();
-        _this.parent.setTOCBoolean(false);
-        return;
-      } else {*/
-        //_this.parent.setTOCBoolean(true);
+        this.element = jQuery(this.emptyTemplate()).appendTo(this.appendTo);
+      } else {
         this.ranges = this.setRanges();
         this.element = jQuery(this.template({ ranges: this.getTplData() })).appendTo(this.appendTo);
         this.tocData = this.initTocData();
         this.selectedElements = $.getRangeIDByCanvasID(_this.structures, _this.parent.currentCanvasID);
         this.element.find('.has-child ul').hide();
         this.render();
-        this.bindEvents();
-      //}
+      }
+      this.bindEvents();
     },
 
     setRanges: function() {
@@ -62,7 +58,7 @@
     },
 
     tabStateUpdated: function(data) {
-        if (data.tabs[data.selectedTabIndex].options.id == 'tocTab') {
+        if (data.tabs[data.selectedTabIndex].options.id === 'tocTab') {
             this.element.show();
         } else {
             this.element.hide();
@@ -286,6 +282,13 @@
     // returnToPlace: function() {
     //   console.log('returnToPlace');
     // },
+
+    emptyTemplate: Handlebars.compile([
+            '<ul class="toc">',
+            '<li class="leaf-item open">',
+            '<h2><span>No index available</span></h2>',
+            '</ul>',
+        ].join('')),
 
     template: function(tplData) {
 

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -256,6 +256,11 @@
         }
     });
 
+      // TODO: temporary logic to minimize side panel if only tab is toc and toc is empty
+      jQuery.subscribe('sidePanelVisibilityByTab.' + this.id, function(event, visible) {
+        _this.sidePanelVisibility(visible, '0s');
+      });
+
     },
 
     bindAnnotationEvents: function() {
@@ -380,7 +385,13 @@
       }
       var _this = this,
       tocAvailable = _this.sidePanelOptions.toc,
-      annotationsTabAvailable = _this.sidePanelOptions.annotations;
+      annotationsTabAvailable = _this.sidePanelOptions.annotations,
+      hasStructures = true;
+
+      var structures = _this.manifest.getStructures();
+      if (!structures || structures.length === 0) {
+        hasStructures = false;
+      }
 
       if (this.sidePanel === null) {
         this.sidePanel = new $.SidePanel({
@@ -389,7 +400,8 @@
               manifest: _this.manifest,
               canvasID: _this.currentCanvasID,
               tocTabAvailable: tocAvailable,
-              annotationsTabAvailable: annotationsTabAvailable
+              annotationsTabAvailable: annotationsTabAvailable,
+              hasStructures: hasStructures
         });
       } else {
         this.sidePanel.update('annotations', annotationsTabAvailable);

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -40,6 +40,10 @@
       id : null,
       sidePanel: null, //the actual module for the side panel
       sidePanelAvailable: true,
+      sidePanelOptions: {
+        "toc" : true,
+        "annotations" : false
+      },
       sidePanelVisible: true,
       annotationsAvailable: {
         'ThumbnailsView' : false,
@@ -113,13 +117,12 @@
           _this.focusOverlaysAvailable[key].bottomPanel = {'' : false};
         });
       }
-      if (typeof this.sidePanelAvailable !== 'undefined' && !this.sidePanelAvailable) {
-        jQuery.each(this.focusOverlaysAvailable, function(key, value) {
-          _this.focusOverlaysAvailable[key].sidePanel = {'' : false};
+
+      templateData.sidePanel = this.sidePanelAvailable;
+      if (this.sidePanelAvailable) {
+        templateData.sidePanel = !Object.keys(this.sidePanelOptions).every(function(element, index, array) {
+          return _this.sidePanelOptions[element] === false;
         });
-        templateData.sidePanel = false;
-      } else {
-        templateData.sidePanel = true;
       }
       if (typeof this.overlayAvailable !== 'undefined' && !this.overlayAvailable) {
         jQuery.each(this.focusOverlaysAvailable, function(key, value) {
@@ -241,7 +244,7 @@
         }
       });
 
-      jQuery.subscribe('sidePanelStateUpdated' + this.id, function(event, state) {
+      jQuery.subscribe('sidePanelStateUpdated.' + this.id, function(event, state) {
         if (state.open) {
             _this.element.find('.fa-list').switchClass('fa-list', 'fa-caret-down');
             _this.element.find('.mirador-icon-toc').addClass('selected');
@@ -372,25 +375,12 @@
     },
 
     updateSidePanel: function() {
-      console.log("sidepanel updated",this.currentFocus);
       if (!this.sidePanelAvailable) {
         return;
       }
       var _this = this,
-      tocAvailable = true,
-      structures = _this.manifest.getStructures();
-      if (!structures || structures.length === 0) {
-        tocAvailable = false;
-      }
-
-      var annotationsTabAvailable = this.annotationsAvailable[this.currentFocus];
-      console.log(annotationsTabAvailable);
-      if (annotationsTabAvailable) {
-        console.log(this.annotationsList);
-        if (this.annotationsList.length === 0) {
-          annotationsTabAvailable = false;
-        }
-      }
+      tocAvailable = _this.sidePanelOptions.toc,
+      annotationsTabAvailable = _this.sidePanelOptions.annotations;
 
       if (this.sidePanel === null) {
         this.sidePanel = new $.SidePanel({
@@ -402,7 +392,7 @@
               annotationsTabAvailable: annotationsTabAvailable
         });
       } else {
-        this.sidePanel.state({tabs: {annotationsTabAvailable: annotationsTabAvailable}});
+        this.sidePanel.update('annotations', annotationsTabAvailable);
       }
     },
  
@@ -421,7 +411,7 @@
       }
     },
 
-    setTOCBoolean: function(boolValue) {
+    /*setTOCBoolean: function(boolValue) {
       var _this = this;
       jQuery.each(this.focusOverlaysAvailable, function(key, value) {
         _this.focusOverlaysAvailable[key].sidePanel.TableOfContents = boolValue;
@@ -430,7 +420,7 @@
       if (!boolValue) {
         this.element.find('.mirador-icon-toc').hide();
       }
-    },
+    },*/
 
     togglePanels: function(panelType, panelState, viewType, focusState) {
       //update state in focusOverlaysAvailable

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -20,23 +20,23 @@
       focusModules:           {'ThumbnailsView': null, 'ImageView': null, 'ScrollView': null, 'BookView': null},
       focusOverlaysAvailable: {
         'ThumbnailsView': {
-          'overlay' : {'MetadataView' : false}, 
-          'sidePanel' : {'TableOfContents' : true},
+          'overlay' : {'MetadataView' : false},
+          'sidePanel' : {'SidePanel' : true},
           'bottomPanel' : {'' : false}
         },
         'ImageView': {
-          'overlay' : {'MetadataView' : false}, 
-          'sidePanel' : {'TableOfContents' : true},
+          'overlay' : {'MetadataView' : false},
+          'sidePanel' : {'SidePanel' : true},
           'bottomPanel' : {'ThumbnailsView' : true}
         },
         'ScrollView': {
-          'overlay' : {'MetadataView' : false}, 
-          'sidePanel' : {'TableOfContents' : true},
+          'overlay' : {'MetadataView' : false},
+          'sidePanel' : {'SidePanel' : true},
           'bottomPanel' : {'' : false}
         },
         'BookView': {
           'overlay' : {'MetadataView' : false},
-          'sidePanel' : {'TableOfContents' : true},
+          'sidePanel' : {'SidePanel' : true},
           'bottomPanel' : {'ThumbnailsView' : true}
         }
       },
@@ -88,7 +88,7 @@
 
       //remove any imageModes that are not available as a focus
       this.imageModes = jQuery.map(this.imageModes, function(value, index) {
-        if (jQuery.inArray(value, _this.focuses) === -1) return null;  
+        if (jQuery.inArray(value, _this.focuses) === -1) return null;
         return value;
       });
 
@@ -131,11 +131,11 @@
       jQuery.each(this.focuses, function(index, value) {
         templateData[value] = true;
       });
-      templateData.title = manifest.label; 
-      templateData.displayLayout = this.displayLayout; 
-      templateData.layoutOptions = this.layoutOptions; 
+      templateData.title = manifest.label;
+      templateData.displayLayout = this.displayLayout;
+      templateData.layoutOptions = this.layoutOptions;
       // if displayLayout is true,  but all individual options are set to false, set displayLayout to false
-      if (this.displayLayout) { 
+      if (this.displayLayout) {
         templateData.displayLayout = !Object.keys(this.layoutOptions).every(function(element, index, array) {
           return _this.layoutOptions[element] === false;
         });
@@ -172,7 +172,7 @@
       this.bindEvents();
 
       if (this.imagesList.length === 1) {
-        this.bottomPanelVisibility(false);      
+        this.bottomPanelVisibility(false);
       } else {
         this.bottomPanelVisibility(this.bottomPanelVisible);
       }
@@ -210,7 +210,7 @@
     bindEvents: function() {
       var _this = this;
 
-      //this event should trigger from layout      
+      //this event should trigger from layout
       jQuery(window).resize($.debounce(function(){
         if (_this.focusModules.ScrollView) {
           var containerHeight = _this.element.find('.view-container').height();
@@ -238,8 +238,21 @@
           _this.element.find('.remove-object-option').show();
         }
       });
+
+      jQuery.subscribe('sidePanelStateUpdated' + this.id, function(event, state) {
+        if (state.open) {
+            _this.element.find('.fa-list').switchClass('fa-list', 'fa-caret-down');
+            _this.element.find('.mirador-icon-toc').addClass('selected');
+            _this.element.find('.view-container').removeClass('maximised');
+        } else {
+            _this.element.find('.mirador-icon-toc').removeClass('selected');
+            _this.element.find('.fa-caret-down').switchClass('fa-caret-down', 'fa-list');
+            _this.element.find('.view-container').addClass('maximised');
+        }
+    });
+
     },
-    
+
     bindAnnotationEvents: function() {
       var _this = this;
       jQuery.subscribe('annotationCreated.'+_this.id, function(event, oaAnno, osdOverlay) {
@@ -258,7 +271,7 @@
           console.log("There was an error saving this new annotation");
           //remove this overlay because we couldn't save annotation
           jQuery(osdOverlay).remove();
-        }); 
+        });
       });
 
       jQuery.subscribe('annotationUpdated.'+_this.id, function(event, oaAnno) {
@@ -270,21 +283,21 @@
               return false;
             }
           });
-          jQuery.publish(('annotationListLoaded.' + _this.id));          
+          jQuery.publish(('annotationListLoaded.' + _this.id));
         },
         function() {
-          console.log("There was an error updating this annotation");        
+          console.log("There was an error updating this annotation");
         });
       });
 
-      jQuery.subscribe('annotationDeleted.'+_this.id, function(event, annoId) {        
+      jQuery.subscribe('annotationDeleted.'+_this.id, function(event, annoId) {
         //remove from endpoint
         //first function is success callback, second is error callback
         _this.endpoint.deleteAnnotation(annoId, function() {
           _this.annotationsList = jQuery.grep(_this.annotationsList, function(e){ return e['@id'] !== annoId; });
           jQuery.publish(('annotationListLoaded.' + _this.id));
           jQuery.publish(('removeOverlay.' + _this.id), annoId);
-        }, 
+        },
         function() {
           // console.log("There was an error deleting this annotation");
         });
@@ -320,11 +333,11 @@
           //instantiate any panels that exist for this view but are still null
           if (view !== '' && _this[panelType] === null) {
             _this[panelType] = new $[view]({
-              manifest: _this.manifest, 
-              appendTo: _this.element.find('.'+panelType), 
-              parent: _this, 
-              panel: true, 
-              canvasID: _this.currentCanvasID, 
+              manifest: _this.manifest,
+              appendTo: _this.element.find('.'+panelType),
+              parent: _this,
+              panel: true,
+              canvasID: _this.currentCanvasID,
               imagesList: _this.imagesList,
               thumbInfo: {thumbsHeight: 80, listingCssCls: 'panel-listing-thumbs', thumbnailCls: 'panel-thumbnail-view'}
             });
@@ -334,7 +347,7 @@
           displayed = _this.focusOverlaysAvailable[state][panelType][view];
 
           //toggle any valid panels
-          if (view !== '' && displayed) {   
+          if (view !== '' && displayed) {
             _this.togglePanels(panelType, displayed, view, state);
           }
 
@@ -395,7 +408,7 @@
       tocIconElement = this.element.find('.mirador-icon-toc'),
       sidePanelElement = this.element.find('.sidePanel'),
       viewContainerElement = this.element.find('.view-container');
-      
+
       sidePanelElement.css('transition-duration', transitionDuration);
       viewContainerElement.css('transition', transitionDuration);
       if (visible && sidePanelElement.hasClass('minimized')) {
@@ -468,10 +481,10 @@
       this.updateManifestInfo();
       this.updatePanelsAndOverlay(focusState);
       jQuery.publish("windowUpdated", {
-        id: _this.id, 
-        viewType: _this.currentFocus, 
-        canvasID: _this.currentCanvasID, 
-        imageMode: _this.currentImageMode, 
+        id: _this.id,
+        viewType: _this.currentFocus,
+        canvasID: _this.currentCanvasID,
+        imageMode: _this.currentImageMode,
         loadedManifest: _this.manifest.jsonLd['@id'],
         slotAddress: _this.slotAddress
       });
@@ -481,10 +494,10 @@
       this.currentCanvasID = canvasID;
       if (this.focusModules.ThumbnailsView === null) {
         this.focusModules.ThumbnailsView = new $.ThumbnailsView({
-          manifest: this.manifest, 
-          appendTo: this.element.find('.view-container'), 
-          parent: this, 
-          canvasID: this.currentCanvasID, 
+          manifest: this.manifest,
+          appendTo: this.element.find('.view-container'),
+          parent: this,
+          canvasID: this.currentCanvasID,
           imagesList: this.imagesList
         });
       } else {
@@ -498,11 +511,11 @@
       this.currentCanvasID = canvasID;
       if (this.focusModules.ImageView === null) {
         this.focusModules.ImageView = new $.ImageView({
-          manifest: this.manifest, 
-          appendTo: this.element.find('.view-container'), 
-          parent: this, 
+          manifest: this.manifest,
+          appendTo: this.element.find('.view-container'),
+          parent: this,
           windowId: this.id,
-          canvasID: canvasID, 
+          canvasID: canvasID,
           imagesList: this.imagesList,
           osdOptions: this.focusOptions,
           bottomPanelAvailable: this.bottomPanelAvailable,
@@ -523,11 +536,11 @@
       this.currentCanvasID = canvasID;
       if (this.focusModules.BookView === null) {
         this.focusModules.BookView = new $.BookView({
-          manifest: this.manifest, 
-          appendTo: this.element.find('.view-container'), 
-          parent: this, 
+          manifest: this.manifest,
+          appendTo: this.element.find('.view-container'),
+          parent: this,
           windowId: this.id,
-          canvasID: canvasID, 
+          canvasID: canvasID,
           imagesList: this.imagesList,
           osdOptions: this.focusOptions,
           bottomPanelAvailable: this.bottomPanelAvailable,
@@ -545,18 +558,18 @@
       if (this.focusModules.ScrollView === null) {
         var containerHeight = this.element.find('.view-container').height();
         this.focusModules.ScrollView = new $.ScrollView({
-          manifest: this.manifest, 
-          appendTo: this.element.find('.view-container'), 
-          parent: this, 
-          canvasID: this.currentCanvasID, 
-          imagesList: this.imagesList, 
+          manifest: this.manifest,
+          appendTo: this.element.find('.view-container'),
+          parent: this,
+          canvasID: this.currentCanvasID,
+          imagesList: this.imagesList,
           thumbInfo: {thumbsHeight: Math.floor(containerHeight * this.scrollImageRatio), listingCssCls: 'scroll-listing-thumbs', thumbnailCls: 'scroll-view'}
         });
       } else {
         var view = this.focusModules.ScrollView;
         view.updateImage(canvasID);
       }
-      this.toggleFocus('ScrollView', '');    
+      this.toggleFocus('ScrollView', '');
     },
 
     updateFocusImages: function(imageList) {
@@ -583,7 +596,7 @@
       }
       jQuery.publish(('currentCanvasIDUpdated.' + _this.id), canvasID);
     },
-    
+
     replaceWindow: function(newSlotAddress, newElement) {
       this.slotAddress = newSlotAddress;
       this.appendTo = newElement;
@@ -667,10 +680,10 @@
           _this.annotationsList = _this.annotationsList.concat(_this.endpoint.annotationsList);
           // clear out some bad data
           _this.annotationsList = jQuery.grep(_this.annotationsList, function (value, index) {
-            if (typeof value.on === "undefined") { 
+            if (typeof value.on === "undefined") {
               return false;
             }
-            return true; 
+            return true;
           });
           jQuery.publish('annotationListLoaded.' + _this.id);
         });
@@ -817,4 +830,3 @@
   };
 
 }(Mirador));
-


### PR DESCRIPTION
This approach is a bit different than we had discussed in #666 in order to get the change in quickly (but without disruption) as a starting point for adding tabs to the side panel.  Knowing if a tab is empty and should be hidden would require the tabs.js widget to listen for all possible tabs' state changes, which starts to look a bit like a "plugin" type pattern since the listener may know know what to listen to without its own code getting updated with every possible tab.  But this PR stops short of a full plugin implementation since that requires more "big" decisions than I feel comfortable making on my own, although I could easily see a "tabs plugin" directory that builds a tab list based on the tab widgets that exist inside.  

Instead, I took a simplified approach so we could get this accepted/merged before we start getting conflicts due to other commits.  If you want to add a tab using this code, there are two steps:

1. Add additional tabs through the tabs.js state object like so:  
    tabs: [{id:'tocTab', label:'Indices'}, {id:'annotationsTab', label:'Annotations'}],
2. Add a "tab" widget that has an id property that matches the id supplied to the tabs.js widget (see annotationsTab.js)

To hide a tab, just remove it from the list referred to in step 1 (the tocTab is currently the only one).  You will not see the tabs until you add one since it hides the tab/label if there is only one tab.  I understand that the "tabs" array I refer to in step 1 could be defined in the configuration window object, but I'm struggling to remember how to set that up.  I don't mind adding it, but need some guidance.