### PR TITLE
Added ability to provide manifest as json content instead of URI

### DIFF
--- a/js/src/manifests/manifest.js
+++ b/js/src/manifests/manifest.js
@@ -1,7 +1,15 @@
 (function($){
 
-  $.Manifest = function(manifestUri, location) {
-    if (manifestUri.indexOf('info.json') !== -1) {
+  $.Manifest = function(manifestUri, location, manifestContent) {
+    if (manifestContent) {
+      jQuery.extend(true, this, {
+          jsonLd: null,
+          location: location,
+          uri: manifestUri,
+          request: null
+      });
+      this.initFromManifestContent(manifestContent);
+    } else if (manifestUri.indexOf('info.json') !== -1) {
       // The following is an ugly hack. We need to finish the
       // Manifesto utility library.
       // See: https://github.com/IIIF/manifesto
@@ -63,6 +71,14 @@
       this.request.done(function(jsonLd) {
         _this.jsonLd = _this.generateInfoWrapper(jsonLd);
       });
+    },
+    initFromManifestContent: function (manifestContent) {
+      var _this = this;
+      this.request = jQuery.Deferred();
+      this.request.done(function(jsonLd) {
+        _this.jsonLd = jsonLd;
+      });
+      setTimeout(function () { _this.request.resolve(manifestContent); }, 0);
     },
     getThumbnailForCanvas : function(canvas, width) {
       var version = "1.1",


### PR DESCRIPTION
Supersedes #780 

If user prepares manifest json object on the client side, he now can pass manifest to Mirador directly, rather than providing URL to download manifest from back end.

Like, having ready manifest in `manifest`, and it's URI in manifestURI you could initialize Mirador the following way:

```
Mirador({
          "id": "mirador", // The CSS ID selector for the containing element.
          "layout": "1x1", // The number and arrangement of windows ("row"x"column")?
          "saveSession": false,
          "data": [
            {"manifestUri": manifestURI, "location": "British Museum", "manifestContent": manifest}
          ],....
});
```

Right now it's only one-time initialization of Mirador, no way of dynamically alter running instance, e. g. providing new manifest do display.