### PR TITLE
Redesign of manifest panel (revised PR #555)

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -79,6 +79,19 @@ a {
   border: 0;
 }
 
+/* media-queries
++---------------------------------------------------------------------------- */
+
+@media screen and (max-width: 768px) {
+  #load-controls form {
+    float: none;
+  }
+  
+  #url-load-form {
+    margin-bottom: 5px; 
+  }
+}
+
 
 /* main menu
 ---------------------------------------------------------------------------- */
@@ -215,7 +228,7 @@ a {
 
 /* main menu select menu 
 ---------------------------------------------------------------------------- */
-  #manifest-select-menu, #workspace-select-menu, #workspaceContainer {
+#workspace-select-menu, #workspaceContainer {
     position: absolute;
     height: 100%;
     width: 100%;
@@ -223,6 +236,20 @@ a {
     display: none;
     overflow: hidden;
     z-index: 5;
+}
+#manifest-select-menu {
+  position: absolute;
+  margin: 6px;
+  display: block;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  display: none;
+  overflow: hidden;
+  z-index: 101;
+  background-color: #fff;
+  box-shadow: 0 0 6px #333;
 }
 #bookmark-panel {
   position: absolute;
@@ -234,6 +261,7 @@ a {
   z-index: 5;
   right: 0;
   top: 0;
+  padding: 10px;
 }
 #bookmark-panel span {
   width: 100%;
@@ -250,7 +278,7 @@ a {
   position: relative;
   width: 100%;
   height:100%;
-  padding-left: 30px;
+  padding: 10px;
   box-sizing: border-box;
   overflow: hidden;
   margin:0 auto;
@@ -258,18 +286,21 @@ a {
 .items-listing {
   margin: 0;
   padding-left: 0;
-  padding-bottom: 30px;
   box-sizing: border-box;
 }
 .items-listing li {
   list-style-type: none;
   overflow: hidden;
-  border-bottom: 1px solid gray;
+  border-bottom: 1px solid #d3d3d3;
   padding-top: 10px;
   padding-bottom: 10px;
   position: relative;
   padding-left: 5px;
-  margin-right: 10px;
+  transition: background-color 0.3s ease-out;
+}
+.items-listing li:hover {
+  background-color: #ddd;
+  cursor: pointer;
 }
 .manifest-load-status-indicator {
   width:100%;
@@ -305,16 +336,16 @@ a {
   bottom:0;
   width:100%;
 }
-.items-listing li:hover {
-  background: #dddddd;
-  cursor: pointer;
-}
 .select-metadata {
-  width:200px;
+  width: 45%;
+  max-width: 450px;
+  min-width: 300px;
+  position: relative;
+  /*width:200px;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow:hidden;
-  position: relative;
+  position: relative;*/
 }
 .repo-image {
   position:relative;
@@ -332,15 +363,46 @@ a {
   margin: 0;
   font-weight: normal;
   color:rgba(0,0,0,0.7);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow:hidden;
 }
 .items-listing h3 {
   color:rgba(0,0,0,0.8);
-  font-weight:bold;
   margin-top:2px;
-  font-weight: bold;
+  font-size: 1em;
+}
+.manifest-title h3 {
+  line-height: 1.2em;
+  height: 3.6em;
+  position: relative;
+  overflow: hidden;
+}
+.manifest-title h3:after {
+  content: "";
+  text-align: right;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 20%;
+  height: 1.2em;
+  /*background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);*/
+}
+.item-info {
+  position: absolute;
+  bottom: 0;
+  display: table;
+  width: 100%;
+}
+.item-info-row {
+  display: table-row;
+}
+.repo-label, .canvas-count {
+  display: table-cell;
+  white-space: nowrap;
+  font-size: .85em;
+  vertical-align: bottom;
+  color: gray;
+}
+.canvas-count {
+  text-align: right;
 }
 .repo-image, .select-metadata, .preview-images {
   float:left;
@@ -358,6 +420,7 @@ a {
   margin-right:15px;
   min-height: 25px;
   min-width: 25px;
+  /*transition: all 0.1s ease-out; ?*/
 }
 
 .preview-image:hover {
@@ -386,54 +449,67 @@ li.highlight {
   padding-left: 8px !important;
   padding-right: 8px !important;
 }
-
-.remaining-items {
+.ellipsis {
+  float: left;
+  height:80px;
   opacity: 0.5;
   text-align: center;
-  position: absolute;
-  right: 0;
-  height:80px;
-  margin-right: 10px;
-}
-.remaining-items h3 {
-  margin-top: 30px;
   font-weight: bold;
+  font-size: 1.3em;
+  box-sizing: border-box;
+  padding-top: 26px;
 }
 #load-controls {
-  float: left;
-  height:100%;
-  width: 19%;
+  margin-top: 20px;
 }
-#load-controls label {
-  font-weight: bold;
+#load-controls:after {
+  content: "";
+  display: table;
+  clear: both;
 }
 #load-controls input {
   height:25px;
-  /*font-size:18px;*/
-  border:3px solid gray;
-  margin:0 auto;
-  width:100%;
+  border:1px solid #d3d3d3;
+  color: gray;
+  background:none;
+  border-radius: 2px;
+  transition: border-color 0.3s ease-out;
 }
 #manifest-select-menu .remove-object-option {
   cursor: pointer;
-  margin-top:20px;
-  display: block;
+  display: inline-block;
+  font-size: .9em;
+  font-weight: bold;
+  transition: color 0.2s ease-out;
+}
+#manifest-select-menu .remove-object-option:hover {
+  color: rgb( 146, 145, 145 );
 }
 #manifest-search-form {
-  margin-top: 30px;
+  float:left;
 }
-#manifest-search-form input {
-  background:none;
-  /*border:none;
-  border-bottom:2px solid black;*/
-  width: 100%;
+#manifest-search-form label {
+  margin-right: 6px;
+}
+#url-load-form {
+  float: right; 
+}
+#url-load-form input[type="text"] {
+  width: 250px;
+  margin: 0 5px;
+}
+#load-controls input[type="submit"]{
+  height: 29px;
 }
 #manifest-search i {
   position:absolute;
   left:0;
   color:black;
 }
