### PR TITLE
532 global window settings

### DIFF
--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -38,48 +38,45 @@
                                 //only valid if no windowObjects have been initialized
                                 //if there are multiple slots, it will be bound to the first slot and the selected manifest will open in that slot
 
+    'windowSettings' : {
+      "availableViews" : ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'], //any subset removes others
+      "viewType" : 'ThumbnailsView', //one of [_'ThumbnailsView'_, 'ImageView', 'ScrollView', 'BookView'] - if using availableViews, must be in subset
+      "bottomPanel" : true, //whether or not to make the bottom panel available in this window
+      "bottomPanelVisible" : true, //whether or not to make the bottom panel visible in this window on load. This setting is dependent on bottomPanel being true
+      "sidePanel" : true, //whether or not to make the side panel available in this window
+      //control what is available in the side panel. if "sidePanel" is false, these options won't be applied
+      "sidePanelOptions" : {
+        "toc" : true,
+        "annotations" : false
+      },
+      "sidePanelVisible" : true, //whether or not to make the side panel visible in this window on load. This setting is dependent on sidePanel being true
+      "overlay" : true, //whether or not to make the metadata overlay available/visible in this window
+      "annotationLayer" : true, //whether or not to make annotation layer available in this window
+      "annotationCreation" : true, /*whether or not to make annotation creation available in this window,
+                             only valid if annotationLayer is set to True and an annotationEndpoint is defined.
+                             This setting does NOT affect whether or not a user can edit an individual annotation that has already been created.*/
+      "annotationState" : 'annoOff', //[_'annoOff'_, 'annoOnCreateOff', 'annoOnCreateOn'] whether or not to turn on the annotation layer on window load
+      "fullScreen" : true, //whether or not to make the window's fullScreen button visible to user
+      "displayLayout" : true, //whether or not to display all layout options, removing individual menu options is separate
+      //control individual menu items in layout menu. if "displayLayout" is false, these options won't be applied
+      "layoutOptions" : {
+        "newObject" : true,
+        "close" : true,
+        "slotRight" : true,
+        "slotLeft" : true,
+        "slotAbove" : true,
+        "slotBelow" : true,
+      }
+    },
+
     'windowObjects' : [
-      /** within a single object, the following options:
-       *   "loadedManifest": [manifestURI] e.g. "http://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/manifest.json"
-       *   "canvasID": [canvas URI] e.g. "http://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/canvas/canvas-12"
-       *
-       *   "availableViews" : defaults to ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'], any subset removes others
-       *   "viewType" : one of [_'ThumbnailsView'_, 'ImageView', 'ScrollView', 'BookView'] - if using availableViews, must be in subset
-       *
-       *   "bottomPanel" : [_true_, false] whether or not to make the bottom panel available in this window
-       *   "bottomPanelVisible" : [_true_, false] whether or not to make the bottom panel visible in this window on load. This setting is dependent
-       *                           on bottomPanel being true
-       *   "sidePanel" : [_true_, false] whether or not to make the side panel available in this window
-       *   "sidePanelOptions" : control individual menu items in layout menu. if "displayLayout" is false, these options won't be applied
-       *     {
-       *     "toc" : [_true_, false]
-       *     "annotations" : [true, _false_]
-       *     }
-       *   "sidePanelVisible" : [_true_, false] whether or not to make the side panel visible in this window on load. This setting is dependent
-       *                           on sidePanel being true
-       *   "overlay" : [_true_, false] whether or not to make the overlay available/visible in this window
-       *
-       *   "annotationLayer" : [_true_, false] whether or not to make annotation layer available in this window
-       *   "annotationCreation" : [_true_, false] whether or not to make annotation creation available in this window,
-       *                          only valid if annotationLayer is set to True and an annotationEndpoint is defined.
-       *                          This setting does NOT affect whether or not a user can edit an individual annotation that has already been created.
-       *   "annotationState" : [_'annoOff'_, 'annoOnCreateOff', 'annoOnCreateOn'] whether or not to turn on the annotation layer on window load
-       *
-       *   "fullScreen" : [_true_, false] whether or not to make the fullScreen HUD button visible to user
-       *
-       *   "displayLayout" : [_true_, false], whether or not to display all layout options, removing individual menu options is separate
-       *   "layoutOptions" : control individual menu items in layout menu. if "displayLayout" is false, these options won't be applied
-       *     {
-       *     "newObject" : [_true_, false]
-       *     "close" : [_true_, false]
-       *     "slotRight" : [_true_, false]
-       *     "slotLeft" : [_true_, false]
-       *     "slotAbove" : [_true_, false]
-       *     "slotBelow" : [_true_, false]
-       *     }
-       *   "windowOptions" : [data specific to the view type, such as OSD bounds and zoom level - automatically saved in SaveController]
-       *   "id" : [unique window ID - set by application and automatically saved in SaveController]
-       **/
+      /* Using the same settings listed in `windowSettings`, change the settings for a specific window
+       * A few additional settings only available in `windowObjecs`
+       * "loadedManifest": [manifestURI] e.g. "http://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/manifest.json"
+       * "canvasID": [canvas URI] e.g. "http://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/canvas/canvas-12"
+       * "id" : [unique window ID - set by application and automatically saved in SaveController]
+       * "windowOptions" : [data specific to the view type, such as OSD bounds and zoom level - automatically saved in SaveController]
+       */
     ],
 
     'defaultWindowSettings': {

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -38,6 +38,7 @@
                                 //only valid if no windowObjects have been initialized
                                 //if there are multiple slots, it will be bound to the first slot and the selected manifest will open in that slot
 
+    //default window settings, but can be changed in Mirador configuration on initialization
     'windowSettings' : {
       "availableViews" : ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'], //any subset removes others
       "viewType" : 'ThumbnailsView', //one of [_'ThumbnailsView'_, 'ImageView', 'ScrollView', 'BookView'] - if using availableViews, must be in subset
@@ -71,6 +72,7 @@
 
     'windowObjects' : [
       /* Using the same settings listed in `windowSettings`, change the settings for a specific window
+       * Structured as an array of objects
        * A few additional settings only available in `windowObjecs`
        * "loadedManifest": [manifestURI] e.g. "http://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/manifest.json"
        * "canvasID": [canvas URI] e.g. "http://dms-data.stanford.edu/data/manifests/Walters/qm670kv1873/canvas/canvas-12"
@@ -78,10 +80,6 @@
        * "windowOptions" : [data specific to the view type, such as OSD bounds and zoom level - automatically saved in SaveController]
        */
     ],
-
-    'defaultWindowSettings': {
-
-    },
 
     // Control for whether or not to auto hide controls on the OSD canvas and specific durations in milliseconds
     // durations assume `autoHideControls` is true

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -277,36 +277,15 @@
     loadManifestFromConfig: function(options) {
       // check if there are available slots, otherwise don't process this object from config
       //if we have more windowObjects that slots in the layout, return
+      // it may not be necesary to set the slotAddress here since it is also covered in workspace
       var slotAddress = options.slotAddress ? options.slotAddress : this.workspace.getAvailableSlot() ? this.workspace.getAvailableSlot().layoutAddress : null;
+      options.slotAddress = slotAddress;
       if (!slotAddress) {
         return;
       }
 
-      var windowConfig = {
-        manifest: this.state.getStateProperty('manifests')[options.loadedManifest],
-        viewType : options.viewType,
-        availableViews : options.availableViews,
-        canvasID : options.canvasID,
-        id : options.id,
-        windowOptions : options.windowOptions,
-        //need to do the rewrite from setting to param for window
-        bottomPanelAvailable : options.bottomPanel,
-        bottomPanelVisible : options.bottomPanelVisible,
-        //need to do the rewrite from setting to param for window
-        sidePanelAvailable : options.sidePanel,
-        sidePanelOptions : options.sidePanelOptions,
-        sidePanelVisible : options.sidePanelVisible,
-        //need to do the rewrite from setting to param for window
-        overlayAvailable : options.overlay,
-        annotationLayer : options.annotationLayer,
-        annotationCreation : options.annotationCreation,
-        annotationState : options.annotationState,
-        fullScreen : options.fullScreen,
-        slotAddress: slotAddress,
-        displayLayout : options.displayLayout,
-        layoutOptions: options.layoutOptions
-      };
-
+      //make a copy of options and pass that so we don't get a circular reference
+      var windowConfig = jQuery.extend(true, {}, options);
       jQuery.publish('ADD_WINDOW', windowConfig);
     }
   };

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -284,21 +284,24 @@
 
       var windowConfig = {
         manifest: this.state.getStateProperty('manifests')[options.loadedManifest],
-        currentFocus : options.viewType,
-        focusesOriginal : options.availableViews,
-        currentCanvasID : options.canvasID,
+        viewType : options.viewType,
+        availableViews : options.availableViews,
+        canvasID : options.canvasID,
         id : options.id,
-        focusOptions : options.windowOptions,
+        windowOptions : options.windowOptions,
+        //need to do the rewrite from setting to param for window
         bottomPanelAvailable : options.bottomPanel,
         bottomPanelVisible : options.bottomPanelVisible,
+        //need to do the rewrite from setting to param for window
         sidePanelAvailable : options.sidePanel,
         sidePanelOptions : options.sidePanelOptions,
         sidePanelVisible : options.sidePanelVisible,
+        //need to do the rewrite from setting to param for window
         overlayAvailable : options.overlay,
-        annotationLayerAvailable : options.annotationLayer,
-        annotationCreationAvailable : options.annotationCreation,
+        annotationLayer : options.annotationLayer,
+        annotationCreation : options.annotationCreation,
         annotationState : options.annotationState,
-        fullScreenAvailable : options.fullScreen,
+        fullScreen : options.fullScreen,
         slotAddress: slotAddress,
         displayLayout : options.displayLayout,
         layoutOptions: options.layoutOptions

--- a/js/src/viewer/manifestListItem.js
+++ b/js/src/viewer/manifestListItem.js
@@ -139,8 +139,8 @@
       this.element.on('click', function() {
         var windowConfig = {
           manifest: _this.manifest,
-          currentCanvasID: null,
-          currentFocus: 'ThumbnailsView'
+          canvasID: null,
+          viewType: 'ThumbnailsView'
         };
         jQuery.publish('ADD_WINDOW', windowConfig);
       });
@@ -149,8 +149,8 @@
         e.stopPropagation();
         var windowConfig = {
           manifest: _this.manifest,
-          currentCanvasID: jQuery(this).attr('data-image-id'),
-          currentFocus: 'ImageView'
+          canvasID: jQuery(this).attr('data-image-id'),
+          viewType: 'ImageView'
         };
         jQuery.publish('ADD_WINDOW', windowConfig);
       });

