### PR TITLE
Make annotation body editor pluggable, existing TinyMCE being default choice

### DIFF
--- a/js/src/annotations/annotationTooltip.js
+++ b/js/src/annotations/annotationTooltip.js
@@ -3,9 +3,10 @@
   $.AnnotationTooltip = function(options) {
 
     jQuery.extend(this, {
-      element:   null,
+      targetElement: null,
       annotations: [],
-      windowId:  ""
+      parent: null,
+      windowId: "",
     }, options);
 
     this.init();
@@ -14,45 +15,293 @@
   $.AnnotationTooltip.prototype = {
 
     init: function() {
-      this.bindEvents();
+      this.editor = $[$.saveController.currentConfig.annotationBodyEditor.module];
+      this.editorOptions = $.saveController.currentConfig.annotationBodyEditor.options;
+
+      this.activeEditor = null;
+      this.activeEditorTip = null;
+      this.inEditOrCreateMode = false;
     },
 
-    bindEvents: function() {
+    /**
+     * @param params: {
+     *   annotation: any -- annotation JSON
+     *   onAnnotationCreated: (annotation) => void
+     *   onCompleted: () => void
+     *   onCancel: () => void
+     * }
+     */
+    showEditor: function(params) {
       var _this = this;
-    },
-    
-    getEditor: function(annotation) {
-      var annoText = "",
-      tags = [],
-      _this = this;
+      if (_this.activeEditor) { return; }
 
-      if (!jQuery.isEmptyObject(annotation)) {
-        if (jQuery.isArray(annotation.resource)) {
-          jQuery.each(annotation.resource, function(index, value) {
-            if (value['@type'] === "oa:Tag") {
-              tags.push(value.chars);
-            } else {
-              annoText = value.chars;
-            }
-          });
-        } else {
-          annoText = annotation.resource.chars;
-        }
-      }
-
-      return this.editorTemplate({content : annoText,
-        tags : tags.join(" "),
-        id : jQuery.isEmptyObject(annotation) ? "" : annotation['@id'],
+      var editorContainer = _this.editorTemplate({
+        id : jQuery.isEmptyObject(params.annotation) ? "" : params.annotation['@id'],
         windowId : _this.windowId
+      });
+      var selector = '#annotation-editor-' + _this.windowId;
+
+      _this.activeEditor = new _this.editor(
+        jQuery.extend({}, _this.editorOptions, {
+          annotation: params.annotation,
+          windowId: _this.windowId
+        }));
+      _this.activeEditorTip = _this.targetElement.qtip({
+        content: {
+          text: editorContainer
+        },
+        position: {
+          my: 'center',
+          at: 'center'
+        },
+        style: {
+          classes: 'qtip-bootstrap qtip' + _this.windowId
+        },
+        show: {
+          event: false
+        },
+        hide: {
+          fixed: true,
+          delay: 300,
+          event: false
+        },
+        events: {
+          render: function(event, api) {
+            jQuery.publish('annotationEditorAvailable.' + _this.windowId);
+            jQuery.publish('disableTooltips.' + _this.windowId);
+
+            jQuery(selector).parent().parent().draggable();
+
+            jQuery(selector).on("submit", function(event) {
+              event.preventDefault();
+              jQuery(selector + ' a.save').click();
+            });
+
+            jQuery(selector + ' a.cancel').on("click", function(event) {
+              event.preventDefault();
+              if (_this.activeEditor.isDirty()) {
+                if (!window.confirm("Do you want to cancel this annotation?")) {
+                  return false;
+                }
+              }
+              api.destroy();
+              if (params.onCancel) { params.onCancel(); }
+            });
+
+            jQuery(selector + ' a.save').on("click", function(event) {
+              event.preventDefault();
+
+              var annotation = _this.activeEditor.createAnnotation();
+              if (params.onAnnotationCreated) { params.onAnnotationCreated(annotation); }
+
+              api.destroy();
+              //reenable viewer tooltips
+              jQuery.publish('enableTooltips.' + _this.windowId);
+              _this.activeEditor = null;
+              _this.activeEditorTip = null;
+
+              if (params.onCompleted) { params.onCompleted(); }
+            });
+
+            _this.activeEditor.show(selector);
+          }
+        }
+      });
+      _this.activeEditorTip.qtip('show');
+    },
+
+    /**
+     * @param params: {
+     *   container: HTMLElement
+     *   viewport: HTMLElement
+     *   getAnnoFromRegion: (regionId: string) => any[]
+     *   onTooltipShown: (event: QTipShowEvent, api: QTipAPI) => void
+     *   onTooltipHidden: (event: QTipShowEvent, api: QTipAPI) => void
+     *   onEnterEditMode: (api: QTipAPI, oaAnno: any) => void
+     *   onExitEditMode: (api: QTipAPI, oaAnno: any) => void
+     *   onAnnotationSaved: (annotation) => void
+     * }
+     */
+    initializeViewerUpgradableToEditor: function(params) {
+      var _this = this;
+      _this.activeEditorTip = jQuery(_this.targetElement).qtip({
+        overwrite: false,
+        content: {
+          text: ''
+        },
+        position: {
+          target: 'mouse',
+          my: 'bottom left',
+          at: 'top right',
+          adjust: {
+            mouse: false,
+            method: 'shift'
+          },
+          container: params.container,
+          viewport: params.viewport
+        },
+        style: {
+          classes: 'qtip-bootstrap qtip-viewer',
+          tip: false
+        },
+        show: {
+          event: false
+        },
+        hide: {
+          fixed: true,
+          delay: 300,
+          event: false
+        },
+        events: {
+          show: function(event, api) {
+            if (params.onTooltipShown) { params.onTooltipShown(event, api); }
+          },
+          hidden: function(event, api) {
+            if (params.onTooltipHidden) { params.onTooltipHidden(event, api); }
+          },
+          visible: function(event, api) {
+            _this.removeAllEvents(api, params);
+            _this.addViewerEvents(api, params);
+          },
+          move: function(event, api) {
+            _this.removeAllEvents(api, params);
+            _this.addViewerEvents(api, params);
+            _this.addEditorEvents(api, params);
+          }
+        }
+      });
+      var api = jQuery(_this.targetElement).qtip('api');
+      api.cache.annotations = [];
+      api.cache.hidden = true;
+    },
+
+    removeAllEvents: function(api, viewerParams) {
+      var _this = this;
+      var editorSelector = '#annotation-editor-' + _this.windowId;
+      var viewerSelector = '#annotation-viewer-' + _this.windowId;
+      jQuery(viewerSelector + ' a.delete').off("click");
+      jQuery(viewerSelector + ' a.edit').off("click");
+      jQuery(editorSelector + ' a.save').off("click");
+      jQuery(editorSelector + ' a.cancel').off("click");
+    },
+
+    addViewerEvents: function(api, viewerParams) {
+      var _this = this;
+      var selector = '#annotation-viewer-' + _this.windowId;
+
+      jQuery(selector + ' a.delete').on("click", function(event) {
+        event.preventDefault();
+        if (!window.confirm("Do you want to delete this annotation?")) {
+          return false;
+        }
+        var display = jQuery(this).parents('.annotation-display');
+        var id = display.attr('data-anno-id');
+        jQuery.publish('annotationDeleted.' + _this.windowId, [id]);
+        api.hide();
+        display.remove();
+      });
+
+      jQuery(selector + ' a.edit').on("click", function(event) {
+        event.preventDefault();
+        var display = jQuery(this).parents('.annotation-display');
+        var id = display.attr('data-anno-id');
+        var oaAnno = viewerParams.getAnnoFromRegion(id)[0];
+        _this.freezeQtip(api, oaAnno, viewerParams);
+        _this.removeAllEvents(api, viewerParams);
+        _this.addEditorEvents(api, viewerParams);
       });
     },
 
-    getViewer: function(annotations) {
+    addEditorEvents: function(api, viewerParams) {
+      var _this = this;
+      var selector = '#annotation-editor-' + _this.windowId;
+
+      jQuery(selector).on("submit", function(event) {
+        event.preventDefault();
+        jQuery(selector + ' a.save').click();
+      });
+
+      jQuery(selector + ' a.save').on("click", function(event) {
+        event.preventDefault();
+        var display = jQuery(this).parents('.annotation-editor');
+        var id = display.attr('data-anno-id');
+        var oaAnno = viewerParams.getAnnoFromRegion(id)[0];
+        _this.activeEditor.updateAnnotation(oaAnno);
+        viewerParams.onAnnotationSaved(oaAnno);
+        _this.unFreezeQtip(api, oaAnno, viewerParams);
+      });
+
+      jQuery(selector + ' a.cancel').on("click", function(event) {
+        event.preventDefault();
+        var display = jQuery(this).parents('.annotation-editor');
+        var id = display.attr('data-anno-id');
+        var oaAnno = viewerParams.getAnnoFromRegion(id)[0];
+        _this.unFreezeQtip(api, oaAnno, viewerParams);
+      });
+    },
+
+    /**
+     * Shows annotation tooltip initialized with
+     * <code>initializeViewerUpgradableToEditor()</code>
+     *
+     * @param params: {
+     *   annotations: any[]
+     *   triggerEvent: MouseEvent
+     *   shouldDisplayTooltip: (api: QTipAPI) => boolean
+     * }
+     */
+    showViewer: function(params) {
+      var _this = this;
+      var api = jQuery(_this.targetElement).qtip('api');
+      if (!api) { return; }
+      if (params.shouldDisplayTooltip && !params.shouldDisplayTooltip(api)) {
+        return;
+      }
+      if (params.annotations.length === 0) {
+        if (!api.cache.hidden) {
+          api.disable(false);
+          api.hide(params.triggerEvent);
+          api.cache.annotations = [];
+          api.cache.hidden = true;
+          api.disable(true);
+        }
+      } else {
+        var oldAnnotations = api.cache.annotations;
+        var isTheSame = oldAnnotations.length == params.annotations.length;
+        if (isTheSame) {
+          for (var i = 0; i < params.annotations.length; i++) {
+            if (oldAnnotations[i] != params.annotations[i]) {
+              isTheSame = false;
+              break;
+            }
+          }
+        }
+        if (api.cache.hidden || !isTheSame) {
+          api.disable(false);
+          _this.setTooltipContent(params.annotations);
+          api.cache.origin = params.triggerEvent;
+          api.reposition(params.triggerEvent, true);
+          api.show(params.triggerEvent);
+          api.cache.annotations = params.annotations;
+          api.cache.hidden = false;
+          api.disable(true);
+        }
+      }
+    },
+
+    setTooltipContent: function(annotations) {
+      var api = jQuery(this.targetElement).qtip('api');
+      if (api) {
+        api.set({'content.text': this.getViewerContent(annotations)});
+        jQuery.publish('tooltipViewerSet.' + this.windowId);
+      }
+    },
+
+    getViewerContent: function(annotations) {
       var annoText,
-      tags = [],
-      _this = this,
-      htmlAnnotations = [],
-      id;
+        tags = [],
+        htmlAnnotations = [],
+        id;
 
       jQuery.each(annotations, function(index, annotation) {
         tags = [];
@@ -91,47 +340,87 @@
         });
       });
 
-      var template = this.viewerTemplate({annotations : htmlAnnotations,
-        windowId : _this.windowId});
+      var template = this.viewerTemplate({
+        annotations : htmlAnnotations,
+        windowId : this.windowId
+      });
       return template;
       //return combination of all of them
     },
 
+    freezeQtip: function(api, oaAnno, viewerParams) {
+      if (this.inEditOrCreateMode) { throw 'AnnotationTooltip already in edit mode'; }
+      this.inEditOrCreateMode = true;
+      jQuery.publish('disableRectTool.' + this.windowId);
+      var editorContainer = this.editorTemplate({
+        id: jQuery.isEmptyObject(oaAnno) ? "" : oaAnno['@id'],
+        windowId: this.windowId
+      });
+      api.set({
+        'content.text': editorContainer,
+        'hide.event': false
+      });
+      jQuery.publish('annotationEditorAvailable.' + this.windowId);
+      //add rich text editor
+      this.activeEditor = new this.editor(
+        jQuery.extend({}, this.editorOptions, {
+          annotation: oaAnno,
+          windowId: this.windowId
+        }));
+      this.activeEditor.show('form.annotation-tooltip');
+      jQuery(api.elements.tooltip).removeClass("qtip-viewer");
+      if (viewerParams.onEnterEditMode) {
+        viewerParams.onEnterEditMode(api, oaAnno);
+      }
+    },
+
+    unFreezeQtip: function(api, oaAnno, viewerParams) {
+      if (!this.inEditOrCreateMode) { throw 'AnnotationTooltip not in edit mode'; }
+      this.inEditOrCreateMode = false;
+      jQuery.publish('enableRectTool.' + this.windowId);
+      api.set({
+        'content.text': this.getViewerContent([oaAnno]),
+        'hide.event': 'mouseleave'
+      }).hide();
+      jQuery(api.elements.tooltip).addClass("qtip-viewer");
+      if (viewerParams.onExitEditMode) {
+        viewerParams.onExitEditMode(api, oaAnno);
+      }
+    },
+
     //when this is being used to edit an existing annotation, insert them into the inputs
     editorTemplate: Handlebars.compile([
-                                       '<form id="annotation-editor-{{windowId}}" class="annotation-editor annotation-tooltip" {{#if id}}data-anno-id="{{id}}"{{/if}}>',
-                                       '<textarea class="text-editor" placeholder="{{t "comments"}}…">{{#if content}}{{content}}{{/if}}</textarea>',
-                                       '<input id="tags-editor-{{windowId}}" class="tags-editor" placeholder="{{t "addTagsHere"}}…" {{#if tags}}value="{{tags}}"{{/if}}>',
-                                       '<div>',
-                                       // need to add a delete, if permissions allow
-                                       '<div class="button-container">',
-                                       '<a href="#cancel" class="cancel"><i class="fa fa-times-circle-o fa-fw"></i>{{t "cancel"}}</a>',
-                                       '<a href="#save" class="save"><i class="fa fa-database fa-fw"></i>{{t "save"}}</a>',
-                                       '</div>',
-                                       '</div>',
-                                       '</form>'
+      '<form id="annotation-editor-{{windowId}}" class="annotation-editor annotation-tooltip" {{#if id}}data-anno-id="{{id}}"{{/if}}>',
+      '<div>',
+      // need to add a delete, if permissions allow
+      '<div class="button-container">',
+      '<a href="#cancel" class="cancel"><i class="fa fa-times-circle-o fa-fw"></i>{{t "cancel"}}</a>',
+      '<a href="#save" class="save"><i class="fa fa-database fa-fw"></i>{{t "save"}}</a>',
+      '</div>',
+      '</div>',
+      '</form>'
     ].join('')),
 
     viewerTemplate: Handlebars.compile([
-                                       '<div class="all-annotations" id="annotation-viewer-{{windowId}}">',
-                                       '{{#each annotations}}',
-                                       '<div class="annotation-display annotation-tooltip" data-anno-id="{{id}}">',
-                                       '<div class="button-container">',
-                                         '{{#if showUpdate}}<a href="#edit" class="edit"><i class="fa fa-pencil-square-o fa-fw"></i>{{t "edit"}}</a>{{/if}}',
-                                         '{{#if showDelete}}<a href="#delete" class="delete"><i class="fa fa-trash-o fa-fw"></i>{{t "delete"}}</a>{{/if}}',
-                                       '</div>',
-                                       '<div class="text-viewer">',
-                                       '{{#if username}}<p class="user">{{username}}:</p>{{/if}}',
-                                       '<p>{{{annoText}}}</p>',
-                                       '</div>',
-                                       '<div id="tags-viewer-{{windowId}}" class="tags-viewer">',
-                                       '{{#each tags}}',
-                                       '<span class="tag">{{this}}</span>',
-                                       '{{/each}}',
-                                       '</div>',
-                                       '</div>',
-                                       '{{/each}}',
-                                       '</div>'                      
+      '<div class="all-annotations" id="annotation-viewer-{{windowId}}">',
+      '{{#each annotations}}',
+      '<div class="annotation-display annotation-tooltip" data-anno-id="{{id}}">',
+      '<div class="button-container">',
+        '{{#if showUpdate}}<a href="#edit" class="edit"><i class="fa fa-pencil-square-o fa-fw"></i>{{t "edit"}}</a>{{/if}}',
+        '{{#if showDelete}}<a href="#delete" class="delete"><i class="fa fa-trash-o fa-fw"></i>{{t "delete"}}</a>{{/if}}',
+      '</div>',
+      '<div class="text-viewer">',
+      '{{#if username}}<p class="user">{{username}}:</p>{{/if}}',
+      '<p>{{{annoText}}}</p>',
+      '</div>',
+      '<div id="tags-viewer-{{windowId}}" class="tags-viewer">',
+      '{{#each tags}}',
+      '<span class="tag">{{this}}</span>',
+      '{{/each}}',
+      '</div>',
+      '</div>',
+      '{{/each}}',
+      '</div>'
     ].join(''))
   };
 

--- a/js/src/annotations/annotationTooltip.js
+++ b/js/src/annotations/annotationTooltip.js
@@ -5,7 +5,6 @@
     jQuery.extend(this, {
       targetElement: null,
       annotations: [],
-      parent: null,
       windowId: "",
     }, options);
 
@@ -15,8 +14,8 @@
   $.AnnotationTooltip.prototype = {
 
     init: function() {
-      this.editor = $[$.saveController.currentConfig.annotationBodyEditor.module];
-      this.editorOptions = $.saveController.currentConfig.annotationBodyEditor.options;
+      this.editor = $[this.state.currentConfig.annotationBodyEditor.module];
+      this.editorOptions = this.state.currentConfig.annotationBodyEditor.options;
 
       this.activeEditor = null;
       this.activeEditorTip = null;

--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -5,8 +5,7 @@
       parent: null,
       osd: null,
       list: null,
-      annotationsToShapesMap: {},
-      inEditOrCreateMode: false
+      annotationsToShapesMap: {}
     }, options);
 
     this.init();
@@ -98,6 +97,7 @@
                     }
                   };
                 }