-#manifest-search-form input:focus, #url-load-form input:focus {
+#manifest-search-form input:focus, #url-load-form input:focus,
+#manifest-search-form input:focus, 
+#url-load-form input:focus,
+#url-load-form input[type="submit"]:hover{
   outline:none;
   border-color:deepskyblue;
 }
@@ -445,10 +521,10 @@ li.highlight {
 }
 
 .select-results {
-  margin-left: 20%;
   height:100%;
   overflow-y: scroll;
-  padding-top: 30px;
+  margin-top: 10px;
+  border-top: 1px solid gray;
 }
 
 /* main-menu workspaces-panel */

--- a/js/src/viewer/manifestListItem.js
+++ b/js/src/viewer/manifestListItem.js
@@ -12,9 +12,8 @@
       resultsWidth:               0,  // based on screen width
       maxPreviewImagesWidth:      0,
       repoWidth:                  80,
-      metadataWidth:              200,
+      metadataWidth:              450,
       margin:                     15,
-      remainingItemsMinWidth:     80, // set a minimum width for the "more" image
       imagesTotalWidth:           0,
       tplData:                    null,
       allImages:                  []
@@ -30,15 +29,16 @@
       var _this = this;
       //need a better way of calculating this because JS can't get width and margin of hidden elements, so must manually set that info
       //ultimately use 95% of space available, since sometimes it still displays too many images
-      this.maxPreviewImagesWidth = this.resultsWidth - (this.repoWidth + this.margin + this.metadataWidth + this.margin + this.remainingItemsMinWidth);
+      //this.maxPreviewImagesWidth = this.resultsWidth - (this.repoWidth + this.margin + this.metadataWidth + this.margin + this.remainingItemsMinWidth);
+      this.maxPreviewImagesWidth = this.resultsWidth - (this.repoWidth + this.margin + this.metadataWidth + this.margin);
       this.maxPreviewImagesWidth = this.maxPreviewImagesWidth * 0.95;
 
       this.fetchTplData(this.manifestId);
       this.element = jQuery(this.template(this.tplData)).prependTo(this.parent.manifestListElement).hide().fadeIn('slow');
 
