### PR TITLE
fr/es translations for "thumbnailsView"

### DIFF
--- a/js/src/workspaces/slot.js
+++ b/js/src/workspaces/slot.js
@@ -243,7 +243,7 @@
                                 '</div>',
                                 '</h1>',
                                  '<h1 class="addItemText">{{t "addItem"}}</h1>',
-                                 '<h1 class="dropMeMessage">Drop to Load Manifest</h1>',
+                                 '<h1 class="dropMeMessage">{{t "dropToLoad"}}</h1>',
                                  '</div>',
                                  '<a class="addItemLink" role="button" aria-label="Add item"></a>',
                                  '<a class="remove-slot-option"><i class="fa fa-times fa-lg fa-fw"></i> {{t "close"}}</a>',

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -32,5 +32,7 @@
     "newObject": "New Object",
     "objectMetadata": "Object Metadata",
     "fullScreen": "Full Screen",
-    "logo": "Logo"
+    "logo": "Logo",
+    "load": "Load",
+    "dropToLoad": "Drop to Load Manifest"
 }

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -29,5 +29,7 @@
     "thumbnailsView": "Miniaturas",
     "objectMetadata": "Metadatos",
     "fullScreen": "Pantalla completa",
-    "logo": "Logo"
+    "logo": "Logo",
+    "load": "Cargar",
+    "dropToLoad": "Soltar aquí para añadir el objeto"
 }

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -26,6 +26,7 @@
     "imageView": "Vista de la Imagen",
     "bookView": "Vista del Libro",
     "scrollView": "Vista del rollo de papel",
+    "thumbnailsView": "Miniaturas",
     "objectMetadata": "Metadatos",
     "fullScreen": "Pantalla completa",
     "logo": "Logo"

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -22,6 +22,7 @@
     "imageView": "Simple page",
     "bookView": "Double page",
     "scrollView": "Défilement horizontal",
+    "thumbnailsView": "Mosaïque",
     "comments": "Commentaires",
     "addTagsHere": "Ajouter des mots-clés",
     "save": "Enregistrer",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -33,5 +33,7 @@
     "newObject": "Nouvel objet",
     "objectMetadata": "Métadonnées",
     "fullScreen": "Plein écran",
-    "logo": "Logo"
+    "logo": "Logo",
+    "load": "Charger",
+    "dropToLoad": "Déposer ici pour ajouter l'objet"
 }


### PR DESCRIPTION
Per #827 

Not in this PR but I could also add new strings and french and spanish translations for:
```
"load": "Load"
"load": "Charger"
"load": "Cargar"
```
(per #729)
and also
```
"dropToLoad": "Drop to Load Manifest"
"dropToLoad": "Déposer ici pour ajouter l'objet"
"dropToLoad": "Soltar aquí para añadir el objeto"
```