### PR TITLE
Failsafe to get currentConfig anyway if jsonBlob call fails

### DIFF
--- a/js/src/utils/saveController.js
+++ b/js/src/utils/saveController.js
@@ -45,7 +45,7 @@
           //get json from JSON storage and set currentConfig to it
           var params = paramURL.split('=');
           var jsonblob = params[1];
-	  this.currentConfig = this.storageModule.readSync(jsonblob);
+          this.currentConfig = this.storageModule.readSync(jsonblob) || config;
         } else {
           this.currentConfig = config;
         }


### PR DESCRIPTION
This patch will prevent currentConfig in saveController from not being initialized when jsonBlob call fails. 