-      var remainingOffset = this.repoWidth + this.margin + this.metadataWidth + this.margin + this.imagesTotalWidth;
-      _this.noiseImage = $.viewer.buildPath + $.viewer.imagesPath + 'noise.png';
-      this.element.find('.remaining-items').css('left', remainingOffset).css('background-image','url('+_this.noiseImage+')').css('background-repeat','repeat');
+      //var remainingOffset = this.repoWidth + this.margin + this.metadataWidth + this.margin + this.imagesTotalWidth;
+      //_this.noiseImage = $.viewer.buildPath + $.viewer.imagesPath + 'noise.png';
+      //this.element.find('.remaining-items').css('left', remainingOffset).css('background-image','url('+_this.noiseImage+')').css('background-repeat','repeat');
 
       this.bindEvents();
     },
@@ -142,7 +142,8 @@
       });
 
       jQuery.subscribe('manifestPanelWidthChanged', function(event, newWidth){
-        var newMaxPreviewWidth = newWidth - (_this.repoWidth + _this.margin + _this.metadataWidth + _this.margin + _this.remainingItemsMinWidth),
+        //var newMaxPreviewWidth = newWidth - (_this.repoWidth + _this.margin + _this.metadataWidth + _this.margin + _this.remainingItemsMinWidth),
+        var newMaxPreviewWidth = newWidth - (_this.repoWidth + _this.margin + _this.metadataWidth + _this.margin),
         remainingOffset = 0,
         remaining,
         newRemaining;
@@ -165,7 +166,7 @@
             } else {
               //add the remaining element
               newRemaining = 1;
-              _this.element.find('.preview-images').after('<div class="remaining-items"><h3><span class="remaining-amount">'+newRemaining+'</span> more</h3></div>');
+              //_this.element.find('.preview-images').after('<div class="remaining-items"><h3><span class="remaining-amount">'+newRemaining+'</span> more</h3></div>');
             }
 
             //update size of "More" icon
@@ -207,7 +208,7 @@
             }
           }
         }
-        _this.maxPreviewImagesWidth = newMaxPreviewWidth;
+        //_this.maxPreviewImagesWidth = newMaxPreviewWidth;
       });
     },
 
@@ -220,26 +221,32 @@
     },
 
     template: Handlebars.compile([
-                                 '<li>',
-                                 '<div class="repo-image">',
-                                 '<img src="{{repoImage}}" alt="repoImg">',
-                                 '</div>',
-                                 '<div class="select-metadata">',
-                                 '<h3 class="manifest-title">{{label}}</h3>',
-                                 '<h4>{{canvasCount}} {{t "items"}}</h4>',
-                                 '{{#if repository}}',
-                                 '<h4 class="repository-label">{{repository}}</h4>',
-                                 '{{/if}}',
-                                 '</div>',
-                                 '<div class="preview-images">',
-                                 '{{#each images}}',
-                                 '<img src="{{url}}" width="{{width}}" height="{{height}}" class="preview-image flash" data-image-id="{{id}}">',
-                                 '{{/each}}',
-                                 '</div>',
-                                 '{{#if remaining}}',
-                                 '<div class="remaining-items"><h3><span class="remaining-amount">{{remaining}}</span> {{t "more"}}</h3></div>',
-                                 '{{/if}}',
-                                 '</li>'
+      '<li>',
+      '<div class="repo-image">',
+        '<img src="{{repoImage}}" alt="repoImg">',
+      '</div>',
+      '<div class="select-metadata">',
+        '<div class="manifest-title">',
+          '<h3>{{label}}</h3>',
+        '</div>',
+        '<div class="item-info">',
+          '<div class="item-info-row">',
+            '{{#if repository}}',
+              '<div class="repo-label">{{repository}}</div>',
+            '{{/if}}',
+            '<div class="canvas-count">{{canvasCount}} {{t "items"}}</div>',
+          '</div>',
+        '</div>',
+      '</div>',
+      '<div class="preview-images">',
+      '{{#each images}}',
+        '<img src="{{url}}" width="{{width}}" height="{{height}}" class="preview-image flash" data-image-id="{{id}}">',
+      '{{/each}}',
+      '</div>',
+      '{{#if remaining}}',
+        '<div class="ellipsis">&hellip;</div>',
+      '{{/if}}',
+      '</li>'
     ].join(''))
   };
 