+
                 oaAnnos[oaAnnos.length - 1].on.selector.value = _this.svgOverlay.getSVGString(shapeArray);
                 annotationShapesAreEdited = true;
                 break;
@@ -146,58 +146,21 @@
       });
 
       var windowElement = _this.state.getWindowElement(_this.windowId);
-
-      this.tooltips = jQuery(this.osdViewer.element).qtip({
-        overwrite: false,
-        content: {
-          text: ''
-        },
-        position: {
-          target: 'mouse',
-          my: 'bottom left',
-          at: 'top right',
-          adjust: {
-            mouse: false,
-            method: 'shift'
-          },
-          container: windowElement,
-          viewport: windowElement
-        },
-        style: {
-          classes: 'qtip-bootstrap qtip-viewer',
-          tip: false
-        },
-        show: {
-          event: false
-        },
-        hide: {
-          fixed: true,
-          delay: 300,
-          event: false
-        },
-        events: {
-          visible: function(event, api) {
-            _this.removeAnnotationEvents(event, api);
-            _this.annotationEvents(event, api);
-          },
-          move: function(event, api) {
-            _this.removeAnnotationEvents(event, api);
-            _this.annotationEvents(event, api);
-            _this.annotationSaveEvent(event, api);
-          }
+      this.annoTooltip = new $.AnnotationTooltip({
+        targetElement: jQuery(this.osdViewer.element),
+        parent: _this,
+        windowId: _this.parent.windowId
+      });
+      this.annoTooltip.initializeViewerUpgradableToEditor({
+        container: windowElement,
+        viewport: windowElement,
+        getAnnoFromRegion: _this.getAnnoFromRegion.bind(this),
+        onAnnotationSaved: function(oaAnno) {
+          //save to endpoint
+          jQuery.publish('annotationUpdated.' + _this.windowId, [oaAnno]);
         }
       });
-      var api = jQuery(this.osdViewer.element).qtip('api');
-      api.cache.annotations = [];
-      api.cache.hidden = true;
       this.svgOverlay.paperScope.view.draw();
-    },
-
-    setTooltipContent: function(api, annotations) {
-      var _this = this;
-      var annoTooltip = new $.AnnotationTooltip({"windowId": _this.windowId});
-      api.set({'content.text': annoTooltip.getViewer(annotations)});
-      jQuery.publish('tooltipViewerSet.' + _this.windowId);
     },
 
     showTooltipsFromMousePosition: function(event, location, absoluteLocation) {
@@ -219,56 +182,28 @@
           }
         }
       }
