### PR TITLE
grunt version dependency issues (#821)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/IIIF/mirador"
   },
   "devDependencies": {
-    "grunt": "*",
+    "grunt": ">=0.4.5 <1.0.0",
     "grunt-contrib-compress": "*",
     "grunt-contrib-concat": "*",
     "grunt-contrib-copy": "*",


### PR DESCRIPTION
This is a (hopefully) temporary fix for #821 
Which references an issue in grunt (gruntjs/grunt#1488)
Which has a recommended (hopefully temporary) solution of the following: http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies

The core of the issue is how grunt deals with peerDependencies in it's >=1.x versions and that the plugins need to change the way they're dealing with their dependency on grunt. This is ultimately up to the plugin devs to fix or for people to stop using the plugins that aren't updating.