### PR TITLE
Fixed DEFAULT_SETTINGS overwrite in SaveController initialization

### DIFF
--- a/js/src/utils/saveController.js
+++ b/js/src/utils/saveController.js
@@ -22,8 +22,7 @@
       config.mainMenuSettings.buttons = {};
     }
 
-    this.init(jQuery.extend(false, $.DEFAULT_SETTINGS, config));
-
+    this.init(jQuery.extend(true, {}, $.DEFAULT_SETTINGS, config));
   };
 
   $.SaveController.prototype = {


### PR DESCRIPTION
This is extremely important when reusing Mirador withing a page multiple times, otherwise you've got your DEFAULT_SETTINGS rewritten.