### PR TITLE
manifest order

### DIFF
--- a/js/src/mirador.js
+++ b/js/src/mirador.js
@@ -1,5 +1,5 @@
 // This file defines the global Mirador constructor function.
-// This is the entry point to Miraodr and is intentionally sparse.
+// This is the entry point to Mirador and is intentionally sparse.
 (function(global) {
   function Mirador(config) {
     if (this instanceof Mirador) {

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -38,6 +38,9 @@
                                 //only valid if no windowObjects have been initialized
                                 //if there are multiple slots, it will be bound to the first slot and the selected manifest will open in that slot
 
+    // whether or not to preserve the order of the manifests, as provided in the configuration, in the manifest listing page
+    'preserveManifestOrder' : false,
+
     //default window settings, but can be changed in Mirador configuration on initialization
     'windowSettings' : {
       "availableViews" : ['ThumbnailsView', 'ImageView', 'ScrollView', 'BookView'], //any subset removes others

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -31,6 +31,7 @@
     },
 
     'manifests' : [],
+    'data' : [],
 
     'layout': '1x1',
 

--- a/js/src/utils/saveController.js
+++ b/js/src/utils/saveController.js
@@ -34,7 +34,7 @@
       
       this.eventEmitter = config.eventEmitter;
       
-      // Don't want to save session, therefore don't set up save controller
+      // Don't want to save session
       if (config.saveSession === false) {
         this.currentConfig = config;
         this.bindEvents();
@@ -129,6 +129,17 @@
 
     getStateProperty: function(prop) {
       return this.get(prop, 'currentConfig');
+    },
+
+    getManifestIndex: function(manifestUri) {
+      var manifestIndex = -1;
+      jQuery.each(this.currentConfig.data, function(index, dataObj) {
+        if (dataObj.manifestUri === manifestUri) {
+          manifestIndex = index;
+          return false;
+        }
+      });
+      return manifestIndex;
     },
 
     get: function(prop, parent) {

--- a/js/src/viewer/manifestListItem.js
+++ b/js/src/viewer/manifestListItem.js
@@ -45,7 +45,28 @@
       });
 
       this.fetchTplData(this.manifestId);
-      this.element = jQuery(this.template(this.tplData)).prependTo(this.appendTo).hide().fadeIn('slow');
+      
+      if (_this.state.getStateProperty('preserveManifestOrder')) {
+        if (this.appendTo.children().length === 0) {
+          this.element = jQuery(this.template(this.tplData)).prependTo(this.appendTo).hide().fadeIn('slow');          
+        } else {
+          var liList = _this.appendTo.find('li');
+          jQuery.each(liList, function(index, item) {
+              var prev = parseFloat(jQuery(item).attr('data-index-number'));
+              var next = parseFloat(jQuery(liList[index+1]).attr('data-index-number'));
+              var current = _this.tplData.index;
+              if (current <= prev && (next > current || isNaN(next)) ) {
+                _this.element = jQuery(_this.template(_this.tplData)).insertBefore(jQuery(item)).hide().fadeIn('slow');
+                return false;
+              } else if (current > prev && (current < next || isNaN(next))) {                
+                _this.element = jQuery(_this.template(_this.tplData)).insertAfter(jQuery(item)).hide().fadeIn('slow');
+                return false;
+              }
+          });
+        }
+      } else {
+        this.element = jQuery(this.template(this.tplData)).prependTo(this.appendTo).hide().fadeIn('slow');
+      }
 
       this.bindEvents();
       this.listenForActions();
@@ -60,7 +81,8 @@
         label: $.JsonLd.getTextValue(manifest.label),
         repository: location,
         canvasCount: manifest.sequences[0].canvases.length,
-        images: []
+        images: [],
+        index: _this.state.getManifestIndex(manifest['@id'])
       };
 
       this.tplData.repoImage = (function() {
@@ -220,7 +242,7 @@
     },
 
     template: Handlebars.compile([
-      '<li>',
+      '<li data-index-number={{index}}>',
       '<div class="repo-image">',
         '<img src="{{repoImage}}" alt="repoImg">',
       '</div>',

--- a/spec/viewer/manifestListItem.test.js
+++ b/spec/viewer/manifestListItem.test.js
@@ -1,4 +1,39 @@
 describe('ManifestListItem', function () {
+
+  beforeEach(function() {
+    this.eventEmitter = new Mirador.EventEmitter();
+    jasmine.getJSONFixtures().fixturesPath = 'spec/fixtures';
+    this.dummyManifestContent = getJSONFixture('dummyManifest.json');
+    this.manifest = new Mirador.Manifest(null, 'Dummy Location', this.dummyManifestContent);
+    this.appendTo = jQuery('<ul>'+
+      '<li data-index-number="1"></li>'+
+      '<li data-index-number="5"></li>'+
+      '<li data-index-number="8"></li>'+
+      '<li data-index-number="13"></li>'+
+      '<li data-index-number="14"></li>'+
+      '<li data-index-number="16"></li>'+
+      '</ul>');
+  });
+
+  it('insert index 2', function() {
+    var listItem = new Mirador.ManifestListItem({
+      appendTo: this.appendTo,
+      state: new Mirador.SaveController({
+        eventEmitter:this.eventEmitter, 
+        preserveManifestOrder: true,
+        data: [
+          { "manifestUri": "http://www.example.org/iiif/book2/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book3/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book1/manifest"}
+        ]
+      }),
+      eventEmitter: this.eventEmitter,
+      resultsWidth: 500,
+      manifest: this.manifest
+    });
+
+    expect(this.appendTo).toBe('<ul><li data-index-number="1"></li><li data-index-number="2" style="display: list-item; opacity: 0; "><div class="repo-image"><img src="build/mirador/images/logos/iiif_logo.png" alt="repoImg"></div><div class="select-metadata"><div class="manifest-title"><h3 title="Dummy Manifest">Dummy Manifest</h3></div><div class="item-info"><div class="item-info-row"><div class="repo-label">Dummy Location</div><div class="canvas-count">1 </div></div></div></div><div class="preview-images"></div><i class="fa fa fa-ellipsis-h remaining"></i></li><li data-index-number="5"></li><li data-index-number="8"></li><li data-index-number="13"></li><li data-index-number="14"></li><li data-index-number="16"></li></ul>');
+  });
   xit('fetchTplData', function () {
   });
   xit('render', function () {

--- a/spec/viewer/manifestListItem.test.js
+++ b/spec/viewer/manifestListItem.test.js
@@ -32,7 +32,20 @@ describe('ManifestListItem', function () {
       manifest: this.manifest
     });
 
-    expect(this.appendTo).toBe('<ul><li data-index-number="1"></li><li data-index-number="2" style="display: list-item; opacity: 0; "><div class="repo-image"><img src="build/mirador/images/logos/iiif_logo.png" alt="repoImg"></div><div class="select-metadata"><div class="manifest-title"><h3 title="Dummy Manifest">Dummy Manifest</h3></div><div class="item-info"><div class="item-info-row"><div class="repo-label">Dummy Location</div><div class="canvas-count">1 </div></div></div></div><div class="preview-images"></div><i class="fa fa fa-ellipsis-h remaining"></i></li><li data-index-number="5"></li><li data-index-number="8"></li><li data-index-number="13"></li><li data-index-number="14"></li><li data-index-number="16"></li></ul>');
+    var expectedHTML = '<ul>'+
+    '<li data-index-number="1"></li>'+
+    '<li data-index-number="2" style="display: list-item; opacity: 0; ">'+
+    '<div class="repo-image"><img src="build/mirador/images/logos/iiif_logo.png" alt="repoImg"></div>'+
+    '<div class="select-metadata"><div class="manifest-title"><h3 title="Dummy Manifest">Dummy Manifest</h3></div>'+
+    '<div class="item-info"><div class="item-info-row"><div class="repo-label">Dummy Location</div>'+
+    '<div class="canvas-count">1 </div></div></div></div><div class="preview-images"></div><i class="fa fa fa-ellipsis-h remaining"></i></li>'+
+    '<li data-index-number="5"></li>'+
+    '<li data-index-number="8"></li>'+
+    '<li data-index-number="13"></li>'+
+    '<li data-index-number="14"></li>'+
+    '<li data-index-number="16"></li></ul>';
+
+    expect(this.appendTo[0].outerHTML).toBe(expectedHTML);
   });
   xit('fetchTplData', function () {
   });

--- a/spec/viewer/manifestListItem.test.js
+++ b/spec/viewer/manifestListItem.test.js
@@ -6,6 +6,7 @@ describe('ManifestListItem', function () {
     this.dummyManifestContent = getJSONFixture('dummyManifest.json');
     this.manifest = new Mirador.Manifest(null, 'Dummy Location', this.dummyManifestContent);
     this.appendTo = jQuery('<ul>'+
+      '<li data-index-number="-1"></li>'+
       '<li data-index-number="1"></li>'+
       '<li data-index-number="5"></li>'+
       '<li data-index-number="8"></li>'+
@@ -13,6 +14,40 @@ describe('ManifestListItem', function () {
       '<li data-index-number="14"></li>'+
       '<li data-index-number="16"></li>'+
       '</ul>');
+  });
+
+  it('insert index 0', function() {
+    var listItem = new Mirador.ManifestListItem({
+      appendTo: this.appendTo,
+      state: new Mirador.SaveController({
+        eventEmitter:this.eventEmitter, 
+        preserveManifestOrder: true,
+        data: [
+          { "manifestUri": "http://www.example.org/iiif/book1/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book2/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book3/manifest"}
+        ]
+      }),
+      eventEmitter: this.eventEmitter,
+      resultsWidth: 500,
+      manifest: this.manifest
+    });
+
+    var expectedHTML = '<ul>'+
+    '<li data-index-number="-1"></li>'+
+    '<li data-index-number="0" style="display: list-item; opacity: 0; ">'+
+    '<div class="repo-image"><img src="build/mirador/images/logos/iiif_logo.png" alt="repoImg"></div>'+
+    '<div class="select-metadata"><div class="manifest-title"><h3 title="Dummy Manifest">Dummy Manifest</h3></div>'+
+    '<div class="item-info"><div class="item-info-row"><div class="repo-label">Dummy Location</div>'+
+    '<div class="canvas-count">1 </div></div></div></div><div class="preview-images"></div><i class="fa fa fa-ellipsis-h remaining"></i></li>'+
+    '<li data-index-number="1"></li>'+
+    '<li data-index-number="5"></li>'+
+    '<li data-index-number="8"></li>'+
+    '<li data-index-number="13"></li>'+
+    '<li data-index-number="14"></li>'+
+    '<li data-index-number="16"></li></ul>';
+
+    expect(this.appendTo[0].outerHTML).toBe(expectedHTML);
   });
 
   it('insert index 2', function() {
@@ -33,6 +68,7 @@ describe('ManifestListItem', function () {
     });
 
     var expectedHTML = '<ul>'+
+    '<li data-index-number="-1"></li>'+
     '<li data-index-number="1"></li>'+
     '<li data-index-number="2" style="display: list-item; opacity: 0; ">'+
     '<div class="repo-image"><img src="build/mirador/images/logos/iiif_logo.png" alt="repoImg"></div>'+
@@ -47,6 +83,129 @@ describe('ManifestListItem', function () {
 
     expect(this.appendTo[0].outerHTML).toBe(expectedHTML);
   });
+
+  it('insert index 6', function() {
+    var listItem = new Mirador.ManifestListItem({
+      appendTo: this.appendTo,
+      state: new Mirador.SaveController({
+        eventEmitter:this.eventEmitter, 
+        preserveManifestOrder: true,
+        data: [
+          { "manifestUri": "http://www.example.org/iiif/book2/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book3/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book4/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book5/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book6/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book7/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book1/manifest"}
+        ]
+      }),
+      eventEmitter: this.eventEmitter,
+      resultsWidth: 500,
+      manifest: this.manifest
+    });
+
+    var expectedHTML = '<ul>'+
+    '<li data-index-number="-1"></li>'+
+    '<li data-index-number="1"></li>'+
+    '<li data-index-number="5"></li>'+
+    '<li data-index-number="6" style="display: list-item; opacity: 0; ">'+
+    '<div class="repo-image"><img src="build/mirador/images/logos/iiif_logo.png" alt="repoImg"></div>'+
+    '<div class="select-metadata"><div class="manifest-title"><h3 title="Dummy Manifest">Dummy Manifest</h3></div>'+
+    '<div class="item-info"><div class="item-info-row"><div class="repo-label">Dummy Location</div>'+
+    '<div class="canvas-count">1 </div></div></div></div><div class="preview-images"></div><i class="fa fa fa-ellipsis-h remaining"></i></li>'+    
+    '<li data-index-number="8"></li>'+
+    '<li data-index-number="13"></li>'+
+    '<li data-index-number="14"></li>'+
+    '<li data-index-number="16"></li></ul>';
+
+    expect(this.appendTo[0].outerHTML).toBe(expectedHTML);
+  });
+
+  it('insert index 17', function() {
+    var listItem = new Mirador.ManifestListItem({
+      appendTo: this.appendTo,
+      state: new Mirador.SaveController({
+        eventEmitter:this.eventEmitter, 
+        preserveManifestOrder: true,
+        data: [
+          { "manifestUri": "http://www.example.org/iiif/book2/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book3/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book4/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book5/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book6/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book7/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book8/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book9/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book10/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book11/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book12/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book13/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book14/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book15/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book16/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book17/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book18/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book1/manifest"}
+        ]
+      }),
+      eventEmitter: this.eventEmitter,
+      resultsWidth: 500,
+      manifest: this.manifest
+    });
+
+    var expectedHTML = '<ul>'+
+    '<li data-index-number="-1"></li>'+
+    '<li data-index-number="1"></li>'+
+    '<li data-index-number="5"></li>'+
+    '<li data-index-number="8"></li>'+
+    '<li data-index-number="13"></li>'+
+    '<li data-index-number="14"></li>'+
+    '<li data-index-number="16"></li>'+
+    '<li data-index-number="17" style="display: list-item; opacity: 0; ">'+
+    '<div class="repo-image"><img src="build/mirador/images/logos/iiif_logo.png" alt="repoImg"></div>'+
+    '<div class="select-metadata"><div class="manifest-title"><h3 title="Dummy Manifest">Dummy Manifest</h3></div>'+
+    '<div class="item-info"><div class="item-info-row"><div class="repo-label">Dummy Location</div>'+
+    '<div class="canvas-count">1 </div></div></div></div><div class="preview-images"></div><i class="fa fa fa-ellipsis-h remaining"></i></li>'+
+    '</ul>';
+
+    expect(this.appendTo[0].outerHTML).toBe(expectedHTML);
+  });
+
+  it('insert another at index -1', function() {
+    var listItem = new Mirador.ManifestListItem({
+      appendTo: this.appendTo,
+      state: new Mirador.SaveController({
+        eventEmitter:this.eventEmitter, 
+        preserveManifestOrder: true,
+        data: [
+          { "manifestUri": "http://www.example.org/iiif/book2/manifest"},
+          { "manifestUri": "http://www.example.org/iiif/book3/manifest"}
+        ]
+      }),
+      eventEmitter: this.eventEmitter,
+      resultsWidth: 500,
+      manifest: this.manifest
+    });
+
+    var expectedHTML = '<ul>'+
+    '<li data-index-number="-1" style="display: list-item; opacity: 0; ">'+
+    '<div class="repo-image"><img src="build/mirador/images/logos/iiif_logo.png" alt="repoImg"></div>'+
+    '<div class="select-metadata"><div class="manifest-title"><h3 title="Dummy Manifest">Dummy Manifest</h3></div>'+
+    '<div class="item-info"><div class="item-info-row"><div class="repo-label">Dummy Location</div>'+
+    '<div class="canvas-count">1 </div></div></div></div><div class="preview-images"></div><i class="fa fa fa-ellipsis-h remaining"></i></li>'+
+    '<li data-index-number="-1"></li>'+
+    '<li data-index-number="1"></li>'+
+    '<li data-index-number="5"></li>'+
+    '<li data-index-number="8"></li>'+
+    '<li data-index-number="13"></li>'+
+    '<li data-index-number="14"></li>'+
+    '<li data-index-number="16"></li>'+
+    '</ul>';
+
+    expect(this.appendTo[0].outerHTML).toBe(expectedHTML);
+  });
+
   xit('fetchTplData', function () {
   });
   xit('render', function () {


### PR DESCRIPTION
closes #570 

Added `preserveManifestOrder` setting to determine whether or not to display the manifests in a particular order. By default, Mirador does the original behavior - displaying items in the manifest page as they resolve, because `preserveManifestOrder` is set to `false`.  If set to `true` the code attempts to determine the index value for that manifest and insert it properly according to the other manifests that have already been added to that page. If the index value for a manifest is not available for some reason (i.e. added by URL or the URI in the `data` array does not match the URI in the manifest itself), default to adding them to the top, as Mirador typically adds them.