### PR TITLE
Change multi-lingual thumbnail label display to sensible defaults

### DIFF
--- a/js/src/utils/jsonLd.js
+++ b/js/src/utils/jsonLd.js
@@ -1,0 +1,22 @@
+(function($) {
+  
+  $.JsonLd = {
+    getTextValue: function(propertyValue, language) {
+      if (typeof language === 'undefined') { language = "en"; }
+      if (typeof propertyValue === 'string') { return propertyValue; }
+      else if (Array.isArray(propertyValue)) {
+        var text;
+        jQuery.each(propertyValue, function(i3, what) {
+          // {@value: ..., @language: ...}
+          if (!text || what['@language'] === language) {
+            text = what['@value'];
+          }
+        });
+        return text;
+      } else {
+        return propertyValue['@value'];
+      }
+    }
+  };
+  
+}(Mirador));

--- a/js/src/widgets/metadataView.js
+++ b/js/src/widgets/metadataView.js
@@ -127,8 +127,8 @@
   getMetadataDetails: function(jsonLd) {
       // TODO: This should not default to English
       var mdList = {
-          'label':        '<b>' + jsonLd.label + '</b>' || '',
-          'description':  jsonLd.description || ''
+        'label': '<b>' + ($.JsonLd.getTextValue(jsonLd.label) || '') + '</b>',
+        'description':  jsonLd.description || ''
       };
       var value = "";
       var label = "";
@@ -141,7 +141,7 @@
             // {@value: ..., @language: ...}
             if (item['@language'] == "en") {
               value += item['@value'];
-              value += "<br/>";                  
+              value += "<br/>";
             }
           }
         });        
@@ -152,27 +152,9 @@
         value = "";
         label = "";
         jQuery.each(jsonLd.metadata, function(index, item) {
-          if (typeof item.label === "string") {
-            label = item.label;
-          } else {
-            jQuery.each(item.label, function(i2, what) {
-              // {@value: ..., @language: ...}
-              if (what['@language'] === "en") {
-                label = what['@value'];
-              }
-            });
-          }
-          if (typeof item.value === "string") {
-            value = item.value;
-          } else {
-            jQuery.each(item.value, function(i3, what) {
-              // {@value: ..., @language: ...}
-              if (what['@language'] === "en") {
-                value = what['@value'];
-              }
-            });
-          } 
-        mdList[label] = value;
+          label = $.JsonLd.getTextValue(item.label);
+          value = $.JsonLd.getTextValue(item.value);
+          mdList[label] = value;
         });
       }
  

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -136,7 +136,7 @@
       jQuery.each(this.focuses, function(index, value) {
         templateData[value] = true;
       });
-      templateData.title = manifest.label;
+      templateData.title = $.JsonLd.getTextValue(manifest.label);
       templateData.displayLayout = this.displayLayout;
       templateData.layoutOptions = this.layoutOptions;
       // if displayLayout is true,  but all individual options are set to false, set displayLayout to false


### PR DESCRIPTION
(this is repost of #806, rebased to master)

As mentioned in #653 [Object object] is displayed where thumbnail label should be when labels are multi-lingual.

As discussion and ongoing work progresses in original issue, this is intermediate result addresses two things:

1) JsonLd.getTextValue(property, language) is introduced to fetch text from a property. Defaults to English. If label in specified language is not found, function tries to get label in any language (non-deterministic).
2) Two calls to this function are introduced in metadataView and window to uniformly cope with multilingual label.

We laid foundations to solving the original issue, further work will be introducing language selector and propagating language property to JsonLd.getTextValue call, but we will not be able to implement that in near future.

Also may have influence on fixing #798.