--- a/js/src/viewer/manifestListItem.js
+++ b/js/src/viewer/manifestListItem.js
@@ -150,7 +150,7 @@
         var windowConfig = {
           manifest: _this.manifest,
           canvasID: jQuery(this).attr('data-image-id'),
-          viewType: 'ImageView'
+          viewType: _this.state.getStateProperty('windowSettings').viewType //get the view type from settings rather than always defaulting to ImageView
         };
         jQuery.publish('ADD_WINDOW', windowConfig);
       });

--- a/js/src/workspace.js
+++ b/js/src/workspace.js
@@ -422,8 +422,8 @@
           slotAddress: slot.layoutAddress, 
           state: _this.state,
           appendTo: slot.element,
-          currentCanvasID: window.currentCanvasID,
-          currentFOcus: window.currentFocus
+          canvasID: window.canvasID,
+          viewType: window.viewType
         });
       });
     },
@@ -475,7 +475,31 @@
         windowConfig.id = windowConfig.id || $.genUUID();
 
         jQuery.publish("windowSlotAdded", {id: windowConfig.id, slotAddress: windowConfig.slotAddress});
-        newWindow = new $.Window(windowConfig);
+
+        //extend the windowConfig with the default settings
+        var mergedConfig = jQuery.extend(true, {}, _this.state.getStateProperty('windowSettings'), windowConfig);
+
+        //"rename" some keys in the merged object to align settings parameters with window parameters        
+        if (mergedConfig.loadedManifest) {
+          mergedConfig.manifest = _this.state.getStateProperty('manifests')[mergedConfig.loadedManifest];
+          delete mergedConfig.loadedManifest;
+        }
+
+        if (mergedConfig.bottomPanel) {
+          mergedConfig.bottomPanelAvailable = mergedConfig.bottomPanel;
+          delete mergedConfig.bottomPanel;
+        }
+
+        if (mergedConfig.sidePanel) {
+          mergedConfig.sidePanelAvailable = mergedConfig.sidePanel;
+          delete mergedConfig.sidePanel;
+        }
+
+        if (mergedConfig.overlay) {
+          mergedConfig.overlayAvailable = mergedConfig.overlay;
+          delete mergedConfig.overlay;
+        }
+        newWindow = new $.Window(mergedConfig);
         _this.windows.push(newWindow);
 
         targetSlot.window = newWindow;

