### PR TITLE
changed line 69 in tab.js to fix bug in triggering tabs when two or m…

### DIFF
--- a/js/src/widgets/tabs.js
+++ b/js/src/widgets/tabs.js
@@ -65,7 +65,7 @@
             var _this = this;
 
             this.element.find('.tab').on('click', function(event) {
-                jQuery.publish('tabSelected.' + _this.windowId, jQuery( ".tabGroup li" ).index( this ));
+                jQuery.publish('tabSelected.' + _this.windowId, jQuery( this ).index());
             });
         },
         render: function(renderingData) {


### PR DESCRIPTION
John Abrahams and i have been working with the tabs and we needed this fix to be make the tabs work when there was more than window open. 

Here's what John wrote:

> Original code in tabs.js (https://github.com/jeffreycwitt/mirador/blob/feature/2.1-search-within/js/src/widgets/tabs.js#L69):
> jQuery.publish('tabSelected.' + _this.windowId, jQuery( ".tabGroup li" ).index( this ));
> 
> Change to:
> jQuery.publish('tabSelected.' + _this.windowId, jQuery( this ).index());
> 
> The original code is selected all tabs on the screen, which in your example would be 4 total across both windows. The CSS selector is just too general in the original case and picks up more elements then it should. The modification is instead of selected ".tabGroup li", select the clicked element and take its position among sibling elements.