### PR TITLE
Fixed annotations overlay resize not preserving annotation positions

### DIFF
--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -278,7 +278,7 @@
       var maxSize = 2048;
       var realSize = {
         width: this.viewer.viewport.containerSize.x / viewportBounds.width,
-        height: this.viewer.viewport.contentSize.y / viewportBounds.height,
+        height: this.viewer.viewport.containerSize.y / viewportBounds.height,
         offsetX: 0,
         offsetY: 0,
         scale: 1
@@ -378,7 +378,7 @@
     },
 
     // replaces paper.js objects with the required properties only.
-    // shape coordinates are viewport coordinates.
+    // 'shapes' coordinates are image coordiantes
     replaceShape: function(shape, annotation) {
       var cloned = new this.paperScope.Path({
         segments: shape.segments,
@@ -395,7 +395,6 @@
       cloned.closed = shape.closed;
       cloned.data.rotation = shape.data.rotation;
       cloned.data.annotation = annotation;
-      cloned.scale(this.viewer.viewport.containerSize.x / this.viewer.viewport.contentSize.x, new this.paperScope.Point(0, 0));
       if (cloned.name.toString().indexOf('pin_') != -1) { // pin shapes with fixed size.
         this.fitPinSize(cloned);
       }
@@ -543,9 +542,8 @@
     getName: function(tool) {
       return tool.idPrefix + $.genUUID();
     },
-
+    
     getSVGString: function(shapes) {
-      var scale = this.viewer.viewport.contentSize.x / this.viewer.viewport.containerSize.x;
       var svg = "<svg xmlns='http://www.w3.org/2000/svg'>";
       if (shapes.length > 1) {
         svg += "<g>";
@@ -555,11 +553,9 @@
           }
           var anno = shapes[i].data.annotation;
           shapes[i].data.annotation = null;
-          shapes[i].scale(scale, new this.paperScope.Point(0, 0));
           svg += shapes[i].exportSVG({
             "asString": true
           });
-          shapes[i].scale(1 / scale, new this.paperScope.Point(0, 0));
           shapes[i].data.annotation = anno;
         }
         svg += "</g>";
@@ -569,11 +565,9 @@
         }
         var annoSingle = shapes[0].data.annotation;
         shapes[0].data.annotation = null;
-        shapes[0].scale(scale, new this.paperScope.Point(0, 0));
         svg += shapes[0].exportSVG({
           "asString": true
         });
-        shapes[0].scale(1 / scale, new this.paperScope.Point(0, 0));
         shapes[0].data.annotation = annoSingle;
       }
       svg += "</svg>";


### PR DESCRIPTION
Added resize events handling to sync Paper.js zooming and centering with OpenSeadragon. This fixes incorrect positioning of annotation shapes when defining or displaying them and resizing your browser.

Now we also can confirm that annotations shapes are defined against original image dimensions.