### PR TITLE
Fixed New annotation dialog not showing up in fullscreen mode

### DIFF
--- a/js/src/annotations/annotationTooltip.js
+++ b/js/src/annotations/annotationTooltip.js
@@ -51,7 +51,9 @@
         },
         position: {
           my: 'center',
-          at: 'center'
+          at: 'center',
+          container: _this.targetElement,
+          viewport: _this.targetElement
         },
         style: {
           classes: 'qtip-bootstrap qtip' + _this.windowId


### PR DESCRIPTION
Fixed positioning of qtip in DOM to fix annotation dialog not displayed in fullscreen mode.