### PR TITLE
Added configuration options for JSONBlob

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,16 @@
                  { "manifestUri": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0002/manifest.json", "location": 'e-codices'},
                  { "manifestUri": "http://www.e-codices.unifr.ch/metadata/iiif/bge-cl0015/manifest.json", "location": 'e-codices'}
              ],
+
+	    'jsonStorageEndpoint': {
+		'name': 'JSONBlob API Endpoint',
+		'module': 'JSONBlobAPI',
+		'options': {
+			'ssl': false,
+			'host': 'localhost',
+			'port': '8080'
+		}
+	    },
             "windowObjects": []
          });
      });

--- a/index.html
+++ b/index.html
@@ -50,16 +50,6 @@
                  { "manifestUri": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0002/manifest.json", "location": 'e-codices'},
                  { "manifestUri": "http://www.e-codices.unifr.ch/metadata/iiif/bge-cl0015/manifest.json", "location": 'e-codices'}
              ],
-
-	    'jsonStorageEndpoint': {
-		'name': 'JSONBlob API Endpoint',
-		'module': 'JSONBlobAPI',
-		'options': {
-			'ssl': false,
-			'host': 'localhost',
-			'port': '8080'
-		}
-	    },
             "windowObjects": []
          });
      });

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -140,7 +140,9 @@
 	'name': 'JSONBlob API Endpoint',
 	'module': 'JSONBlobAPI',
 	'options': {
-		'ssl': true
+		'ssl': true,
+		'port': '443',
+		'host': 'jsonblob.com'
 	}
     },
 


### PR DESCRIPTION
This PR will add the following options for the JSONBlob. This changes will allow the use of locally installed JSONBlob services. The plugin can be added to the configuration of Mirador like this:

```
'jsonStorageEndpoint': {
    'name': 'JSONBlob API Endpoint',
    'module': 'JSONBlobAPI',
    'options': {
        'ssl': false,
        'host': 'localhost',
        'port': '8080'
    }
}
```

This are the options:

*host* - is the hostname or IP where the service is running
*port* - is the port the service is listening to
*ssl* - can be *true* or *false*, this determines is http or https is used