-      var api = jQuery(this.osdViewer.element).qtip('api');
-      if (api) {
-        //track whether the cursor is within the tooltip (with the specified tolerance) and disables show/hide/update functionality.
-        if (api.elements.tooltip) {
-          var cursorWithinTooltip = true;
-          var leftSide = api.elements.tooltip.offset().left - _this.svgOverlay.hitOptions.tolerance;
-          var rightSide = api.elements.tooltip.offset().left + api.elements.tooltip.width() + _this.svgOverlay.hitOptions.tolerance;
-          if (absoluteLocation.x < leftSide || rightSide < absoluteLocation.x) {
-            cursorWithinTooltip = false;
-          }
-          var topSide = api.elements.tooltip.offset().top - _this.svgOverlay.hitOptions.tolerance;
-          var bottomSide = api.elements.tooltip.offset().top + api.elements.tooltip.height() + _this.svgOverlay.hitOptions.tolerance;
-          if (absoluteLocation.y < topSide || bottomSide < absoluteLocation.y) {
-            cursorWithinTooltip = false;
-          }
-          if (cursorWithinTooltip) {
-            return;
-          }
-        }
-        if (annotations.length === 0) {
-          if (!api.cache.hidden) {
-            api.disable(false);
-            api.hide(event);
-            api.cache.annotations = [];
-            api.cache.hidden = true;
-            api.disable(true);
-          }
-        } else {
-          var oldAnnotations = api.cache.annotations;
-          var isTheSame = oldAnnotations.length == annotations.length;
-          if (isTheSame) {
-            for (var i = 0; i < annotations.length; i++) {
-              if (oldAnnotations[i] != annotations[i]) {
-                isTheSame = false;
-                break;
-              }
+      _this.annoTooltip.showViewer({
+        annotations: annotations,
+        triggerEvent: event,
+        shouldDisplayTooltip: function(api) {
+          //track whether the cursor is within the tooltip (with the specified tolerance) and disables show/hide/update functionality.
+          if (api.elements.tooltip) {
+            var cursorWithinTooltip = true;
+            var leftSide = api.elements.tooltip.offset().left - _this.svgOverlay.hitOptions.tolerance;
+            var rightSide = api.elements.tooltip.offset().left + api.elements.tooltip.width() + _this.svgOverlay.hitOptions.tolerance;
+            if (absoluteLocation.x < leftSide || rightSide < absoluteLocation.x) {
+              cursorWithinTooltip = false;
             }
+            var topSide = api.elements.tooltip.offset().top - _this.svgOverlay.hitOptions.tolerance;
+            var bottomSide = api.elements.tooltip.offset().top + api.elements.tooltip.height() + _this.svgOverlay.hitOptions.tolerance;
+            if (absoluteLocation.y < topSide || bottomSide < absoluteLocation.y) {
+              cursorWithinTooltip = false;
+            }
+            return !cursorWithinTooltip;
           }
-          if (api.cache.hidden || !isTheSame) {
-            api.disable(false);
-            this.setTooltipContent(api, annotations);
-            api.cache.origin = event;
-            api.reposition(event, true);
-            api.show(event);
-            api.cache.annotations = annotations;
-            api.cache.hidden = false;
-            api.disable(true);
-          }
+          return true;
         }
-      }
+      });
     },
 
     bindEvents: function() {
@@ -288,7 +223,7 @@
       });
 
       jQuery.subscribe('updateTooltips.' + _this.windowId, function(event, location, absoluteLocation) {
-        if (!_this.inEditOrCreateMode) {
+        if (_this.annoTooltip && !_this.annoTooltip.inEditOrCreateMode) {
           _this.showTooltipsFromMousePosition(event, location, absoluteLocation);
         }
       });
@@ -298,11 +233,15 @@
       });
 
       jQuery.subscribe('disableTooltips.' + _this.windowId, function() {
-        _this.inEditOrCreateMode = true;
+        if (_this.annoTooltip) {
+          _this.annoTooltip.inEditOrCreateMode = true;
+        }
       });
 
       jQuery.subscribe('enableTooltips.' + _this.windowId, function() {
-        _this.inEditOrCreateMode = false;
+        if (_this.annoTooltip) {
+          _this.annoTooltip.inEditOrCreateMode = false;
+        }
         _this.svgOverlay.restoreDraftShapes();
       });
     },
