### PR TITLE
set fallbackLng to 'en' to avoid trying to load a 'dev' file.  Also s…

### DIFF
--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -48,7 +48,7 @@
       .css('background-repeat','repeat').css('position','fixed');
 
       //initialize i18next
-      i18n.init({debug: false, getAsync: false, resGetPath: _this.state.getStateProperty('buildPath') + _this.state.getStateProperty('i18nPath')+'__lng__/__ns__.json'});
+      i18n.init({fallbackLng: 'en', load: 'unspecific', debug: false, getAsync: false, resGetPath: _this.state.getStateProperty('buildPath') + _this.state.getStateProperty('i18nPath')+'__lng__/__ns__.json'});
 
       //register Handlebars helper
       Handlebars.registerHelper('t', function(i18n_key) {


### PR DESCRIPTION
…et it to always load the unspecific resource file (e.g. en instead of en-US) so it doesn't cause a 404 on missing files.  The downside is it won't load a specific resource file when it does exist, such as zh-CN. 

I think we can use this instead of #920 and determine a better fix for specific files after we upgrade to 2+ of i18next

closes #920 