### PR TITLE
Drag and drop not working in Chrome

### DIFF
--- a/js/src/workspaces/slot.js
+++ b/js/src/workspaces/slot.js
@@ -132,8 +132,20 @@
       var _this = this;
 
       e.preventDefault();
-      var url = e.originalEvent.dataTransfer.getData("text/plain");
-      if (url) {
+      var text_url = e.originalEvent.dataTransfer.getData("text/plain");
+      if (text_url) {
+        _this.handleDrop(text_url);
+      } else {
+        e.originalEvent.dataTransfer.items[0].getAsString(function(url) {
+          _this.handleDrop(url);
+        });
+      }
+    },
+
+    handleDrop: function(url) {
+        var _this = this;
+
+        url = url || text_url;
         var manifestUrl = $.getQueryParams(url).manifest,
             canvasId = $.getQueryParams(url).canvas,
             imageInfoUrl = $.getQueryParams(url).image,
@@ -198,11 +210,7 @@
 
             jQuery.publish('ADD_WINDOW', windowConfig);
           }
-      });
-    } else {
-      _this.element.removeClass('draggedOver');
-      dropTarget.hide();
-    }
+        });
     },
 
     clearSlot: function() {


### PR DESCRIPTION
Fixes #911   Prefers 'text/plain' content from drag and drop event, falls back to Chrome-specific method otherwise.

We might want to rethink our drag-and-drop recommendation, it would be best if the data were explicitly passed from the drag source (e.g., set as a URI).