@@ -310,149 +249,6 @@
     getAnnoFromRegion: function(regionId) {
       return this.list.filter(function(annotation) {
         return annotation['@id'] === regionId;
-      });
-    },
-
-    freezeQtip: function(api, oaAnno, annoTooltip) {
-      this.inEditOrCreateMode = true;
-      api.set({
-        'content.text': annoTooltip.getEditor(oaAnno),
-        'hide.event': false
-      });
-      jQuery.publish('annotationEditorAvailable.' + this.windowId);
-      //add rich text editor
-      tinymce.init({
-        selector: 'form.annotation-tooltip textarea',
-        plugins: "image link media",
-        menubar: false,
-        statusbar: false,
-        toolbar_items_size: 'small',
-        toolbar: "bold italic | bullist numlist | link image media | removeformat",
-        setup: function(editor) {
-          editor.on('init', function(args) {
-            tinymce.execCommand('mceFocus', false, args.target.id);
-          });
-        }
-      });
-      jQuery(api.elements.tooltip).removeClass("qtip-viewer");
-    },
-
-    unFreezeQtip: function(api, oaAnno, annoTooltip) {
-      this.inEditOrCreateMode = false;
-      api.set({
-        'content.text': annoTooltip.getViewer([oaAnno]),
-        'hide.event': 'mouseleave'
-      }).hide();
-      jQuery(api.elements.tooltip).addClass("qtip-viewer");
-    },
-
-    removeAnnotationEvents: function(tooltipevent, api) {
-      var _this = this;
-      var editorSelector = '#annotation-editor-' + _this.windowId;
-      var viewerSelector = '#annotation-viewer-' + _this.windowId;
-      jQuery(viewerSelector + ' a.delete').off("click");
-      jQuery(viewerSelector + ' a.edit').off("click");
-      jQuery(editorSelector + ' a.save').off("click");
-      jQuery(editorSelector + ' a.cancel').off("click");
-    },
-
-    annotationEvents: function(tooltipevent, api) {
-      var _this = this;
-      var annoTooltip = new $.AnnotationTooltip({"windowId": _this.windowId});
-      var selector = '#annotation-viewer-' + _this.windowId;
-      jQuery(selector + ' a.delete').on("click", function(event) {
-        event.preventDefault();
-        if (!window.confirm("Do you want to delete this annotation?")) {
-          return false;
-        }
-        var display = jQuery(this).parents('.annotation-display');
-        var id = display.attr('data-anno-id');
-        jQuery.publish('annotationDeleted.' + _this.windowId, [id]);
-        api.hide();
-        display.remove();
-      });
-
-      jQuery(selector + ' a.edit').on("click", function(event) {
-        event.preventDefault();
-        var display = jQuery(this).parents('.annotation-display');
-        var id = display.attr('data-anno-id');
-        var oaAnno = _this.getAnnoFromRegion(id)[0];
-        _this.freezeQtip(api, oaAnno, annoTooltip);
-        _this.annotationSaveEvent(event, api);
-      });
-    },
-
-    annotationSaveEvent: function(event, api) {
-      var _this = this;
-      var annoTooltip = new $.AnnotationTooltip({"windowId": _this.windowId});
-      var selector = '#annotation-editor-' + _this.windowId;
-
-      jQuery(selector).on("submit", function(event) {
-        event.preventDefault();
-        jQuery(selector + ' a.save').click();
-      });
-
-      jQuery(selector + ' a.save').on("click", function(event) {
-        event.preventDefault();
-        var display = jQuery(this).parents('.annotation-editor');
-        var id = display.attr('data-anno-id');
-        var oaAnno = _this.getAnnoFromRegion(id)[0];
-
-        var tagText = jQuery(this).parents('.annotation-editor').find('.tags-editor').val(),
-          resourceText = tinymce.activeEditor.getContent(),
-          tags = [];
-        tagText = $.trimString(tagText);
-        if (tagText) {
-          tags = tagText.split(/\s+/);
-        }
-
-        var bounds = _this.svgOverlay.viewer.viewport.getBounds(true);
-        // var scope = _this.svgOverlay.viewer.viewport.viewportToImageRectangle(bounds);
-
-        // if (!oaAnno.on.scope) {
-        //   oaAnno.on.scope = {
-        //     "@context": "http://www.harvard.edu/catch/oa.json",
-        //     "@type": "catch:Viewport"
-        //   };
-        // }
-        // oaAnno.on.scope.value = "xywh=" + Math.round(scope.x) + "," + Math.round(scope.y) + "," + Math.round(scope.width) + "," + Math.round(scope.height); //osd bounds
-        // oaAnno.on.selector.value remains the same
-
-        var motivation = [],
-          resource = [];
-
-        //remove all tag-related content in annotation
-        oaAnno.motivation = jQuery.grep(oaAnno.motivation, function(value) {
-          return value !== "oa:tagging";
-        });
-        oaAnno.resource = jQuery.grep(oaAnno.resource, function(value) {
-          return value["@type"] !== "oa:Tag";
-        });
-        //re-add tagging if we have them
-        if (tags.length > 0) {
-          oaAnno.motivation.push("oa:tagging");
-          jQuery.each(tags, function(index, value) {
-            oaAnno.resource.push({
-              "@type": "oa:Tag",
-              "chars": value
-            });
-          });
-        }
-        jQuery.each(oaAnno.resource, function(index, value) {
-          if (value["@type"] === "dctypes:Text") {
-            value.chars = resourceText;
-          }
-        });
-        //save to endpoint
-        jQuery.publish('annotationUpdated.' + _this.windowId, [oaAnno]);
-      });
-
-      jQuery(selector + ' a.cancel').on("click", function(event) {
-        event.preventDefault();
-        var display = jQuery(this).parents('.annotation-editor');
-        var id = display.attr('data-anno-id');
-        var oaAnno = _this.getAnnoFromRegion(id)[0];
-        _this.unFreezeQtip(api, oaAnno, annoTooltip);
       });
     }
   };

