### PR TITLE
Added spec for viewer/manifestsPanel

### DIFF
--- a/js/src/manifests/manifest.js
+++ b/js/src/manifests/manifest.js
@@ -77,7 +77,7 @@
       this.request.done(function(jsonLd) {
         _this.jsonLd = jsonLd;
       });
-      setTimeout(function () { _this.request.resolve(manifestContent); }, 0);
+      _this.request.resolve(manifestContent); // resolve immediately
     },
     getThumbnailForCanvas : function(canvas, width) {
       var version = "1.1",

--- a/js/src/viewer/manifestsPanel.js
+++ b/js/src/viewer/manifestsPanel.js
@@ -47,53 +47,38 @@
 
           // handle subscribed events
           jQuery.subscribe('manifestsPanelVisible.set', function(_, stateValue) {
-             if (stateValue) { _this.show(); return; }
-              _this.hide();
+            _this.onPanelVisible(_, stateValue);
           });
 
           jQuery.subscribe('manifestReceived', function(event, newManifest) {
-            _this.manifestListItems.push(new $.ManifestListItem({ 
-              manifest: newManifest, 
-              resultsWidth: _this.resultsWidth, 
-              state: _this.state,
-              appendTo: _this.manifestListElement }));
-            _this.element.find('#manifest-search').keyup();
+            _this.onManifestReceived(event, newManifest);
           });
         },
 
         bindEvents: function() {
             var _this = this;
+
             // handle interface events
             this.element.find('form#url-load-form').on('submit', function(event) {
-                event.preventDefault();
-                var url = jQuery(this).find('input').val();
-                jQuery.publish('ADD_MANIFEST_FROM_URL', url, "(Added from URL)");
+              event.preventDefault();
+              _this.addManifestUrl(jQuery(this).find('input').val());
             });
 
-            this.element.find('.remove-object-option').on('click', function() {
-              jQuery.publish('TOGGLE_LOAD_WINDOW');
+            this.element.find('.remove-object-option').on('click', function(event) {
+              _this.togglePanel(event);
             });
 
             // Filter manifests based on user input
-            this.element.find('#manifest-search').on('keyup input', function() {
-               if (this.value.length > 0) {
-                  _this.element.find('.items-listing li').show().filter(function() {
-                     return jQuery(this).text().toLowerCase().indexOf(_this.element.find('#manifest-search').val().toLowerCase()) === -1;
-                  }).hide();
-               } else {
-                  _this.element.find('.items-listing li').show();
-               }
+            this.element.find('#manifest-search').on('keyup input', function(event) {
+              _this.filterManifests(this.value);
             });
 
             this.element.find('#manifest-search-form').on('submit', function(event) {
               event.preventDefault();
             });
 
-            jQuery(window).resize($.throttle(function(){
-              var clone = _this.element.clone().css("visibility","hidden").css("display", "block").appendTo(_this.appendTo);
-              _this.resultsWidth = clone.find('.select-results').outerWidth();
-              clone.remove();
-              jQuery.publish("manifestPanelWidthChanged", _this.resultsWidth);
+            jQuery(window).resize($.throttle(function() {
+              _this.resizePanel();
             }, 50, true));
         },
         
@@ -104,8 +89,50 @@
 
         show: function() {
             var _this = this;
-
             jQuery(this.element).show({effect: "fade", duration: 160, easing: "easeInCubic"});
+        },
+        
+        addManifestUrl: function(url) {
+          jQuery.publish('ADD_MANIFEST_FROM_URL', url, "(Added from URL)");
+        },
+        
+        togglePanel: function(event) {
+          jQuery.publish('TOGGLE_LOAD_WINDOW');
+        },
+        
+        filterManifests: function(value) {
+          var _this = this;
+          if (value.length > 0) {
+             _this.element.find('.items-listing li').show().filter(function() {
+                return jQuery(this).text().toLowerCase().indexOf(value.toLowerCase()) === -1;
+             }).hide();
+          } else {
+             _this.element.find('.items-listing li').show();
+          }
+        },
+
+        resizePanel: function() {
+          var _this = this;
+          var clone = _this.element.clone().css("visibility","hidden").css("display", "block").appendTo(_this.appendTo);
+          _this.resultsWidth = clone.find('.select-results').outerWidth();
+          clone.remove();
+          jQuery.publish("manifestPanelWidthChanged", _this.resultsWidth);
+        },
+        
+        onPanelVisible: function(_, stateValue) {
+          var _this = this;
+          if (stateValue) { _this.show(); return; }
+           _this.hide();
+        },
+
+        onManifestReceived: function(event, newManifest) {
+          var _this = this;
+          _this.manifestListItems.push(new $.ManifestListItem({ 
+            manifest: newManifest, 
+            resultsWidth: _this.resultsWidth, 
+            state: _this.state,
+            appendTo: _this.manifestListElement }));
+          _this.element.find('#manifest-search').keyup();
         },
 
         template: Handlebars.compile([

--- a/spec/fixtures/dummyManifest.json
+++ b/spec/fixtures/dummyManifest.json
@@ -1,0 +1,42 @@
+{
+   "@context":"http://iiif.io/api/presentation/2/context.json",
+   "@id":"http://www.example.org/iiif/book1/manifest",
+   "@type":"sc:Manifest",
+   "label":"Dummy Manifest",
+   "description": "A dummy manifest with a single, empty canvas.",
+   "sequences":[
+      {
+         "@id":"http://www.example.org/iiif/book1/sequence/normal",
+         "@type":"sc:Sequence",
+         "label":"Default Sequence",
+         "canvases":[
+            {
+               "@id":"http://www.example.org/iiif/book1/canvas/p1",
+               "@type":"sc:Canvas",
+               "label":"Default Canvas",
+               "width":1234,
+               "height":4321,
+               "images": [
+                  {
+                     "@id": "http://www.example.org/iiif/image/1",
+                     "@type": "oa:Annotation",
+                     "motivation": "sc:painting",
+                     "on": "http://www.example.org/iiif/book1/canvas/p1",
+                     "resource": {
+                        "@id": "http://www.example.org/iiif/resource/1",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 1234,
+                        "width": 4321,
+                        "service": {
+                           "@id": "http://www.example.org/iiif/image/1",
+                           "profile": "http://iiif.io/api/image/2/profiles/level2.json"
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}

--- a/spec/viewer/manifestsPanel.test.js
+++ b/spec/viewer/manifestsPanel.test.js
@@ -1,10 +1,117 @@
-describe('viewer/manifestsPanel', function () {
-  xit('listenForActions', function () {
+describe('viewer/manifestsPanel', function() {
+  beforeEach(function() {
+    jasmine.getJSONFixtures().fixturesPath = 'spec/fixtures';
+    this.dummyManifestContent = getJSONFixture('dummyManifest.json');
+    this.viewerDiv = jQuery('<div>');
+    this.panel = new Mirador.ManifestsPanel({
+      appendTo: this.viewerDiv,
+      state: new Mirador.SaveController({})
+    })
   });
-  xit('bindEvents', function () {
+
+  it('should initialize itself', function() {
+    expect(this.panel).toBeDefined();
   });
-  xit('hide', function () {
+
+  it('should listen for actions', function() {
+    var manifest = new Mirador.Manifest(null, 'Dummy Location', this.dummyManifestContent);
+    spyOn(this.panel, 'onPanelVisible');
+    spyOn(this.panel, 'onManifestReceived');
+    jQuery.publish('manifestsPanelVisible.set');
+    jQuery.publish('manifestReceived', manifest);
+    expect(this.panel.onPanelVisible).toHaveBeenCalled();
+    expect(this.panel.onManifestReceived).toHaveBeenCalled();
   });
-  xit('show', function () {
+  
+  it('should bind events', function() {
+    var element = this.panel.element;
+    
+    spyOn(this.panel, 'addManifestUrl');
+    element.find('form#url-load-form').trigger('submit');
+    expect(this.panel.addManifestUrl).toHaveBeenCalled();
+    
+    spyOn(this.panel, 'togglePanel');
+    element.find('.remove-object-option').trigger('click');
+    expect(this.panel.togglePanel).toHaveBeenCalled();
+    
+    spyOn(this.panel, 'filterManifests');
+    element.find('#manifest-search').trigger('keyup');
+    expect(this.panel.filterManifests).toHaveBeenCalled();
+    
+    spyOn(this.panel, 'resizePanel');
+    jQuery(window).trigger('resize');
+    expect(this.panel.resizePanel).toHaveBeenCalled();
   });
+  
+  ['hide', 'show'].forEach(function(action) {
+    it('should ' + action, function() {
+      spyOn(jQuery.fn, action);
+      this.panel[action]();
+      expect(jQuery.fn[action]).toHaveBeenCalled();
+    });
+  });
+
+  it('should add manifest from url', function() {
+    spyOn(jQuery, 'publish');
+    var url = "http://example.com/manifest.json";
+    this.panel.addManifestUrl(url);
+    expect(jQuery.publish).toHaveBeenCalledWith('ADD_MANIFEST_FROM_URL', url, "(Added from URL)");
+  });
+  
+  it('should toggle load window', function() {
+    spyOn(jQuery, 'publish');
+    this.panel.togglePanel();
+    expect(jQuery.publish).toHaveBeenCalledWith('TOGGLE_LOAD_WINDOW');
+  });
+  
+  it('should filter manifests', function() {
+    var manifest = new Mirador.Manifest(null, 'Dummy Location', this.dummyManifestContent);
+    var searchText = this.dummyManifestContent.label
+    var item = null;
+
+    this.panel.onManifestReceived(null, manifest);
+    expect(this.panel.manifestListItems.length).toBe(1);
+    
+    item = this.panel.element.find('.items-listing li:first');
+    expect(item.length).toBe(1);
+
+    this.panel.filterManifests(searchText);
+    expect(item.css('display')).not.toBe('none');
+    
+    this.panel.filterManifests("XXX");
+    expect(item.css('display')).toBe('none');
+    
+    this.panel.filterManifests("");
+    expect(item.css('display')).not.toBe('none');
+  });
+  
+  it('should set panel visibility', function() {
+    spyOn(this.panel, 'show');
+    spyOn(this.panel, 'hide');
+
+    this.panel.onPanelVisible(null, true);
+    expect(this.panel.show).toHaveBeenCalled();
+    expect(this.panel.hide).not.toHaveBeenCalled();
+    
+    this.panel.show.calls.reset();
+    this.panel.hide.calls.reset();
+
+    this.panel.onPanelVisible(null, false);
+    expect(this.panel.show).not.toHaveBeenCalled();
+    expect(this.panel.hide).toHaveBeenCalled();
+  });
+  
+  it('should resize', function() {
+    spyOn(jQuery, 'publish');
+    this.panel.resizePanel();
+    expect(jQuery.publish).toHaveBeenCalledWith('manifestPanelWidthChanged', this.panel.resultsWidth);
+  });
+  
+  it('should receive a new manifest', function() {
+    var manifest = new Mirador.Manifest(null, 'Dummy Location', this.dummyManifestContent);
+    expect(this.panel.manifestListItems.length).toBe(0);
+    this.panel.onManifestReceived(null, manifest);
+    expect(this.panel.manifestListItems.length).toBe(1);
+  });
+
 });


### PR DESCRIPTION
Added spec for the `ManifestsPanel`. I refactored a few things to make testing a little bit easier. 

Note: I think PR https://github.com/IIIF/mirador/pull/891 needs to be merged first, because [travis build 875](https://travis-ci.org/IIIF/mirador/builds/128138633) is generating this warning: *Warning: No provider for "framework:fixture"* and doesn't appear to be running all the tests.

@rsinghal @aeschylus Can you review and let me know if anything looks problematic?