### PR TITLE
Fix for #955: Ability to drag and drop direct manifest URLs

### DIFF
--- a/js/src/utils/utils.js
+++ b/js/src/utils/utils.js
@@ -64,6 +64,9 @@
     var assoc  = {};
     var decode = function (s) { return decodeURIComponent(s.replace(/\+/g, " ")); };
     var queryString = url.split('?')[1];
+    if (typeof queryString === "undefined") {
+      return {};
+    }
     var keyValues = queryString.split('&');
 
     for(var i in keyValues) {

--- a/js/src/workspaces/slot.js
+++ b/js/src/workspaces/slot.js
@@ -148,7 +148,7 @@
         var _this = this;
 
         url = url || text_url;
-        var manifestUrl = $.getQueryParams(url).manifest,
+        var manifestUrl = $.getQueryParams(url).manifest || url,
             canvasId = $.getQueryParams(url).canvas,
             imageInfoUrl = $.getQueryParams(url).image,
             windowConfig;

--- a/spec/utils/utils.test.js
+++ b/spec/utils/utils.test.js
@@ -127,5 +127,9 @@ describe('Utils', function() {
       expect(queryParams.manifest).toBe("http://www.e-codices.unifr.ch/metadata/iiif/kba-0003/manifest.json");
       expect(queryParams.canvas).toBe("http://www.e-codices.unifr.ch/metadata/iiif/kba-0003/canvas/kba-0003_002r.json");
     });
+    it('should properly parse a url without query parameters', function() {
+      var queryParams = this.utils.getQueryParams('http://www.google.com');
+      expect(queryParams).toEqual({});
+    });
   });
 });


### PR DESCRIPTION
Links to manifest URLs can now be directly dropped into empty Mirador slots without errors.

See: #955 