### PR TITLE
Bug-fixes & functionality that replaces comment popup&tooltips

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1171,6 +1171,68 @@ li.highlight {
 /* color picker custom style
 ---------------------------------------------------------------------------- */
 
+.draw-tool * {
+  text-shadow: none !important;
+}
+
+.draw-tool>i {
+  text-shadow: 0 0 5px black !important;
+}
+
+.draw-tool .sp-replacer {
+  vertical-align: top;
+  margin-top: 2px;
+  height: 14px !important;
+}
+
+.mirador-line-type:hover {
+  border-color: #F0C49B;
+  color: #111;
+  transition: all 0.3s ease;
+  opacity: 1;
+}
+
+.mirador-line-type {
+  border-radius: 5px !important;
+  padding: 0px !important;
+  height: 22px !important;
+  width: 67px !important;
+  opacity: 0.6;
+  border: 1px solid #91765d;
+  background: white none repeat scroll 0 0;
+  margin: 2px 10px 0px 0px !important;
+}
+
+.mirador-line-type ul {
+  color: #333333;
+  margin-top: 0px !important;
+}
+
+.mirador-line-type li {
+  text-shadow: none !important;
+  font-size: 10px !important;
+}
+
+.mirador-line-type>span {
+  color: black;
+  float: right;
+  margin-right: 5px;
+}
+
+.mirador-line-type>i {
+  vertical-align: top;
+  width: 30px !important;
+  margin: 4px 0px 0px 4px !important;
+}
+
+.mirador-line-type i {
+  color: #333333;
+  width: 45px;
+  height: 10px;
+  font-size: 15px !important;
+  background-repeat: no-repeat;
+}
+
 .sp-button-container a {
   color: #555555 !important;
   text-shadow: none !important;
@@ -1181,6 +1243,8 @@ li.highlight {
 
 .borderColorPicker + div + .sp-container, .fillColorPicker + div + .sp-container {
   width: 300px !important;
+  border-width: 0px !important;
+  opacity: 0.9;
 }
 
 .borderColorPicker + div .sp-preview, .fillColorPicker + div .sp-preview {

--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -184,6 +184,10 @@
           }
         }
       }
+      if (_this.svgOverlay.availableExternalCommentsPanel) {
+        _this.eventEmitter.publish('annotationMousePosition.' + _this.parent.windowId, [annotations]);
+        return;
+      }
       _this.annoTooltip.showViewer({
         annotations: annotations,
         triggerEvent: event,

--- a/js/src/annotations/osd-svg-ellipse.js
+++ b/js/src/annotations/osd-svg-ellipse.js
@@ -38,6 +38,7 @@
         segments: segments,
         name: overlay.getName(_this)
       });
+      shape.dashArray = overlay.dashArray;
       shape.strokeWidth = 1 / overlay.paperScope.view.zoom;
       shape.strokeColor = overlay.strokeColor;
       shape.fillColor = overlay.fillColor;

--- a/js/src/annotations/osd-svg-freehand.js
+++ b/js/src/annotations/osd-svg-freehand.js
@@ -18,6 +18,7 @@
       var _this = this;
       var shape = new overlay.paperScope.Path({
         segments: [initialPoint],
+        dashArray: overlay.dashArray,
         strokeWidth: 1 / overlay.paperScope.view.zoom,
         strokeColor: overlay.strokeColor,
         fullySelected: true,

--- a/js/src/annotations/osd-svg-pin.js
+++ b/js/src/annotations/osd-svg-pin.js
@@ -17,7 +17,7 @@
       overlay.mode = 'create';
       var _this = this;
       var pathData = '';
-      var size = overlay.pinSize;
+      var size = overlay.fixedShapeSize;
       pathData += 'M' + initialPoint.x + ',' + initialPoint.y;
       pathData += ' Q' + initialPoint.x + ',' + (initialPoint.y - size);
       pathData += ' ' + (initialPoint.x + size) + ',' + (initialPoint.y - 2 * size);
@@ -27,13 +27,14 @@
       pathData += ' ' + initialPoint.x + ',' + initialPoint.y;
       var shape = new overlay.paperScope.Path(pathData);
       shape.name = overlay.getName(_this);
+      shape.dashArray = overlay.dashArray;
       shape.strokeWidth = 1 / overlay.paperScope.view.zoom;
       shape.strokeColor = overlay.strokeColor;
       shape.fillColor = overlay.fillColor;
       shape.fillColor.alpha = overlay.fillColorAlpha;
       shape.fullySelected = true;
       shape.closed = true;
-      overlay.fitPinSize(shape);
+      overlay.fitFixedSizeShapes(shape);
       return shape;
     },
 

--- a/js/src/annotations/osd-svg-polygon.js
+++ b/js/src/annotations/osd-svg-polygon.js
@@ -18,6 +18,7 @@
       var _this = this;
       var shape = new overlay.paperScope.Path({
         segments: [initialPoint],
+        dashArray: overlay.dashArray,
         strokeWidth: 1 / overlay.paperScope.view.zoom,
         strokeColor: overlay.strokeColor,
         fullySelected: true,

--- a/js/src/annotations/osd-svg-rectangle.js
+++ b/js/src/annotations/osd-svg-rectangle.js
@@ -37,6 +37,7 @@
         fullySelected: true,
         name: overlay.getName(_this)
       });
+      shape.dashArray = overlay.dashArray;
       shape.strokeWidth = 1 / overlay.paperScope.view.zoom;
       shape.strokeColor = overlay.strokeColor;
       shape.fillColor = overlay.fillColor;

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -101,11 +101,18 @@
     ],
 
     'drawingToolsSettings': {
+      // Additional tool settings.
+      /**
+       *'Pin': {
+       *},
+       **/
       'doubleClickReactionTime': 300,
       'strokeColor': 'deepSkyBlue',
       'fillColor': 'deepSkyBlue',
       'fillColorAlpha': 0.0
     },
+
+    'availableExternalCommentsPanel': false,
 
     'availableCanvasTools': [
 

--- a/js/src/widgets/imageView.js
+++ b/js/src/widgets/imageView.js
@@ -53,7 +53,7 @@
       this.createOpenSeadragonInstance($.Iiif.getImageUrl(this.currentImg));
       _this.eventEmitter.publish('UPDATE_FOCUS_IMAGES.' + this.windowId, {array: [this.canvasID]});
 
-      var allTools = $.getTools();
+      var allTools = $.getTools(this.state.getStateProperty('drawingToolsSettings'));
       this.availableTools = [];
       for ( var i = 0; i < this.state.getStateProperty('availableAnnotationDrawingTools').length; i++) {
         for ( var j = 0; j < allTools.length; j++) {

--- a/spec/annotations/osd-svg-overlay.test.js
+++ b/spec/annotations/osd-svg-overlay.test.js
@@ -66,8 +66,11 @@ describe('Overlay', function() {
         'pixelFromPoint': function(point, current) {
           return point;
         },
-        getBounds: function() {
-          return {x:0, y:0, width:10, height: 10};
+        'getBounds': function(current) {
+          return {
+            'x': 800,
+            'y': 600
+          };
         },
         'containerSize': {
           'x': 800,
@@ -88,6 +91,27 @@ describe('Overlay', function() {
       'fillColorAlpha': 0.0
     };
     var state = new Mirador.SaveController({eventEmitter: this.eventEmitter});
+    /*
+    
+    TODO RADOSLAV
+     getStateProperty: function(key) {
+     if (key === 'drawingToolsSettings') {
+     return {
+     'doubleClickReactionTime': 300,
+     'strokeColor': 'deepSkyBlue',
+     'fillColor': 'deepSkyBlue',
+     'fillColorAlpha': 0.0
+     };
+     }
+     if (key === 'availableAnnotationDrawingTools') {
+     return [];
+     }
+     if (key === 'availableExternalCommentsPanel') {
+     return false;
+     }
+     return null;
+     }
+     */
     this.overlay = new Mirador.Overlay(this.viewerMock, this.windowObjMock.viewer.id, this.windowObjMock.windowId, state, this.eventEmitter);
   });
 

--- a/spec/annotations/osd-svg-pin.test.js
+++ b/spec/annotations/osd-svg-pin.test.js
@@ -20,14 +20,14 @@ describe('Pin', function() {
       'mode': mode,
       'path': path,
       'segment': segment,
-      'pinSize': 5,
+      'fixedShapeSize': 5,
       'hitOptions': {
         'fill': true,
         'stroke': true,
         'segments': true,
         'tolerance': 0
       },
-      'fitPinSize': function() {
+      'fitFixedSizeShapes': function() {
       },
       onDrawFinish: function() {
       },


### PR DESCRIPTION
Bug-fixes & functionality that replaces Mirador comment popup and tooltips with external ones

Functionality that replaces Mirador comment popup and tooltips and notifies external applications
Bug-fix: change implementation of resize function because latest merges assosiated with image coordinates doesn't work fine. It can be reproduced with the only image from http://oculus-dev.harvardx.harvard.edu/manifests/drs:48309543
#764
Bug-fix: in-manifest annotations not being aligned properly with canvas
#918