--- a/js/src/viewer/manifestsPanel.js
+++ b/js/src/viewer/manifestsPanel.js
@@ -30,6 +30,9 @@
             //cloning the element and adjusting the display and visibility means it won't break the normal flow
             var clone = this.element.clone().css("visibility","hidden").css("display", "block").appendTo(this.appendTo);
             this.resultsWidth = clone.find('.select-results').outerWidth();
+            this.controlsHeight = clone.find('.manifest-panel-controls').outerHeight();
+            this.paddingListElement = this.controlsHeight;
+            this.manifestListElement.css("padding-bottom", this.paddingListElement);
             clone.remove();
             
             // this.manifestLoadStatusIndicator = new $.ManifestLoadStatusIndicator({
@@ -101,25 +104,27 @@
         template: Handlebars.compile([
           '<div id="manifest-select-menu">',
           '<div class="container">',
+            '<div class="manifest-panel-controls">',
+              '<a class="remove-object-option"><i class="fa fa-times fa-lg fa-fw"></i>{{t "close"}}</a>',
               '<div id="load-controls">',
-              '<a class="remove-object-option"><i class="fa fa-times fa-lg fa-fw"></i> {{t "close"}}</a>',
-              '<form action="" id="manifest-search-form">',
+                '{{#if showURLBox}}',
+                  '<form action="" id="url-load-form">',
+                    '<label for="url-loader">{{t "addNewObject"}}:</label>',
+                    '<input type="text" id="url-loader" name="url-load" placeholder="http://...">',
+                    '<input type="submit" value="Load">',
+                  '</form>',
+                '{{/if}}',
+                '<form action="" id="manifest-search-form">',
                   '<label for="manifest-search">{{t "filterObjects"}}:</label>',
-                  '<input id="manifest-search" type="text" name="manifest-filter" placeholder="{{t "filterObjects"}}...">',
-              '</form>',
-              '{{#if showURLBox}}',
-              '<br/>',
-              '<form action="" id="url-load-form">',
-                  '<label for="url-loader">{{t "addNewObject"}}:</label>',
-                  '<input type="text" id="url-loader" name="url-load" placeholder="http://...">',
-              '</form>',
-              '{{/if}}',
+                  '<input id="manifest-search" type="text" name="manifest-filter">',
+                '</form>',
               '</div>',
+            '</div>',
               '<div class="select-results">',
-                  '<ul class="items-listing">',
-                  '</ul>',
+                '<ul class="items-listing">',
+                '</ul>',
               '</div>',
-              '</div>',
+          '</div>',
           '</div>'
         ].join(''))
     };


### PR DESCRIPTION
This PR replaces #555, it is aligned with master branch.
It mainly includes changes in css and handlebars templates. I've removed the new light gray background from the first PR.
It remains a few tweaks and commented code in javascript that need to be reviewed or cleaned:
* [manifestListItem.js#L33](https://github.com/regisrob/mirador/blob/4e0e08aa4217ab80ac147db4f30ebb4deabc2c36/js/src/viewer/manifestListItem.js#L33)
* [manifestListItem.js#L39](https://github.com/regisrob/mirador/blob/4e0e08aa4217ab80ac147db4f30ebb4deabc2c36/js/src/viewer/manifestListItem.js#L39)
* [manifestListItem.js#L145](https://github.com/regisrob/mirador/blob/4e0e08aa4217ab80ac147db4f30ebb4deabc2c36/js/src/viewer/manifestListItem.js#L145)
* [manifestListItem.js#L169](https://github.com/regisrob/mirador/blob/4e0e08aa4217ab80ac147db4f30ebb4deabc2c36/js/src/viewer/manifestListItem.js#L169)
* [manifestListItem.js#L211](https://github.com/regisrob/mirador/blob/4e0e08aa4217ab80ac147db4f30ebb4deabc2c36/js/src/viewer/manifestListItem.js#L211)

See my comment on #555 for more details about the changes and what still needs to be done to reflect the mockups.