--- a/js/src/workspaces/slot.js
+++ b/js/src/workspaces/slot.js
@@ -163,8 +163,8 @@
             // image view. If we don't specify the focus, the
             // window will open in thumbnail view with the
             // chosen page highlighted.
-            windowConfig.currentCanvasID = canvasId;
-            windowConfig.currentFocus = 'ImageView';
+            windowConfig.canvasID = canvasId;
+            windowConfig.viewType = 'ImageView';
           }
 
           jQuery.publish('ADD_WINDOW', windowConfig);
@@ -204,8 +204,8 @@
               // image view. If we don't specify the focus, the
               // window will open in thumbnail view with the
               // chosen page highlighted.
-              windowConfig.currentCanvasID = canvasId;
-              windowConfig.currentFocus = 'ImageView';
+              windowConfig.canvasID = canvasId;
+              windowConfig.viewType = 'ImageView';
             }
 
             jQuery.publish('ADD_WINDOW', windowConfig);

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -5,18 +5,14 @@
     jQuery.extend(this, {
       element:           null,
       scrollImageRatio:  0.9,
-      //manifest:          null,
       canvasID:          null,
       focusImages:       [],
       imagesList:        null,
       annotationsList:   [],
       endpoint:          null,
-      //slotAddress:       null,
       currentImageMode:  'ImageView',
       imageModes:        ['ImageView', 'BookView'],
-      originalImageModes:        ['ImageView', 'BookView'],
-      //viewType:          'ThumbnailsView',
-      //availableViews:    ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
+      originalImageModes:['ImageView', 'BookView'],
       focuses:           ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
       focusModules:           {'ThumbnailsView': null, 'ImageView': null, 'ScrollView': null, 'BookView': null},
       focusOverlaysAvailable: {
@@ -38,15 +34,7 @@
         }
       },
       windowOptions: null,
-      //id : null,
       sidePanel: null, //the actual module for the side panel
-      //sidePanelAvailable: true,
-      // sidePanelOptions: {
-      //   "toc" : true,
-      //   "annotations" : false,
-      //   "layers" : false
-      // },
-      //sidePanelVisible: true,
       annotationsAvailable: {
         'ThumbnailsView' : false,
         'ImageView' : true,
@@ -54,23 +42,8 @@
         'BookView' : false
       },
       bottomPanel: null, //the actual module for the bottom panel
-      //bottomPanelAvailable: true,
-      //bottomPanelVisible: true,
       overlay: null,
-      //annotationLayer: true,
-      //annotationCreation: true,
       annoEndpointAvailable : false,
-      //annotationState : 'annoOff',
-      //fullScreen : true,
-      //displayLayout: true,
-      // layoutOptions : {
-      //   "newObject" : true,
-      //   "close" : true,
-      //   "slotRight" : true,
-      //   "slotLeft" : true,
-      //   "slotAbove" : true,
-      //   "slotBelow" : true
-      // },
       iconClasses: {
         "ImageView" : "fa fa-photo fa-lg fa-fw",
         "BookView" : "fa fa-columns fa-lg fa-fw",

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -14,6 +14,7 @@
       //slotAddress:       null,
       currentImageMode:  'ImageView',
       imageModes:        ['ImageView', 'BookView'],
+      originalImageModes:        ['ImageView', 'BookView'],
       //viewType:          'ThumbnailsView',
       //availableViews:    ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
       focuses:           ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
@@ -99,7 +100,8 @@
 
       _this.removeBookView();
 
-      //remove any imageModes that are not available as a focus
+      //reset imagemodes and then remove any imageModes that are not available as a focus
+      this.imageModes = this.originalImageModes;
       this.imageModes = jQuery.map(this.imageModes, function(value, index) {
         if (jQuery.inArray(value, _this.focuses) === -1) return null;
         return value;

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -6,16 +6,16 @@
       element:           null,
       scrollImageRatio:  0.9,
       manifest:          null,
-      currentCanvasID:    null,
+      canvasID:          null,
       focusImages:       [],
       imagesList:        null,
       annotationsList:   [],
       endpoint:          null,
-      slotAddress:     null,
+      slotAddress:       null,
       currentImageMode:  'ImageView',
       imageModes:        ['ImageView', 'BookView'],
-      currentFocus:      'ThumbnailsView',
-      focusesOriginal:   ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
+      viewType:          'ThumbnailsView',
+      availableViews:    ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
       focuses:           ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
       focusModules:           {'ThumbnailsView': null, 'ImageView': null, 'ScrollView': null, 'BookView': null},
       focusOverlaysAvailable: {
@@ -36,7 +36,7 @@
           'bottomPanel' : {'ThumbnailsView' : true}
         }
       },
-      focusOptions: null,
+      windowOptions: null,
       id : null,
       sidePanel: null, //the actual module for the side panel
       sidePanelAvailable: true,
@@ -56,11 +56,11 @@
       bottomPanelAvailable: true,
       bottomPanelVisible: true,
       overlay: null,
-      annotationLayerAvailable: true,
-      annotationCreationAvailable: true,
+      annotationLayer: true,
+      annotationCreation: true,
       annoEndpointAvailable : false,
       annotationState : 'annoOff',
-      fullScreenAvailable : true,
+      fullScreen : true,
       displayLayout: true,
       layoutOptions : {
         "newObject" : true,
@@ -87,7 +87,7 @@
     init: function () {
       var _this = this,
       manifest = _this.manifest.jsonLd,
-      focusState = _this.currentFocus,
+      focusState = _this.viewType,
       templateData = {};
 
       //make sure annotations list is cleared out when changing objects within window
@@ -106,13 +106,13 @@
       });
 
       _this.imagesList = _this.manifest.getCanvases();
-      if (!_this.currentCanvasID) {
-        _this.currentCanvasID = _this.imagesList[0]['@id'];
+      if (!_this.canvasID) {
+        _this.canvasID = _this.imagesList[0]['@id'];
       }
 
       this.annoEndpointAvailable = !jQuery.isEmptyObject(_this.state.getStateProperty('annotationEndpoint'));
-      if (!this.annotationLayerAvailable) {
-        this.annotationCreationAvailable = false;
+      if (!this.annotationLayer) {
+        this.annotationCreation = false;
         this.annoEndpointAvailable = false;
         this.annotationState = 'annoOff';
       }
@@ -160,8 +160,8 @@
           return _this.layoutOptions[element] === false;
         });
       }
-      templateData.currentFocusClass = _this.iconClasses[_this.currentFocus];
-      templateData.showFullScreen = _this.fullScreenAvailable;
+      templateData.currentFocusClass = _this.iconClasses[_this.viewType];
+      templateData.showFullScreen = _this.fullScreen;
       _this.element = jQuery(this.template(templateData)).appendTo(_this.appendTo);
       this.element.find('.manifest-info .mirador-tooltip').each(function() {
         jQuery(this).qtip({
@@ -216,16 +216,16 @@
       _this.bindNavigation();
       switch(focusState) {
         case 'ThumbnailsView':
-          _this.toggleThumbnails(_this.currentCanvasID);
+          _this.toggleThumbnails(_this.canvasID);
         break;
         case 'ImageView':
-          _this.toggleImageView(_this.currentCanvasID);
+          _this.toggleImageView(_this.canvasID);
         break;
         case 'BookView':
-          _this.toggleBookView(_this.currentCanvasID);
+          _this.toggleBookView(_this.canvasID);
         break;
         case 'ScrollView':
-          _this.toggleScrollView(_this.currentCanvasID);
+          _this.toggleScrollView(_this.canvasID);
         break;
         default:
           break;
@@ -247,9 +247,9 @@
 
     update: function(options) {
       jQuery.extend(this, options);
-      if (this.focusOptions) {
-        this.focusOptions.osdBounds = null;
-        this.focusOptions.zoomLevel = null;
+      if (this.windowOptions) {
+        this.windowOptions.osdBounds = null;
+        this.windowOptions.zoomLevel = null;
       }
       this.init();
     },
@@ -257,7 +257,7 @@
     // reset whether BookView is available every time as a user might switch between paged and non-paged objects within a single slot/window
     removeBookView: function() {
       var _this = this;
-      this.focuses = this.focusesOriginal;
+      this.focuses = this.availableViews;
       var manifest = this.manifest.jsonLd;
       if (manifest.sequences[0].viewingHint) {
         if (manifest.sequences[0].viewingHint.toLowerCase() !== 'paged') {
@@ -357,7 +357,7 @@
         if (_this.focusModules.ScrollView) {
           var containerHeight = _this.element.find('.view-container').height();
           var triggerShow = false;
-          if (_this.currentFocus === "ScrollView") {
+          if (_this.viewType === "ScrollView") {
             triggerShow = true;
           }
           _this.focusModules.ScrollView.reloadImages(Math.floor(containerHeight * _this.scrollImageRatio), triggerShow);
@@ -463,7 +463,7 @@
               state:  _this.state,
               windowId: _this.id,
               panel: true,
-              canvasID: _this.currentCanvasID,
+              canvasID: _this.canvasID,
               imagesList: _this.imagesList,
               thumbInfo: {thumbsHeight: 80, listingCssCls: 'panel-listing-thumbs', thumbnailCls: 'panel-thumbnail-view'}
             });
@@ -517,7 +517,7 @@
               state: _this.state,
               appendTo: _this.element.find('.sidePanel'),
               manifest: _this.manifest,
-              canvasID: _this.currentCanvasID,
+              canvasID: _this.canvasID,
               layersTabAvailable: layersTabAvailable,
               tocTabAvailable: tocAvailable,
               annotationsTabAvailable: annotationsTabAvailable,
@@ -597,9 +597,9 @@
 
     adjustFocusSize: function(panelType, panelState) {
       if (panelType === 'bottomPanel') {
-        this.focusModules[this.currentFocus].adjustHeight('focus-max-height', panelState);
+        this.focusModules[this.viewType].adjustHeight('focus-max-height', panelState);
       } else if (panelType === 'sidePanel') {
-        this.focusModules[this.currentFocus].adjustWidth('focus-max-width', panelState);
+        this.focusModules[this.viewType].adjustWidth('focus-max-width', panelState);
       } else {}
     },
 
@@ -624,7 +624,7 @@
     toggleFocus: function(focusState, imageMode) {
       var _this = this;
 
-      this.currentFocus = focusState;
+      this.viewType = focusState;
       if (imageMode && jQuery.inArray(imageMode, this.imageModes) > -1) {
         this.currentImageMode = imageMode;
       }
@@ -641,8 +641,8 @@
       jQuery.publish("focusUpdated");
       jQuery.publish("windowUpdated", {
         id: _this.id,
-        viewType: _this.currentFocus,
-        canvasID: _this.currentCanvasID,
+        viewType: _this.viewType,
+        canvasID: _this.canvasID,
         imageMode: _this.currentImageMode,
         loadedManifest: _this.manifest.jsonLd['@id'],
         slotAddress: _this.slotAddress
@@ -650,14 +650,14 @@
     },
 
     toggleThumbnails: function(canvasID) {
-      this.currentCanvasID = canvasID;
+      this.canvasID = canvasID;
       if (this.focusModules.ThumbnailsView === null) {
         this.focusModules.ThumbnailsView = new $.ThumbnailsView({
           manifest: this.manifest,
           appendTo: this.element.find('.view-container'),
           state:  this.state,
           windowId: this.id,
-          canvasID: this.currentCanvasID,
+          canvasID: this.canvasID,
           imagesList: this.imagesList
         });
       } else {
@@ -668,7 +668,7 @@
     },
 
     toggleImageView: function(canvasID) {
-      this.currentCanvasID = canvasID;
+      this.canvasID = canvasID;
       if (this.focusModules.ImageView === null) {
         this.focusModules.ImageView = new $.ImageView({
           manifest: this.manifest,
@@ -677,10 +677,10 @@
           state:  this.state,
           canvasID: canvasID,
           imagesList: this.imagesList,
-          osdOptions: this.focusOptions,
+          osdOptions: this.windowOptions,
           bottomPanelAvailable: this.bottomPanelAvailable,
-          annotationLayerAvailable: this.annotationLayerAvailable,
-          annotationCreationAvailable: this.annotationCreationAvailable,
+          annotationLayerAvailable: this.annotationLayer,
+          annotationCreationAvailable: this.annotationCreation,
           annoEndpointAvailable: this.annoEndpointAvailable,
           annotationState : this.annotationState
         });
@@ -692,7 +692,7 @@
     },
 
     toggleBookView: function(canvasID) {
-      this.currentCanvasID = canvasID;
+      this.canvasID = canvasID;
       if (this.focusModules.BookView === null) {
         this.focusModules.BookView = new $.BookView({
           manifest: this.manifest,
@@ -701,7 +701,7 @@
           state:  this.state,
           canvasID: canvasID,
           imagesList: this.imagesList,
-          osdOptions: this.focusOptions,
+          osdOptions: this.windowOptions,
           bottomPanelAvailable: this.bottomPanelAvailable
         });
       } else {
@@ -712,7 +712,7 @@
     },
 
     toggleScrollView: function(canvasID) {
-      this.currentCanvasID = canvasID;
+      this.canvasID = canvasID;
       if (this.focusModules.ScrollView === null) {
         var containerHeight = this.element.find('.view-container').height();
         this.focusModules.ScrollView = new $.ScrollView({
@@ -720,7 +720,7 @@
           appendTo: this.element.find('.view-container'),
           state:  this.state,
           windowId: this.id,
-          canvasID: this.currentCanvasID,
+          canvasID: this.canvasID,
           imagesList: this.imagesList,
           thumbInfo: {thumbsHeight: Math.floor(containerHeight * this.scrollImageRatio), listingCssCls: 'scroll-listing-thumbs', thumbnailCls: 'scroll-view'}
         });
@@ -738,7 +738,7 @@
 
     setCurrentCanvasID: function(canvasID) {
       var _this = this;
-      this.currentCanvasID = canvasID;
+      this.canvasID = canvasID;
       jQuery.publish('removeTooltips.' + _this.id);
       jQuery.unsubscribe(('annotationListLoaded.' + _this.id));
       while(_this.annotationsList.length > 0) {
@@ -747,10 +747,10 @@
       this.getAnnotations();
       switch(this.currentImageMode) {
         case 'ImageView':
-          this.toggleImageView(this.currentCanvasID);
+          this.toggleImageView(this.canvasID);
         break;
         case 'BookView':
-          this.toggleBookView(this.currentCanvasID);
+          this.toggleBookView(this.canvasID);
         break;
         default:
           break;
@@ -769,9 +769,9 @@
 
     updateManifestInfo: function() {
       var _this = this;
-      _this.element.find('.mirador-icon-view-type > i:first').removeClass().addClass(_this.iconClasses[_this.currentFocus]);
+      _this.element.find('.mirador-icon-view-type > i:first').removeClass().addClass(_this.iconClasses[_this.viewType]);
       
-      if (this.focusOverlaysAvailable[this.currentFocus].overlay.MetadataView) {
+      if (this.focusOverlaysAvailable[this.viewType].overlay.MetadataView) {
         this.element.find('.mirador-icon-metadata-view').addClass('selected');
       }
     },
@@ -783,7 +783,7 @@
     getAnnotations: function() {
       //first look for manifest annotations
       var _this = this,
-      url = _this.manifest.getAnnotationsListUrl(_this.currentCanvasID);
+      url = _this.manifest.getAnnotationsListUrl(_this.canvasID);
 
       if (url !== false) {
         jQuery.get(url, function(list) {
@@ -816,7 +816,7 @@
           options.imagesList = _this.imagesList;
           _this.endpoint = new $[module](options);
         }
-        _this.endpoint.search({ "uri" : _this.currentCanvasID});
+        _this.endpoint.search({ "uri" : _this.canvasID});
 
         dfd.done(function(loaded) {
           _this.annotationsList = _this.annotationsList.concat(_this.endpoint.annotationsList);
@@ -865,23 +865,23 @@
       });
 
       this.element.find('.single-image-option').on('click', function() {
-        _this.toggleImageView(_this.currentCanvasID);
+        _this.toggleImageView(_this.canvasID);
       });
 
       this.element.find('.book-option').on('click', function() {
-        _this.toggleBookView(_this.currentCanvasID);
+        _this.toggleBookView(_this.canvasID);
       });
 
       this.element.find('.scroll-option').on('click', function() {
-        _this.toggleScrollView(_this.currentCanvasID);
+        _this.toggleScrollView(_this.canvasID);
       });
 
       this.element.find('.thumbnails-option').on('click', function() {
-        _this.toggleThumbnails(_this.currentCanvasID);
+        _this.toggleThumbnails(_this.canvasID);
       });
 
       this.element.find('.mirador-icon-metadata-view').on('click', function() {
-        _this.toggleMetadataOverlay(_this.currentFocus);
+        _this.toggleMetadataOverlay(_this.viewType);
       });
 
       this.element.find('.mirador-icon-toc').on('click', function() {

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -5,17 +5,17 @@
     jQuery.extend(this, {
       element:           null,
       scrollImageRatio:  0.9,
-      manifest:          null,
+      //manifest:          null,
       canvasID:          null,
       focusImages:       [],
       imagesList:        null,
       annotationsList:   [],
       endpoint:          null,
-      slotAddress:       null,
+      //slotAddress:       null,
       currentImageMode:  'ImageView',
       imageModes:        ['ImageView', 'BookView'],
-      viewType:          'ThumbnailsView',
-      availableViews:    ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
+      //viewType:          'ThumbnailsView',
+      //availableViews:    ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
       focuses:           ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'],
       focusModules:           {'ThumbnailsView': null, 'ImageView': null, 'ScrollView': null, 'BookView': null},
       focusOverlaysAvailable: {
@@ -37,15 +37,15 @@
         }
       },
       windowOptions: null,
-      id : null,
+      //id : null,
       sidePanel: null, //the actual module for the side panel
-      sidePanelAvailable: true,
-      sidePanelOptions: {
-        "toc" : true,
-        "annotations" : false,
-        "layers" : false
-      },
-      sidePanelVisible: true,
+      //sidePanelAvailable: true,
+      // sidePanelOptions: {
+      //   "toc" : true,
+      //   "annotations" : false,
+      //   "layers" : false
+      // },
+      //sidePanelVisible: true,
       annotationsAvailable: {
         'ThumbnailsView' : false,
         'ImageView' : true,
@@ -53,23 +53,23 @@
         'BookView' : false
       },
       bottomPanel: null, //the actual module for the bottom panel
-      bottomPanelAvailable: true,
-      bottomPanelVisible: true,
+      //bottomPanelAvailable: true,
+      //bottomPanelVisible: true,
       overlay: null,
-      annotationLayer: true,
-      annotationCreation: true,
+      //annotationLayer: true,
+      //annotationCreation: true,
       annoEndpointAvailable : false,
-      annotationState : 'annoOff',
-      fullScreen : true,
-      displayLayout: true,
-      layoutOptions : {
-        "newObject" : true,
-        "close" : true,
-        "slotRight" : true,
-        "slotLeft" : true,
-        "slotAbove" : true,
-        "slotBelow" : true
-      },
+      //annotationState : 'annoOff',
+      //fullScreen : true,
+      //displayLayout: true,
+      // layoutOptions : {
+      //   "newObject" : true,
+      //   "close" : true,
+      //   "slotRight" : true,
+      //   "slotLeft" : true,
+      //   "slotAbove" : true,
+      //   "slotBelow" : true
+      // },
       iconClasses: {
         "ImageView" : "fa fa-photo fa-lg fa-fw",
         "BookView" : "fa fa-columns fa-lg fa-fw",

--- a/spec/workspaces/window.test.js
+++ b/spec/workspaces/window.test.js
@@ -21,35 +21,39 @@ describe('Window', function() {
         this.toggle = jasmine.createSpy();
         this.adjustHeight = jasmine.createSpy();
       });
-      this.window = new Mirador.Window({
-        state: new Mirador.SaveController(Mirador.DEFAULT_SETTINGS),
-        manifest: {
-          jsonLd: {
-            sequences: [
-              { viewingHint: 'paged',
-                canvases: [{
-                  '@id': ''
-                }]
-            }]
+      var state = new Mirador.SaveController(Mirador.DEFAULT_SETTINGS);
+      this.window = new Mirador.Window(jQuery.extend(true, 
+        {}, 
+        state.getStateProperty('windowSettings'),
+        {
+          state: state,
+          manifest: {
+            jsonLd: {
+              sequences: [
+                { viewingHint: 'paged',
+                  canvases: [{
+                    '@id': ''
+                  }]
+              }]
+            },
+            getCanvases: function() { return [{
+              '@id': '',
+              'images':[{
+              }]
+            }];
+            },
+            getAnnotationsListUrl: function() {
+              return false; // returning false for non-existent value is probably not a good practice?
+            },
+            getStructures: function() {
+              return [];
+            },
+            getVersion: function() {
+              return '1';
+            }
           },
-          getCanvases: function() { return [{
-            '@id': '',
-            'images':[{
-            }]
-          }];
-          },
-          getAnnotationsListUrl: function() {
-            return false; // returning false for non-existent value is probably not a good practice?
-          },
-          getStructures: function() {
-            return [];
-          },
-          getVersion: function() {
-            return '1';
-          }
-        },
-        appendTo: this.appendTo
-      });
+          appendTo: this.appendTo
+      }));
     });
 
     afterEach(function() {


### PR DESCRIPTION
closes #532 

A developer can now set global window settings that affect all windows in that instance of Mirador, and override them in specific windows.  Variable names used in settings.js now better aligns with variable names used in window.js