--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -148,7 +148,7 @@
       var windowElement = _this.state.getWindowElement(_this.windowId);
       this.annoTooltip = new $.AnnotationTooltip({
         targetElement: jQuery(this.osdViewer.element),
-        parent: _this,
+        state: _this.state,
         windowId: _this.parent.windowId
       });
       this.annoTooltip.initializeViewerUpgradableToEditor({

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -591,12 +591,12 @@
       this.path = null;
       this.mode = '';
       this.draftPaths.push(shape);
-      var _this = this;
       var annoTooltip = new $.AnnotationTooltip({
-        targetElement: jQuery(_this.canvas).parents('.mirador-osd'),
-        parent: _this,
-        windowId: _this.windowId
+        targetElement: jQuery(this.canvas).parents('.mirador-osd'),
+        state: this.state,
+        windowId: this.windowId
       });
+      var _this = this;
       annoTooltip.showEditor({
         annotation: {},
         onAnnotationCreated: function (oaAnno) {

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -12,7 +12,7 @@
   };
 
   $.Overlay = function(viewer, osdViewerId, windowId, state) {
-    var drawingToolsSettings = state.getStateProperty('drawingToolsSettings'), 
+    var drawingToolsSettings = state.getStateProperty('drawingToolsSettings'),
     availableAnnotationDrawingTools = state.getStateProperty('availableAnnotationDrawingTools');
     jQuery.extend(this, {
       disabled: true,
@@ -545,7 +545,7 @@
     getName: function(tool) {
       return tool.idPrefix + $.genUUID();
     },
-    
+
     getSVGString: function(shapes) {
       var svg = "<svg xmlns='http://www.w3.org/2000/svg'>";
       if (shapes.length > 1) {
@@ -593,167 +593,50 @@
       this.draftPaths.push(shape);
       var _this = this;
       var annoTooltip = new $.AnnotationTooltip({
-        "windowId": _this.windowId
+        targetElement: jQuery(_this.canvas).parents('.mirador-osd'),
+        parent: _this,
+        windowId: _this.windowId
       });
-      if (!_this.commentPanel) {
-        _this.commentPanel = jQuery(_this.canvas).parents('.mirador-osd').qtip({
-          content: {
-            text: annoTooltip.getEditor({})
-          },
-          position: {
-            my: 'center',
-            at: 'center'
-          },
-          style: {
-            classes: 'qtip-bootstrap qtip' + _this.windowId
-          },
-          show: {
-            event: false
-          },
-          hide: {
-            fixed: true,
-            delay: 300,
-            event: false
-          },
-          events: {
-            render: function(event, api) {
-              jQuery.publish('annotationEditorAvailable.' + _this.windowId);
-              jQuery.publish('disableTooltips.' + _this.windowId);
-
-              var selector = '#annotation-editor-' + _this.windowId;
-              jQuery(selector).parent().parent().draggable();
-
-              tinymce.init({
-                selector: selector + ' textarea',
-                plugins: "image link media",
-                menubar: false,
-                statusbar: false,
-                toolbar_items_size: 'small',
-                toolbar: "bold italic | bullist numlist | link image media | removeformat",
-                setup: function(editor) {
-                  editor.on('init', function(args) {
-                    tinymce.execCommand('mceFocus', false, args.target.id);
-                  });
-                }
-              });
-
-              jQuery(selector).on("submit", function(event) {
-                event.preventDefault();
-                jQuery(selector + ' a.save').click();
-              });
-
-              jQuery(selector + ' a.cancel').on("click", function(event) {
-                event.preventDefault();
-                var content = tinymce.activeEditor.getContent();
-                if (content) {
-                  if (!window.confirm("Do you want to cancel this annotation?")) {
-                    return false;
-                  }
-                }
-                api.destroy();
-
-                // clear draft data.
-                for (var idx = 0; idx < _this.draftPaths.length; idx++) {
-                  _this.draftPaths[idx].remove();
-                }
-                _this.draftPaths = [];
-                if (_this.path) {
-                  _this.path.remove();
-                }
-                _this.paperScope.view.update(true);
-                _this.paperScope.project.activeLayer.selected = false;
-                _this.hoveredPath = null;
-                _this.segment = null;
-                _this.path = null;
-                _this.mode = '';
-
-                //reenable viewer tooltips
-                jQuery.publish('enableTooltips.' + _this.windowId);
-                _this.commentPanel = null;
-              });
-
-              jQuery(selector + ' a.save').on("click", function(event) {
-                event.preventDefault();
-                var tagText = jQuery(this).parents('.annotation-editor').find('.tags-editor').val(),
-                  resourceText = tinymce.activeEditor.getContent(),
-                  tags = [];
-                tagText = $.trimString(tagText);
-                if (tagText) {
-                  tags = tagText.split(/\s+/);
-                }
-
-                var bounds = _this.viewer.viewport.getBounds(true);
-                // var scope = _this.viewer.viewport.viewportToImageRectangle(bounds);
-
-                var motivation = [],
-                  resource = [],
-                  on;
-
-                var svg = _this.getSVGString(_this.draftPaths);
-
-                if (tags && tags.length > 0) {
-                  motivation.push("oa:tagging");
-                  jQuery.each(tags, function(index, value) {
-                    resource.push({
-                      "@type": "oa:Tag",
-                      "chars": value
-                    });
-                  });
-                }
-                motivation.push("oa:commenting");
-                on = {
-                  "@type": "oa:SpecificResource",
-                  "full": _this.state.getWindowObjectById(_this.windowId).canvasID,
-                  "selector": {
-                    "@type": "oa:SvgSelector",
-                    "value": svg
-                  }
-                  // ,
-                  // "scope": {
-                  //   "@context": "http://www.harvard.edu/catch/oa.json",
-                  //   "@type": "catch:Viewport",
-                  //   "value": "xywh=" + Math.round(scope.x) + "," + Math.round(scope.y) + "," + Math.round(scope.width) + "," + Math.round(scope.height) //osd bounds
-                  // }
-                };
-                resource.push({
-                  "@type": "dctypes:Text",
-                  "format": "text/html",
-                  "chars": resourceText
-                });
-                var oaAnno = {
-                  "@context": "http://iiif.io/api/presentation/2/context.json",
-                  "@type": "oa:Annotation",
-                  "motivation": motivation,
-                  "resource": resource,
-                  "on": on
-                };
-                //save to endpoint
-                jQuery.publish('annotationCreated.' + _this.windowId, [oaAnno, shape]);
-
-                api.destroy();
-                //reenable viewer tooltips
-                jQuery.publish('enableTooltips.' + _this.windowId);
-                _this.commentPanel = null;
-                // clear draft data.
-                for (var idx = 0; idx < _this.draftPaths.length; idx++) {
-                  _this.draftPaths[idx].remove();
-                }
-                _this.draftPaths = [];
-                if (_this.path) {
-                  _this.path.remove();
-                }
-                _this.paperScope.view.update(true);
-                _this.paperScope.project.activeLayer.selected = false;
-                _this.hoveredPath = null;
-                _this.segment = null;
-                _this.path = null;
-                _this.mode = '';
-              });
+      annoTooltip.showEditor({
+        annotation: {},
+        onAnnotationCreated: function (oaAnno) {
+          var svg = _this.getSVGString(_this.draftPaths);
+          oaAnno.on = {
+            "@type": "oa:SpecificResource",
+            "full": _this.state.getWindowObjectById(_this.windowId).canvasID,
+            "selector": {
+              "@type": "oa:SvgSelector",
+              "value": svg
             }
-          }
-        });
-        _this.commentPanel.qtip('show');
+          };
+
+          //save to endpoint
+          jQuery.publish('annotationCreated.' + _this.windowId, [oaAnno, shape]);
+        },
+        onCancel: function() {
+          _this.clearDraftData();
+        },
+        onCompleted: function() {
+          _this.clearDraftData();
+        }
+      });
+    },
+
+    clearDraftData: function() {
+      var _this = this;
+      for (var idx = 0; idx < _this.draftPaths.length; idx++) {
+        _this.draftPaths[idx].remove();
       }
+      _this.draftPaths = [];
+      if (_this.path) {
+        _this.path.remove();
+      }
+      _this.paperScope.view.update(true);
+      _this.paperScope.project.activeLayer.selected = false;
+      _this.hoveredPath = null;
+      _this.segment = null;
+      _this.path = null;
+      _this.mode = '';
     }
   };
 }(Mirador));

--- a/js/src/annotations/tinymce-annotation-editor.js
+++ b/js/src/annotations/tinymce-annotation-editor.js
@@ -1,0 +1,139 @@
+(function($){
+
+  $.TinyMCEAnnotationBodyEditor = function(options) {
+
+    jQuery.extend(this, {
+      annotation: null,
+      windowId: null
+    }, options);
+
+    this.init();
+  };
+
+  $.TinyMCEAnnotationBodyEditor.prototype = {
+    init: function() {
+      var _this = this;
+      var annoText = "",
+        tags = [];
+
+      if (!jQuery.isEmptyObject(_this.annotation)) {
+        if (jQuery.isArray(_this.annotation.resource)) {
+          jQuery.each(_this.annotation.resource, function(index, value) {
+            if (value['@type'] === "oa:Tag") {
+              tags.push(value.chars);
+            } else {
+              annoText = value.chars;
+            }
+          });
+        } else {
+          annoText = _this.annotation.resource.chars;
+        }
+      }
+
+      this.editorMarkup = this.editorTemplate({
+        content: annoText,
+        tags : tags.join(" "),
+        windowId : _this.windowId
+      });
+    },
+
+    show: function(selector) {
+      this.editorContainer = jQuery(selector)
+        .prepend(this.editorMarkup);
+      tinymce.init({
+        selector: selector + ' textarea',
+        plugins: "image link media",
+        menubar: false,
+        statusbar: false,
+        toolbar_items_size: 'small',
+        toolbar: "bold italic | bullist numlist | link image media | removeformat",
+        setup: function(editor) {
+          editor.on('init', function(args) {
+            tinymce.execCommand('mceFocus', false, args.target.id);
+          });
+        }
+      });
+    },
+
+    isDirty: function() {
+      return tinymce.activeEditor.isDirty();
+    },
+
+    createAnnotation: function() {
+      var tagText = this.editorContainer.find('.tags-editor').val(),
+        resourceText = tinymce.activeEditor.getContent(),
+        tags = [];
+      tagText = $.trimString(tagText);
+      if (tagText) {
+        tags = tagText.split(/\s+/);
+      }
+
+      var motivation = [],
+        resource = [],
+        on;
+
+      if (tags && tags.length > 0) {
+        motivation.push("oa:tagging");
+        jQuery.each(tags, function(index, value) {
+          resource.push({
+            "@type": "oa:Tag",
+            "chars": value
+          });
+        });
+      }
+      motivation.push("oa:commenting");
+      resource.push({
+        "@type": "dctypes:Text",
+        "format": "text/html",
+        "chars": resourceText
+      });
+      return {
+        "@context": "http://iiif.io/api/presentation/2/context.json",
+        "@type": "oa:Annotation",
+        "motivation": motivation,
+        "resource": resource
+      };
+    },
+
+    updateAnnotation: function(oaAnno) {
+      var tagText = this.editorContainer.find('.tags-editor').val(),
+        resourceText = tinymce.activeEditor.getContent(),
+        tags = [];
+      tagText = $.trimString(tagText);
+      if (tagText) {
+        tags = tagText.split(/\s+/);
+      }
+
+      var motivation = [],
+        resource = [];
+
+      //remove all tag-related content in annotation
+      oaAnno.motivation = jQuery.grep(oaAnno.motivation, function(value) {
+        return value !== "oa:tagging";
+      });
+      oaAnno.resource = jQuery.grep(oaAnno.resource, function(value) {
+        return value["@type"] !== "oa:Tag";
+      });
+      //re-add tagging if we have them
+      if (tags.length > 0) {
+        oaAnno.motivation.push("oa:tagging");
+        jQuery.each(tags, function(index, value) {
+          oaAnno.resource.push({
+            "@type": "oa:Tag",
+            "chars": value
+          });
+        });
+      }
+      jQuery.each(oaAnno.resource, function(index, value) {
+        if (value["@type"] === "dctypes:Text") {
+          value.chars = resourceText;
+        }
+      });
+    },
+
+    editorTemplate: Handlebars.compile([
+      '<textarea class="text-editor" placeholder="{{t "comments"}}…">{{#if content}}{{content}}{{/if}}</textarea>',
+      '<input id="tags-editor-{{windowId}}" class="tags-editor" placeholder="{{t "addTagsHere"}}…" {{#if tags}}value="{{tags}}"{{/if}}>'
+    ].join(''))
+  };
+}(Mirador));

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -34,7 +34,7 @@
 
     'layout': '1x1',
 
-    'openManifestsPage' : false, //defaults to false, whether or not Mirador should display the manifests page, 
+    'openManifestsPage' : false, //defaults to false, whether or not Mirador should display the manifests page,
                                 //only valid if no windowObjects have been initialized
                                 //if there are multiple slots, it will be bound to the first slot and the selected manifest will open in that slot
 
@@ -60,7 +60,7 @@
        *   "overlay" : [_true_, false] whether or not to make the overlay available/visible in this window
        *
        *   "annotationLayer" : [_true_, false] whether or not to make annotation layer available in this window
-       *   "annotationCreation" : [_true_, false] whether or not to make annotation creation available in this window, 
+       *   "annotationCreation" : [_true_, false] whether or not to make annotation creation available in this window,
        *                          only valid if annotationLayer is set to True and an annotationEndpoint is defined.
        *                          This setting does NOT affect whether or not a user can edit an individual annotation that has already been created.
        *   "annotationState" : [_'annoOff'_, 'annoOnCreateOff', 'annoOnCreateOn'] whether or not to turn on the annotation layer on window load
@@ -113,7 +113,7 @@
         'bookmark' : true,
         'layout' : true,
         'options' : false,
-        'fullScreenViewer': true 
+        'fullScreenViewer': true
       }
       //'height': 25,
       //'width': '100%'
@@ -122,7 +122,7 @@
     'workspacePanelSettings': {
       'maxRows': 5,
       'maxColumns': 5,
-      'preserveWindows': true 
+      'preserveWindows': true
     },
 
     //true or false.  controls display of "Add new object from URL" on manifest listing page
@@ -145,7 +145,7 @@
      *  {
      *  name: 'backend name',
      *  module: 'NameEndpoint',
-     *  options: 
+     *  options:
      *  { 'url': '',
      *    'storeId': 123,
      *    'APIKey': '23983hf98j3f9283jf2983fj'
@@ -153,6 +153,10 @@
      *  }
      **/
     'annotationEndpoint': {},
+    'annotationBodyEditor': {
+      'module': 'TinyMCEAnnotationBodyEditor',
+      'options': {}
+    },
 
     'jsonStorageEndpoint': {
 	'name': 'JSONBlob API Endpoint',


### PR DESCRIPTION
# Intro

This change brings pluggable annotation body editor into Mirador, existing TinyMCE remains default implementation.

# Motivation

1. Different use-cases require different data to be associated with an annotation, from rich text, tags to other references etc.
2. When integrating Mirador with existing complex front-end systems developers could reuse some editors that's already exist in system.
3. TinyMCE is complex component with it's own themes, plugins, dynamic resource loading, it's hard to package into build system like webpack, rich text editing may not be not enough reason to deal with the complexities and it's easier to use something less advanced.

# Design
* AnnotationTooltip - manages annotation tooltip lifecycle, controls, container for image editor
* OsdSvgOverlay - service for managing annotations
* TinyMceAnnotationEditor - component for viewing/editing annotation.

## AnnotationTooltip
Annotation tooltip handles annotation dialog - creating, handling events, showing edit/save/cancel buttons, etc.

## EditorComponent
Editor is configured on Mirador init with editor plugin name and parameters:
```
'annotationBodyEditor': {
  'module': 'TinyMCEAnnotationBodyEditor',
  'options': {}
},
```

Editor itself must have following members:
show
isDirty
createAnnotation
updateAnnotation
For more information, parameters and docs consult TinyMceAnnotationEditor.


# Further development ideas
At this point minimal steps were taken to make editor pluggable. A lot of jQuery events are fired along the way, priority was not to change them, just rearrange the code. Still, something is worth improving:

* Cleaner interfaces (no upgrade to edit, etc.) between layers.
* Make annotation viewer part of editor to be customizable
* Abstract annotation tooltip, make it pluggable to make different UIs for annotations possible
* Revise/enrich event/callback system to make things like zoom to given annotation possible

@stanislavkostadinov made event-based handling of annotation body editor to replace annotation body editor interface completely #808 . Both solutions can be integrated and complement each other.