### PR TITLE
Regressed tests from saveController

### DIFF
--- a/spec/utils/saveController.test.js
+++ b/spec/utils/saveController.test.js
@@ -10,9 +10,9 @@ describe("saveController", function() {
         "title": "MS 5",
         "widgets": []
       }],
-    }; 
+    };
   });
-  
+
   describe('saveSession == false', function() {
 
     beforeEach(function() {
@@ -76,8 +76,6 @@ describe("saveController", function() {
   describe('default settings set to undefined', function() {
 
     beforeEach(function() {
-      // clear $.DEFAULT_SETTINGS
-      window.Mirador.DEFAULT_SETTINGS = {};
       this.config.jsonStorageEndpoint = {
         'name': 'JSONBlob API Endpoint',
         'module': 'JSONBlobAPI',


### PR DESCRIPTION
The saveController test was resetting a global config that was effecting other tests.

That reset doesn't appear to have been necessary, as the tests still pass without it, so I just removed it. 