### PR TITLE
Marking all annotation's shapes as 'active' when hovering one of them

### DIFF
--- a/js/lib/paper-full.min.js
+++ b/js/lib/paper-full.min.js
@@ -2,20 +2,20 @@
  * Paper.js v0.9.25 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
  *
- * Copyright (c) 2011 - 2014, Juerg Lehni & Jonathan Puckey
+ * Copyright (c) 2011 - 2016, Juerg Lehni & Jonathan Puckey
  * http://scratchdisk.com/ & http://jonathanpuckey.com/
  *
  * Distributed under the MIT license. See LICENSE file for details.
  *
  * All rights reserved.
  *
- * Date: Sun Oct 25 11:23:38 2015 +0100
+ * Date: Sat Jan 16 16:51:47 2016 +0100
  *
  ***
  *
  * Straps.js - Class inheritance library with support for bean-style accessors
  *
- * Copyright (c) 2006 - 2013 Juerg Lehni
+ * Copyright (c) 2006 - 2016 Juerg Lehni
  * http://scratchdisk.com/
  *
  * Distributed under the MIT license.
@@ -29,10 +29,13902 @@
  * created by Marijn Haverbeke and released under an MIT license.
  *
  */
-var paper=new function(t){var e=new function(){function n(t,n,i,r,a){function o(s,o){o=o||(o=u(n,s))&&(o.get?o:o.value),"string"==typeof o&&"#"===o[0]&&(o=t[o.substring(1)]||o);var l,d="function"==typeof o,f=o,g=a||d&&!o.base?o&&o.get?s in t:t[s]:null;a&&g||(d&&g&&(o.base=g),d&&r!==!1&&(l=s.match(/^([gs]et|is)(([A-Z])(.*))$/))&&(h[l[3].toLowerCase()+l[4]]=l[2]),f&&!d&&f.get&&"function"==typeof f.get&&e.isPlainObject(f)||(f={value:f,writable:!0}),(u(t,s)||{configurable:!0}).configurable&&(f.configurable=!0,f.enumerable=i),c(t,s,f))}var h={};if(n){for(var l in n)n.hasOwnProperty(l)&&!s.test(l)&&o(l);for(var l in h){var d=h[l],f=t["set"+d],g=t["get"+d]||f&&t["is"+d];!g||r!==!0&&0!==g.length||o(l,{get:g,set:f})}}return t}function i(t,e,n){return t&&("length"in t&&!t.getLength&&"number"==typeof t.length?a:o).call(t,e,n=n||t),n}function r(t,e,n){for(var i in e)!e.hasOwnProperty(i)||n&&n[i]||(t[i]=e[i]);return t}var s=/^(statics|enumerable|beans|preserve)$/,a=[].forEach||function(t,e){for(var n=0,i=this.length;i>n;n++)t.call(e,this[n],n,this)},o=function(t,e){for(var n in this)this.hasOwnProperty(n)&&t.call(e,this[n],n,this)},h=Object.create||function(t){return{__proto__:t}},u=Object.getOwnPropertyDescriptor||function(t,e){var n=t.__lookupGetter__&&t.__lookupGetter__(e);return n?{get:n,set:t.__lookupSetter__(e),enumerable:!0,configurable:!0}:t.hasOwnProperty(e)?{value:t[e],enumerable:!0,configurable:!0,writable:!0}:null},l=Object.defineProperty||function(t,e,n){return(n.get||n.set)&&t.__defineGetter__?(n.get&&t.__defineGetter__(e,n.get),n.set&&t.__defineSetter__(e,n.set)):t[e]=n.value,t},c=function(t,e,n){return delete t[e],l(t,e,n)};return n(function(){for(var t=0,e=arguments.length;e>t;t++)r(this,arguments[t])},{inject:function(t){if(t){var e=t.statics===!0?t:t.statics,i=t.beans,r=t.preserve;e!==t&&n(this.prototype,t,t.enumerable,i,r),n(this,e,!0,i,r)}for(var s=1,a=arguments.length;a>s;s++)this.inject(arguments[s]);return this},extend:function(){for(var t,e,i=this,r=0,s=arguments.length;s>r&&!(t=arguments[r].initialize);r++);return t=t||function(){i.apply(this,arguments)},e=t.prototype=h(this.prototype),c(e,"constructor",{value:t,writable:!0,configurable:!0}),n(t,this,!0),arguments.length&&this.inject.apply(t,arguments),t.base=i,t}},!0).inject({inject:function(){for(var t=0,e=arguments.length;e>t;t++){var i=arguments[t];i&&n(this,i,i.enumerable,i.beans,i.preserve)}return this},extend:function(){var t=h(this);return t.inject.apply(t,arguments)},each:function(t,e){return i(this,t,e)},set:function(t){return r(this,t)},clone:function(){return new this.constructor(this)},statics:{each:i,create:h,define:c,describe:u,set:r,clone:function(t){return r(new t.constructor,t)},isPlainObject:function(t){var n=null!=t&&t.constructor;return n&&(n===Object||n===e||"Object"===n.name)},pick:function(e,n){return e!==t?e:n}}})};"undefined"!=typeof module&&(module.exports=e),e.inject({toString:function(){return null!=this._id?(this._class||"Object")+(this._name?" '"+this._name+"'":" @"+this._id):"{ "+e.each(this,function(t,e){if(!/^_/.test(e)){var n=typeof t;this.push(e+": "+("number"===n?s.instance.number(t):"string"===n?"'"+t+"'":t))}},[]).join(", ")+" }"},getClassName:function(){return this._class||""},exportJSON:function(t){return e.exportJSON(this,t)},toJSON:function(){return e.serialize(this)},_set:function(n,i,r){if(n&&(r||e.isPlainObject(n))){for(var s=Object.keys(n._filtering||n),a=0,o=s.length;o>a;a++){var h=s[a];if(!i||!i[h]){var u=n[h];u!==t&&(this[h]=u)}}return!0}},statics:{exports:{enumerable:!0},extend:function et(){var t=et.base.apply(this,arguments),n=t.prototype._class;return n&&!e.exports[n]&&(e.exports[n]=t),t},equals:function(t,n){if(t===n)return!0;if(t&&t.equals)return t.equals(n);if(n&&n.equals)return n.equals(t);if(t&&n&&"object"==typeof t&&"object"==typeof n){if(Array.isArray(t)&&Array.isArray(n)){var i=t.length;if(i!==n.length)return!1;for(;i--;)if(!e.equals(t[i],n[i]))return!1}else{var r=Object.keys(t),i=r.length;if(i!==Object.keys(n).length)return!1;for(;i--;){var s=r[i];if(!n.hasOwnProperty(s)||!e.equals(t[s],n[s]))return!1}}return!0}return!1},read:function(n,i,r,s){if(this===e){var a=this.peek(n,i);return n.__index++,a}var o=this.prototype,h=o._readIndex,u=i||h&&n.__index||0;s||(s=n.length-u);var l=n[u];return l instanceof this||r&&r.readNull&&null==l&&1>=s?(h&&(n.__index=u+1),l&&r&&r.clone?l.clone():l):(l=e.create(this.prototype),h&&(l.__read=!0),l=l.initialize.apply(l,u>0||s<n.length?Array.prototype.slice.call(n,u,u+s):n)||l,h&&(n.__index=u+l.__read,l.__read=t),l)},peek:function(t,e){return t[t.__index=e||t.__index||0]},remain:function(t){return t.length-(t.__index||0)},readAll:function(t,e,n){for(var i,r=[],s=e||0,a=t.length;a>s;s++)r.push(Array.isArray(i=t[s])?this.read(i,0,n):this.read(t,s,n,1));return r},readNamed:function(n,i,r,s,a){var o=this.getNamed(n,i),h=o!==t;if(h){var u=n._filtered;u||(u=n._filtered=e.create(n[0]),u._filtering=n[0]),u[i]=t}return this.read(h?[o]:n,r,s,a)},getNamed:function(n,i){var r=n[0];return n._hasObject===t&&(n._hasObject=1===n.length&&e.isPlainObject(r)),n._hasObject?i?r[i]:n._filtered||r:t},hasNamed:function(t,e){return!!this.getNamed(t,e)},isPlainValue:function(t,e){return this.isPlainObject(t)||Array.isArray(t)||e&&"string"==typeof t},serialize:function(t,n,i,r){n=n||{};var a,o=!r;if(o&&(n.formatter=new s(n.precision),r={length:0,definitions:{},references:{},add:function(t,e){var n="#"+t._id,i=this.references[n];if(!i){this.length++;var r=e.call(t),s=t._class;s&&r[0]!==s&&r.unshift(s),this.definitions[n]=r,i=this.references[n]=[n]}return i}}),t&&t._serialize){a=t._serialize(n,r);var h=t._class;!h||i||a._compact||a[0]===h||a.unshift(h)}else if(Array.isArray(t)){a=[];for(var u=0,l=t.length;l>u;u++)a[u]=e.serialize(t[u],n,i,r);i&&(a._compact=!0)}else if(e.isPlainObject(t)){a={};for(var c=Object.keys(t),u=0,l=c.length;l>u;u++){var d=c[u];a[d]=e.serialize(t[d],n,i,r)}}else a="number"==typeof t?n.formatter.number(t,n.precision):t;return o&&r.length>0?[["dictionary",r.definitions],a]:a},deserialize:function(t,n,i,r){var s=t,a=!i;if(i=i||{},Array.isArray(t)){var o=t[0],h="dictionary"===o;if(1==t.length&&/^#/.test(o))return i.dictionary[o];o=e.exports[o],s=[],r&&(i.dictionary=s);for(var u=o?1:0,l=t.length;l>u;u++)s.push(e.deserialize(t[u],n,i,h));if(o){var c=s;n?s=n(o,c):(s=e.create(o.prototype),o.apply(s,c))}}else if(e.isPlainObject(t)){s={},r&&(i.dictionary=s);for(var d in t)s[d]=e.deserialize(t[d],n,i)}return a&&t&&t.length&&"dictionary"===t[0][0]?s[1]:s},exportJSON:function(t,n){var i=e.serialize(t,n);return n&&n.asString===!1?i:JSON.stringify(i)},importJSON:function(t,n){return e.deserialize("string"==typeof t?JSON.parse(t):t,function(t,i){var r=n&&n.constructor===t?n:e.create(t.prototype),s=r===n;if(1===i.length&&r instanceof m&&(s||!(r instanceof w))){var a=i[0];e.isPlainObject(a)&&(a.insert=!1)}return t.apply(r,i),s&&(n=null),r})},splice:function(e,n,i,r){var s=n&&n.length,a=i===t;i=a?e.length:i,i>e.length&&(i=e.length);for(var o=0;s>o;o++)n[o]._index=i+o;if(a)return e.push.apply(e,n),[];var h=[i,r];n&&h.push.apply(h,n);for(var u=e.splice.apply(e,h),o=0,l=u.length;l>o;o++)u[o]._index=t;for(var o=i+s,l=e.length;l>o;o++)e[o]._index=o;return u},capitalize:function(t){return t.replace(/\b[a-z]/g,function(t){return t.toUpperCase()})},camelize:function(t){return t.replace(/-(.)/g,function(t,e){return e.toUpperCase()})},hyphenate:function(t){return t.replace(/([a-z])([A-Z])/g,"$1-$2").toLowerCase()}}});var n={on:function(t,n){if("string"!=typeof t)e.each(t,function(t,e){this.on(e,t)},this);else{var i=this._eventTypes,r=i&&i[t],s=this._callbacks=this._callbacks||{};s=s[t]=s[t]||[],-1===s.indexOf(n)&&(s.push(n),r&&r.install&&1===s.length&&r.install.call(this,t))}return this},off:function(n,i){if("string"!=typeof n)return e.each(n,function(t,e){this.off(e,t)},this),t;var r,s=this._eventTypes,a=s&&s[n],o=this._callbacks&&this._callbacks[n];return o&&(!i||-1!==(r=o.indexOf(i))&&1===o.length?(a&&a.uninstall&&a.uninstall.call(this,n),delete this._callbacks[n]):-1!==r&&o.splice(r,1)),this},once:function(t,e){return this.on(t,function(){e.apply(this,arguments),this.off(t,e)})},emit:function(t,e){var n=this._callbacks&&this._callbacks[t];if(!n)return!1;var i=[].slice.call(arguments,1);n=n.slice();for(var r=0,s=n.length;s>r;r++)if(n[r].apply(this,i)===!1){e&&e.stop&&e.stop();break}return!0},responds:function(t){return!(!this._callbacks||!this._callbacks[t])},attach:"#on",detach:"#off",fire:"#emit",_installEvents:function(t){var e=this._callbacks,n=t?"install":"uninstall";for(var i in e)if(e[i].length>0){var r=this._eventTypes,s=r&&r[i],a=s&&s[n];a&&a.call(this,i)}},statics:{inject:function nt(t){var n=t._events;if(n){var i={};e.each(n,function(n,r){var s="string"==typeof n,a=s?n:r,o=e.capitalize(a),h=a.substring(2).toLowerCase();i[h]=s?{}:n,a="_"+a,t["get"+o]=function(){return this[a]},t["set"+o]=function(t){var e=this[a];e&&this.off(h,e),t&&this.on(h,t),this[a]=t}}),t._eventTypes=i}return nt.base.apply(this,arguments)}}},i=e.extend({_class:"PaperScope",initialize:function it(){paper=this,this.settings=new e({applyMatrix:!0,handleSize:4,hitTolerance:0}),this.project=null,this.projects=[],this.tools=[],this.palettes=[],this._id=it._id++,it._scopes[this._id]=this;var t=it.prototype;if(!this.support){var n=Y.getContext(1,1);t.support={nativeDash:"setLineDash"in n||"mozDash"in n,nativeBlendModes:K.nativeModes},Y.release(n)}if(!this.browser){var i=navigator.userAgent.toLowerCase(),r=(/(win)/.exec(i)||/(mac)/.exec(i)||/(linux)/.exec(i)||[])[0],s=t.browser={platform:r};r&&(s[r]=!0),i.replace(/(opera|chrome|safari|webkit|firefox|msie|trident|atom)\/?\s*([.\d]+)(?:.*version\/([.\d]+))?(?:.*rv\:([.\d]+))?/g,function(t,e,n,i,r){if(!s.chrome){var a="opera"===e?i:n;"trident"===e&&(a=r,e="msie"),s.version=a,s.versionNumber=parseFloat(a),s.name=e,s[e]=!0}}),s.chrome&&delete s.webkit,s.atom&&delete s.chrome}},version:"0.9.25",getView:function(){return this.project&&this.project.getView()},getPaper:function(){return this},execute:function(t,e,n){paper.PaperScript.execute(t,this,e,n),V.updateFocus()},install:function(t){var n=this;e.each(["project","view","tool"],function(i){e.define(t,i,{configurable:!0,get:function(){return n[i]}})});for(var i in this)!/^_/.test(i)&&this[i]&&(t[i]=this[i])},setup:function(t){return paper=this,this.project=new v(t),this},activate:function(){paper=this},clear:function(){for(var t=this.projects.length-1;t>=0;t--)this.projects[t].remove();for(var t=this.tools.length-1;t>=0;t--)this.tools[t].remove();for(var t=this.palettes.length-1;t>=0;t--)this.palettes[t].remove()},remove:function(){this.clear(),delete i._scopes[this._id]},statics:new function(){function t(t){return t+="Attribute",function(e,n){return e[t](n)||e[t]("data-paper-"+n)}}return{_scopes:{},_id:0,get:function(t){return this._scopes[t]||null},getAttribute:t("get"),hasAttribute:t("has")}}}),r=e.extend(n,{initialize:function(t){this._scope=paper,this._index=this._scope[this._list].push(this)-1,(t||!this._scope[this._reference])&&this.activate()},activate:function(){if(!this._scope)return!1;var t=this._scope[this._reference];return t&&t!==this&&t.emit("deactivate"),this._scope[this._reference]=this,this.emit("activate",t),!0},isActive:function(){return this._scope[this._reference]===this},remove:function(){return null==this._index?!1:(e.splice(this._scope[this._list],null,this._index,1),this._scope[this._reference]==this&&(this._scope[this._reference]=null),this._scope=null,!0)}}),s=e.extend({initialize:function(t){this.precision=t||5,this.multiplier=Math.pow(10,this.precision)},number:function(t){return Math.round(t*this.multiplier)/this.multiplier},pair:function(t,e,n){return this.number(t)+(n||",")+this.number(e)},point:function(t,e){return this.number(t.x)+(e||",")+this.number(t.y)},size:function(t,e){return this.number(t.width)+(e||",")+this.number(t.height)},rectangle:function(t,e){return this.point(t,e)+(e||",")+this.size(t,e)}});s.instance=new s;var a=new function(){function t(t,e,n){return e>t?e:t>n?n:t}var e=[[.5773502691896257],[0,.7745966692414834],[.33998104358485626,.8611363115940526],[0,.5384693101056831,.906179845938664],[.2386191860831969,.6612093864662645,.932469514203152],[0,.4058451513773972,.7415311855993945,.9491079123427585],[.1834346424956498,.525532409916329,.7966664774136267,.9602898564975363],[0,.3242534234038089,.6133714327005904,.8360311073266358,.9681602395076261],[.14887433898163122,.4333953941292472,.6794095682990244,.8650633666889845,.9739065285171717],[0,.26954315595234496,.5190961292068118,.7301520055740494,.8870625997680953,.978228658146057],[.1252334085114689,.3678314989981802,.5873179542866175,.7699026741943047,.9041172563704749,.9815606342467192],[0,.2304583159551348,.44849275103644687,.6423493394403402,.8015780907333099,.9175983992229779,.9841830547185881],[.10805494870734367,.31911236892788974,.5152486363581541,.6872929048116855,.827201315069765,.9284348836635735,.9862838086968123],[0,.20119409399743451,.3941513470775634,.5709721726085388,.7244177313601701,.8482065834104272,.937273392400706,.9879925180204854],[.09501250983763744,.2816035507792589,.45801677765722737,.6178762444026438,.755404408355003,.8656312023878318,.9445750230732326,.9894009349916499]],n=[[1],[.8888888888888888,.5555555555555556],[.6521451548625461,.34785484513745385],[.5688888888888889,.47862867049936647,.23692688505618908],[.46791393457269104,.3607615730481386,.17132449237917036],[.4179591836734694,.3818300505051189,.27970539148927664,.1294849661688697],[.362683783378362,.31370664587788727,.22238103445337448,.10122853629037626],[.3302393550012598,.31234707704000286,.26061069640293544,.1806481606948574,.08127438836157441],[.29552422471475287,.26926671930999635,.21908636251598204,.1494513491505806,.06667134430868814],[.2729250867779006,.26280454451024665,.23319376459199048,.18629021092773426,.1255803694649046,.05566856711617366],[.24914704581340277,.2334925365383548,.20316742672306592,.16007832854334622,.10693932599531843,.04717533638651183],[.2325515532308739,.22628318026289723,.2078160475368885,.17814598076194574,.13887351021978725,.09212149983772845,.04048400476531588],[.2152638534631578,.2051984637212956,.18553839747793782,.15720316715819355,.12151857068790319,.08015808715976021,.03511946033175186],[.2025782419255613,.19843148532711158,.1861610000155622,.16626920581699392,.13957067792615432,.10715922046717194,.07036604748810812,.03075324199611727],[.1894506104550685,.18260341504492358,.16915651939500254,.14959598881657674,.12462897125553388,.09515851168249279,.062253523938647894,.027152459411754096]],i=Math.abs,r=Math.sqrt,s=Math.pow,o=1e-12,h=1.12e-16;return{TOLERANCE:1e-6,EPSILON:o,MACHINE_EPSILON:h,CURVETIME_EPSILON:4e-7,GEOMETRIC_EPSILON:2e-7,WINDING_EPSILON:2e-7,TRIGONOMETRIC_EPSILON:1e-7,CLIPPING_EPSILON:1e-7,KAPPA:4*(r(2)-1)/3,isZero:function(t){return t>=-o&&o>=t},integrate:function(t,i,r,s){for(var a=e[s-2],o=n[s-2],h=.5*(r-i),u=h+i,l=0,c=s+1>>1,d=1&s?o[l++]*t(u):0;c>l;){var f=h*a[l];d+=o[l++]*(t(u+f)+t(u-f))}return h*d},findRoot:function(t,e,n,r,s,a,o){for(var h=0;a>h;h++){var u=t(n),l=u/e(n),c=n-l;if(i(l)<o)return c;u>0?(s=n,n=r>=c?.5*(r+s):c):(r=n,n=c>=s?.5*(r+s):c)}return n},solveQuadratic:function(e,n,a,u,l,c){var d,f,g=0,_=l-o,v=c+o,p=1/0,m=n;if(n/=-2,f=n*n-e*a,0!==f&&i(f)<h){var y=s(i(e*n*a),1/3);if(1e-8>y){var w=s(10,i(Math.floor(Math.log(y)*Math.LOG10E)));isFinite(w)||(w=0),e*=w,n*=w,a*=w,f=n*n-e*a}}if(i(e)<o){if(i(m)<o)return i(a)<o?-1:0;d=-a/m}else if(f>=-h){var x=0>f?0:r(f),b=n+(0>n?-x:x);0===b?(d=a/e,p=-d):(d=b/e,p=a/b)}return isFinite(d)&&(null==l||d>_&&v>d)&&(u[g++]=null==l?d:t(d,l,c)),p!==d&&isFinite(p)&&(null==l||p>_&&v>p)&&(u[g++]=null==l?p:t(p,l,c)),g},solveCubic:function(e,n,u,l,c,d,f){var g,_,v,p=0;if(i(e)<o)e=n,_=u,v=l,g=1/0;else if(i(l)<o)_=n,v=u,g=0;else{var m,y,w,x,b,C,S,P=1+h;if(g=-(n/e)/3,S=e*g,_=S+n,v=_*g+u,w=(S+_)*g+v,y=v*g+l,x=y/e,b=s(i(x),1/3),C=0>x?-1:1,x=-w/e,b=x>0?1.3247179572*Math.max(b,r(x)):b,m=g-C*b,m!==g){do if(g=m,S=e*g,_=S+n,v=_*g+u,w=(S+_)*g+v,y=v*g+l,m=0===w?g:g-y/w/P,m===g){g=m;break}while(C*m>C*g);i(e)*g*g>i(l/g)&&(v=-l/g,_=(v-u)/g)}}var p=a.solveQuadratic(e,_,v,c,d,f);return isFinite(g)&&(0===p||g!==c[p-1])&&(null==d||g>d-o&&f+o>g)&&(c[p++]=null==d?g:t(g,d,f)),p}}},o={_id:1,_pools:{},get:function(t){if(t){var e=t._class,n=this._pools[e];return n||(n=this._pools[e]={_id:1}),n._id++}return this._id++}},h=e.extend({_class:"Point",_readIndex:!0,initialize:function(t,e){var n=typeof t;if("number"===n){var i="number"==typeof e;this.x=t,this.y=i?e:t,this.__read&&(this.__read=i?2:1)}else"undefined"===n||null===t?(this.x=this.y=0,this.__read&&(this.__read=null===t?1:0)):(Array.isArray(t)?(this.x=t[0],this.y=t.length>1?t[1]:t[0]):null!=t.x?(this.x=t.x,this.y=t.y):null!=t.width?(this.x=t.width,this.y=t.height):null!=t.angle?(this.x=t.length,this.y=0,this.setAngle(t.angle)):(this.x=this.y=0,this.__read&&(this.__read=0)),this.__read&&(this.__read=1))},set:function(t,e){return this.x=t,this.y=e,this},equals:function(t){return this===t||t&&(this.x===t.x&&this.y===t.y||Array.isArray(t)&&this.x===t[0]&&this.y===t[1])||!1},clone:function(){return new h(this.x,this.y)},toString:function(){var t=s.instance;return"{ x: "+t.number(this.x)+", y: "+t.number(this.y)+" }"},_serialize:function(t){var e=t.formatter;return[e.number(this.x),e.number(this.y)]},getLength:function(){return Math.sqrt(this.x*this.x+this.y*this.y)},setLength:function(t){if(this.isZero()){var e=this._angle||0;this.set(Math.cos(e)*t,Math.sin(e)*t)}else{var n=t/this.getLength();a.isZero(n)&&this.getAngle(),this.set(this.x*n,this.y*n)}},getAngle:function(){return 180*this.getAngleInRadians.apply(this,arguments)/Math.PI},setAngle:function(t){this.setAngleInRadians.call(this,t*Math.PI/180)},getAngleInDegrees:"#getAngle",setAngleInDegrees:"#setAngle",getAngleInRadians:function(){if(arguments.length){var t=h.read(arguments),e=this.getLength()*t.getLength();if(a.isZero(e))return NaN;var n=this.dot(t)/e;return Math.acos(-1>n?-1:n>1?1:n)}return this.isZero()?this._angle||0:this._angle=Math.atan2(this.y,this.x)},setAngleInRadians:function(t){if(this._angle=t,!this.isZero()){var e=this.getLength();this.set(Math.cos(t)*e,Math.sin(t)*e)}},getQuadrant:function(){return this.x>=0?this.y>=0?1:4:this.y>=0?2:3}},{beans:!1,getDirectedAngle:function(){var t=h.read(arguments);return 180*Math.atan2(this.cross(t),this.dot(t))/Math.PI},getDistance:function(){var t=h.read(arguments),n=t.x-this.x,i=t.y-this.y,r=n*n+i*i,s=e.read(arguments);return s?r:Math.sqrt(r)},normalize:function(e){e===t&&(e=1);var n=this.getLength(),i=0!==n?e/n:0,r=new h(this.x*i,this.y*i);return i>=0&&(r._angle=this._angle),r},rotate:function(t,e){if(0===t)return this.clone();t=t*Math.PI/180;var n=e?this.subtract(e):this,i=Math.sin(t),r=Math.cos(t);return n=new h(n.x*r-n.y*i,n.x*i+n.y*r),e?n.add(e):n},transform:function(t){return t?t._transformPoint(this):this},add:function(){var t=h.read(arguments);return new h(this.x+t.x,this.y+t.y)},subtract:function(){var t=h.read(arguments);return new h(this.x-t.x,this.y-t.y)},multiply:function(){var t=h.read(arguments);return new h(this.x*t.x,this.y*t.y)},divide:function(){var t=h.read(arguments);return new h(this.x/t.x,this.y/t.y)},modulo:function(){var t=h.read(arguments);return new h(this.x%t.x,this.y%t.y)},negate:function(){return new h(-this.x,-this.y)},isInside:function(){return d.read(arguments).contains(this)},isClose:function(){var t=h.read(arguments),n=e.read(arguments);return this.getDistance(t)<n},isCollinear:function(){var t=h.read(arguments);return h.isCollinear(this.x,this.y,t.x,t.y)},isColinear:"#isCollinear",isOrthogonal:function(){var t=h.read(arguments);return h.isOrthogonal(this.x,this.y,t.x,t.y)},isZero:function(){return a.isZero(this.x)&&a.isZero(this.y)},isNaN:function(){return isNaN(this.x)||isNaN(this.y)},dot:function(){var t=h.read(arguments);return this.x*t.x+this.y*t.y},cross:function(){var t=h.read(arguments);return this.x*t.y-this.y*t.x},project:function(){var t=h.read(arguments),e=t.isZero()?0:this.dot(t)/t.dot(t);return new h(t.x*e,t.y*e)},statics:{min:function(){var t=h.read(arguments),e=h.read(arguments);return new h(Math.min(t.x,e.x),Math.min(t.y,e.y))},max:function(){var t=h.read(arguments),e=h.read(arguments);return new h(Math.max(t.x,e.x),Math.max(t.y,e.y))},random:function(){return new h(Math.random(),Math.random())},isCollinear:function(t,e,n,i){return Math.abs(t*i-e*n)<=1e-7*Math.sqrt((t*t+e*e)*(n*n+i*i))},isOrthogonal:function(t,e,n,i){return Math.abs(t*n+e*i)<=1e-7*Math.sqrt((t*t+e*e)*(n*n+i*i))}}},e.each(["round","ceil","floor","abs"],function(t){var e=Math[t];this[t]=function(){return new h(e(this.x),e(this.y))}},{})),u=h.extend({initialize:function(t,e,n,i){this._x=t,this._y=e,this._owner=n,this._setter=i},set:function(t,e,n){return this._x=t,this._y=e,n||this._owner[this._setter](this),this},getX:function(){return this._x},setX:function(t){this._x=t,this._owner[this._setter](this)},getY:function(){return this._y},setY:function(t){this._y=t,this._owner[this._setter](this)}}),l=e.extend({_class:"Size",_readIndex:!0,initialize:function(t,e){var n=typeof t;if("number"===n){var i="number"==typeof e;this.width=t,this.height=i?e:t,this.__read&&(this.__read=i?2:1)}else"undefined"===n||null===t?(this.width=this.height=0,this.__read&&(this.__read=null===t?1:0)):(Array.isArray(t)?(this.width=t[0],this.height=t.length>1?t[1]:t[0]):null!=t.width?(this.width=t.width,this.height=t.height):null!=t.x?(this.width=t.x,this.height=t.y):(this.width=this.height=0,this.__read&&(this.__read=0)),this.__read&&(this.__read=1))},set:function(t,e){return this.width=t,this.height=e,this},equals:function(t){return t===this||t&&(this.width===t.width&&this.height===t.height||Array.isArray(t)&&this.width===t[0]&&this.height===t[1])||!1},clone:function(){return new l(this.width,this.height)},toString:function(){var t=s.instance;return"{ width: "+t.number(this.width)+", height: "+t.number(this.height)+" }"},_serialize:function(t){var e=t.formatter;return[e.number(this.width),e.number(this.height)]},add:function(){var t=l.read(arguments);return new l(this.width+t.width,this.height+t.height)},subtract:function(){var t=l.read(arguments);return new l(this.width-t.width,this.height-t.height)},multiply:function(){var t=l.read(arguments);return new l(this.width*t.width,this.height*t.height)},divide:function(){var t=l.read(arguments);return new l(this.width/t.width,this.height/t.height)},modulo:function(){var t=l.read(arguments);return new l(this.width%t.width,this.height%t.height)},negate:function(){return new l(-this.width,-this.height)},isZero:function(){return a.isZero(this.width)&&a.isZero(this.height)},isNaN:function(){return isNaN(this.width)||isNaN(this.height)},statics:{min:function(t,e){return new l(Math.min(t.width,e.width),Math.min(t.height,e.height))},max:function(t,e){return new l(Math.max(t.width,e.width),Math.max(t.height,e.height))},random:function(){return new l(Math.random(),Math.random())}}},e.each(["round","ceil","floor","abs"],function(t){var e=Math[t];this[t]=function(){return new l(e(this.width),e(this.height))}},{})),c=l.extend({initialize:function(t,e,n,i){this._width=t,this._height=e,this._owner=n,this._setter=i},set:function(t,e,n){return this._width=t,this._height=e,n||this._owner[this._setter](this),this},getWidth:function(){return this._width},setWidth:function(t){this._width=t,this._owner[this._setter](this)},getHeight:function(){return this._height},setHeight:function(t){this._height=t,this._owner[this._setter](this)}}),d=e.extend({_class:"Rectangle",_readIndex:!0,beans:!0,initialize:function(n,i,r,s){var a=typeof n,o=0;if("number"===a?(this.x=n,this.y=i,this.width=r,this.height=s,o=4):"undefined"===a||null===n?(this.x=this.y=this.width=this.height=0,o=null===n?1:0):1===arguments.length&&(Array.isArray(n)?(this.x=n[0],this.y=n[1],this.width=n[2],this.height=n[3],o=1):n.x!==t||n.width!==t?(this.x=n.x||0,this.y=n.y||0,this.width=n.width||0,this.height=n.height||0,o=1):n.from===t&&n.to===t&&(this.x=this.y=this.width=this.height=0,this._set(n),o=1)),!o){var u=h.readNamed(arguments,"from"),c=e.peek(arguments);if(this.x=u.x,this.y=u.y,c&&c.x!==t||e.hasNamed(arguments,"to")){var d=h.readNamed(arguments,"to");this.width=d.x-u.x,this.height=d.y-u.y,this.width<0&&(this.x=d.x,this.width=-this.width),this.height<0&&(this.y=d.y,this.height=-this.height)}else{var f=l.read(arguments);this.width=f.width,this.height=f.height}o=arguments.__index}this.__read&&(this.__read=o)},set:function(t,e,n,i){return this.x=t,this.y=e,this.width=n,this.height=i,this},clone:function(){return new d(this.x,this.y,this.width,this.height)},equals:function(t){var n=e.isPlainValue(t)?d.read(arguments):t;return n===this||n&&this.x===n.x&&this.y===n.y&&this.width===n.width&&this.height===n.height||!1},toString:function(){var t=s.instance;return"{ x: "+t.number(this.x)+", y: "+t.number(this.y)+", width: "+t.number(this.width)+", height: "+t.number(this.height)+" }"},_serialize:function(t){var e=t.formatter;return[e.number(this.x),e.number(this.y),e.number(this.width),e.number(this.height)]},getPoint:function(t){var e=t?h:u;return new e(this.x,this.y,this,"setPoint")},setPoint:function(){var t=h.read(arguments);this.x=t.x,this.y=t.y},getSize:function(t){var e=t?l:c;return new e(this.width,this.height,this,"setSize")},setSize:function(){var t=l.read(arguments);this._fixX&&(this.x+=(this.width-t.width)*this._fixX),this._fixY&&(this.y+=(this.height-t.height)*this._fixY),this.width=t.width,this.height=t.height,this._fixW=1,this._fixH=1},getLeft:function(){return this.x},setLeft:function(t){this._fixW||(this.width-=t-this.x),this.x=t,this._fixX=0},getTop:function(){return this.y},setTop:function(t){this._fixH||(this.height-=t-this.y),this.y=t,this._fixY=0},getRight:function(){return this.x+this.width},setRight:function(e){this._fixX!==t&&1!==this._fixX&&(this._fixW=0),this._fixW?this.x=e-this.width:this.width=e-this.x,this._fixX=1},getBottom:function(){return this.y+this.height},setBottom:function(e){this._fixY!==t&&1!==this._fixY&&(this._fixH=0),this._fixH?this.y=e-this.height:this.height=e-this.y,this._fixY=1},getCenterX:function(){return this.x+.5*this.width},setCenterX:function(t){this.x=t-.5*this.width,this._fixX=.5},getCenterY:function(){return this.y+.5*this.height},setCenterY:function(t){this.y=t-.5*this.height,this._fixY=.5},getCenter:function(t){var e=t?h:u;return new e(this.getCenterX(),this.getCenterY(),this,"setCenter")},setCenter:function(){var t=h.read(arguments);return this.setCenterX(t.x),this.setCenterY(t.y),this},getArea:function(){return this.width*this.height},isEmpty:function(){return 0===this.width||0===this.height},contains:function(e){return e&&e.width!==t||4==(Array.isArray(e)?e:arguments).length?this._containsRectangle(d.read(arguments)):this._containsPoint(h.read(arguments))},_containsPoint:function(t){var e=t.x,n=t.y;return e>=this.x&&n>=this.y&&e<=this.x+this.width&&n<=this.y+this.height},_containsRectangle:function(t){var e=t.x,n=t.y;return e>=this.x&&n>=this.y&&e+t.width<=this.x+this.width&&n+t.height<=this.y+this.height},intersects:function(){var t=d.read(arguments);return t.x+t.width>this.x&&t.y+t.height>this.y&&t.x<this.x+this.width&&t.y<this.y+this.height},touches:function(){var t=d.read(arguments);return t.x+t.width>=this.x&&t.y+t.height>=this.y&&t.x<=this.x+this.width&&t.y<=this.y+this.height},intersect:function(){var t=d.read(arguments),e=Math.max(this.x,t.x),n=Math.max(this.y,t.y),i=Math.min(this.x+this.width,t.x+t.width),r=Math.min(this.y+this.height,t.y+t.height);return new d(e,n,i-e,r-n)},unite:function(){var t=d.read(arguments),e=Math.min(this.x,t.x),n=Math.min(this.y,t.y),i=Math.max(this.x+this.width,t.x+t.width),r=Math.max(this.y+this.height,t.y+t.height);return new d(e,n,i-e,r-n)},include:function(){var t=h.read(arguments),e=Math.min(this.x,t.x),n=Math.min(this.y,t.y),i=Math.max(this.x+this.width,t.x),r=Math.max(this.y+this.height,t.y);return new d(e,n,i-e,r-n)},expand:function(){var t=l.read(arguments),e=t.width,n=t.height;return new d(this.x-e/2,this.y-n/2,this.width+e,this.height+n)},scale:function(e,n){return this.expand(this.width*e-this.width,this.height*(n===t?e:n)-this.height)}},e.each([["Top","Left"],["Top","Right"],["Bottom","Left"],["Bottom","Right"],["Left","Center"],["Top","Center"],["Right","Center"],["Bottom","Center"]],function(t,e){var n=t.join(""),i=/^[RL]/.test(n);e>=4&&(t[1]+=i?"Y":"X");var r=t[i?0:1],s=t[i?1:0],a="get"+r,o="get"+s,l="set"+r,c="set"+s,d="get"+n,f="set"+n;this[d]=function(t){var e=t?h:u;return new e(this[a](),this[o](),this,f)},this[f]=function(){var t=h.read(arguments);this[l](t.x),this[c](t.y)}},{beans:!0})),f=d.extend({initialize:function(t,e,n,i,r,s){this.set(t,e,n,i,!0),this._owner=r,this._setter=s},set:function(t,e,n,i,r){return this._x=t,this._y=e,this._width=n,this._height=i,r||this._owner[this._setter](this),this}},new function(){var t=d.prototype;return e.each(["x","y","width","height"],function(t){var n=e.capitalize(t),i="_"+t;this["get"+n]=function(){return this[i]},this["set"+n]=function(t){this[i]=t,this._dontNotify||this._owner[this._setter](this)}},e.each(["Point","Size","Center","Left","Top","Right","Bottom","CenterX","CenterY","TopLeft","TopRight","BottomLeft","BottomRight","LeftCenter","TopCenter","RightCenter","BottomCenter"],function(e){var n="set"+e;this[n]=function(){this._dontNotify=!0,t[n].apply(this,arguments),this._dontNotify=!1,this._owner[this._setter](this)}},{isSelected:function(){return this._owner._boundsSelected},setSelected:function(t){var e=this._owner;e.setSelected&&(e._boundsSelected=t,e.setSelected(t||e._selectedSegmentState>0))}}))}),g=e.extend({_class:"Matrix",initialize:function rt(t){var e=arguments.length,n=!0;if(6===e?this.set.apply(this,arguments):1===e?t instanceof rt?this.set(t._a,t._c,t._b,t._d,t._tx,t._ty):Array.isArray(t)?this.set.apply(this,t):n=!1:0===e?this.reset():n=!1,!n)throw Error("Unsupported matrix parameters")},set:function(t,e,n,i,r,s,a){return this._a=t,this._c=e,this._b=n,this._d=i,this._tx=r,this._ty=s,a||this._changed(),this},_serialize:function(t){return e.serialize(this.getValues(),t)},_changed:function(){var t=this._owner;t&&(t._applyMatrix?t.transform(null,!0):t._changed(9))},clone:function(){return new g(this._a,this._c,this._b,this._d,this._tx,this._ty)},equals:function(t){return t===this||t&&this._a===t._a&&this._b===t._b&&this._c===t._c&&this._d===t._d&&this._tx===t._tx&&this._ty===t._ty||!1},toString:function(){var t=s.instance;return"[["+[t.number(this._a),t.number(this._b),t.number(this._tx)].join(", ")+"], ["+[t.number(this._c),t.number(this._d),t.number(this._ty)].join(", ")+"]]"},reset:function(t){return this._a=this._d=1,this._c=this._b=this._tx=this._ty=0,t||this._changed(),this},apply:function(t,n){var i=this._owner;return i?(i.transform(null,!0,e.pick(t,!0),n),this.isIdentity()):!1},translate:function(){var t=h.read(arguments),e=t.x,n=t.y;return this._tx+=e*this._a+n*this._b,this._ty+=e*this._c+n*this._d,this._changed(),this},scale:function(){var t=h.read(arguments),e=h.read(arguments,0,{readNull:!0});return e&&this.translate(e),this._a*=t.x,this._c*=t.x,this._b*=t.y,this._d*=t.y,e&&this.translate(e.negate()),this._changed(),this},rotate:function(t){t*=Math.PI/180;var e=h.read(arguments,1),n=e.x,i=e.y,r=Math.cos(t),s=Math.sin(t),a=n-n*r+i*s,o=i-n*s-i*r,u=this._a,l=this._b,c=this._c,d=this._d;return this._a=r*u+s*l,this._b=-s*u+r*l,this._c=r*c+s*d,this._d=-s*c+r*d,this._tx+=a*u+o*l,this._ty+=a*c+o*d,this._changed(),this},shear:function(){var t=h.read(arguments),e=h.read(arguments,0,{readNull:!0});e&&this.translate(e);var n=this._a,i=this._c;return this._a+=t.y*this._b,this._c+=t.y*this._d,this._b+=t.x*n,this._d+=t.x*i,e&&this.translate(e.negate()),this._changed(),this},skew:function(){var t=h.read(arguments),e=h.read(arguments,0,{readNull:!0}),n=Math.PI/180,i=new h(Math.tan(t.x*n),Math.tan(t.y*n));return this.shear(i,e)},concatenate:function(t){var e=this._a,n=this._b,i=this._c,r=this._d,s=t._a,a=t._b,o=t._c,h=t._d,u=t._tx,l=t._ty;return this._a=s*e+o*n,
-this._b=a*e+h*n,this._c=s*i+o*r,this._d=a*i+h*r,this._tx+=u*e+l*n,this._ty+=u*i+l*r,this._changed(),this},preConcatenate:function(t){var e=this._a,n=this._b,i=this._c,r=this._d,s=this._tx,a=this._ty,o=t._a,h=t._b,u=t._c,l=t._d,c=t._tx,d=t._ty;return this._a=o*e+h*i,this._b=o*n+h*r,this._c=u*e+l*i,this._d=u*n+l*r,this._tx=o*s+h*a+c,this._ty=u*s+l*a+d,this._changed(),this},chain:function(t){var e=this._a,n=this._b,i=this._c,r=this._d,s=this._tx,a=this._ty,o=t._a,h=t._b,u=t._c,l=t._d,c=t._tx,d=t._ty;return new g(o*e+u*n,o*i+u*r,h*e+l*n,h*i+l*r,s+c*e+d*n,a+c*i+d*r)},isIdentity:function(){return 1===this._a&&0===this._c&&0===this._b&&1===this._d&&0===this._tx&&0===this._ty},orNullIfIdentity:function(){return this.isIdentity()?null:this},isInvertible:function(){return!!this._getDeterminant()},isSingular:function(){return!this._getDeterminant()},transform:function(t,e,n){return arguments.length<3?this._transformPoint(h.read(arguments)):this._transformCoordinates(t,e,n)},_transformPoint:function(t,e,n){var i=t.x,r=t.y;return e||(e=new h),e.set(i*this._a+r*this._b+this._tx,i*this._c+r*this._d+this._ty,n)},_transformCoordinates:function(t,e,n){for(var i=0,r=0,s=2*n;s>i;){var a=t[i++],o=t[i++];e[r++]=a*this._a+o*this._b+this._tx,e[r++]=a*this._c+o*this._d+this._ty}return e},_transformCorners:function(t){var e=t.x,n=t.y,i=e+t.width,r=n+t.height,s=[e,n,i,n,i,r,e,r];return this._transformCoordinates(s,s,4)},_transformBounds:function(t,e,n){for(var i=this._transformCorners(t),r=i.slice(0,2),s=r.slice(),a=2;8>a;a++){var o=i[a],h=1&a;o<r[h]?r[h]=o:o>s[h]&&(s[h]=o)}return e||(e=new d),e.set(r[0],r[1],s[0]-r[0],s[1]-r[1],n)},inverseTransform:function(){return this._inverseTransform(h.read(arguments))},_getDeterminant:function(){var t=this._a*this._d-this._b*this._c;return isFinite(t)&&!a.isZero(t)&&isFinite(this._tx)&&isFinite(this._ty)?t:null},_inverseTransform:function(t,e,n){var i=this._getDeterminant();if(!i)return null;var r=t.x-this._tx,s=t.y-this._ty;return e||(e=new h),e.set((r*this._d-s*this._b)/i,(s*this._a-r*this._c)/i,n)},decompose:function(){var t=this._a,e=this._b,n=this._c,i=this._d;if(a.isZero(t*i-e*n))return null;var r=Math.sqrt(t*t+e*e);t/=r,e/=r;var s=t*n+e*i;n-=t*s,i-=e*s;var o=Math.sqrt(n*n+i*i);return n/=o,i/=o,s/=o,e*n>t*i&&(t=-t,e=-e,s=-s,r=-r),{scaling:new h(r,o),rotation:180*-Math.atan2(e,t)/Math.PI,shearing:s}},getValues:function(){return[this._a,this._c,this._b,this._d,this._tx,this._ty]},getTranslation:function(){return new h(this._tx,this._ty)},getScaling:function(){return(this.decompose()||{}).scaling},getRotation:function(){return(this.decompose()||{}).rotation},inverted:function(){var t=this._getDeterminant();return t&&new g(this._d/t,-this._c/t,-this._b/t,this._a/t,(this._b*this._ty-this._d*this._tx)/t,(this._c*this._tx-this._a*this._ty)/t)},shiftless:function(){return new g(this._a,this._c,this._b,this._d,0,0)},applyToContext:function(t){t.transform(this._a,this._c,this._b,this._d,this._tx,this._ty)}},e.each(["a","c","b","d","tx","ty"],function(t){var n=e.capitalize(t),i="_"+t;this["get"+n]=function(){return this[i]},this["set"+n]=function(t){this[i]=t,this._changed()}},{})),_=e.extend({_class:"Line",initialize:function(t,e,n,i,r){var s=!1;arguments.length>=4?(this._px=t,this._py=e,this._vx=n,this._vy=i,s=r):(this._px=t.x,this._py=t.y,this._vx=e.x,this._vy=e.y,s=n),s||(this._vx-=this._px,this._vy-=this._py)},getPoint:function(){return new h(this._px,this._py)},getVector:function(){return new h(this._vx,this._vy)},getLength:function(){return this.getVector().getLength()},intersect:function(t,e){return _.intersect(this._px,this._py,this._vx,this._vy,t._px,t._py,t._vx,t._vy,!0,e)},getSide:function(t,e){return _.getSide(this._px,this._py,this._vx,this._vy,t.x,t.y,!0,e)},getDistance:function(t){return Math.abs(_.getSignedDistance(this._px,this._py,this._vx,this._vy,t.x,t.y,!0))},isCollinear:function(t){return h.isCollinear(this._vx,this._vy,t._vx,t._vy)},isOrthogonal:function(t){return h.isOrthogonal(this._vx,this._vy,t._vx,t._vy)},statics:{intersect:function(t,e,n,i,r,s,o,u,l,c){l||(n-=t,i-=e,o-=r,u-=s);var d=n*u-i*o;if(!a.isZero(d)){var f=t-r,g=e-s,_=(o*g-u*f)/d,v=(n*g-i*f)/d,p=1e-12,m=-p,y=1+p;if(c||_>m&&y>_&&v>m&&y>v)return c||(_=0>=_?0:_>=1?1:_),new h(t+_*n,e+_*i)}},getSide:function(t,e,n,i,r,s,a,o){a||(n-=t,i-=e);var h=r-t,u=s-e,l=h*i-u*n;return 0!==l||o||(l=(h*n+h*n)/(n*n+i*i),l>=0&&1>=l&&(l=0)),0>l?-1:l>0?1:0},getSignedDistance:function(t,e,n,i,r,s,a){return a||(n-=t,i-=e),0===n?i>0?r-t:t-r:0===i?0>n?s-e:e-s:((r-t)*i-(s-e)*n)/Math.sqrt(n*n+i*i)}}}),v=r.extend({_class:"Project",_list:"projects",_reference:"project",initialize:function(t){r.call(this,!0),this.layers=[],this._activeLayer=null,this.symbols=[],this._currentStyle=new D(null,null,this),this._view=V.create(this,t||Y.getCanvas(1,1)),this._selectedItems={},this._selectedItemCount=0,this._updateVersion=0},_serialize:function(t,n){return e.serialize(this.layers,t,!0,n)},clear:function(){for(var t=this.layers.length-1;t>=0;t--)this.layers[t].remove();this.symbols=[]},isEmpty:function(){return 0===this.layers.length},remove:function st(){return st.base.call(this)?(this._view&&this._view.remove(),!0):!1},getView:function(){return this._view},getCurrentStyle:function(){return this._currentStyle},setCurrentStyle:function(t){this._currentStyle.initialize(t)},getIndex:function(){return this._index},getOptions:function(){return this._scope.settings},getActiveLayer:function(){return this._activeLayer||new w({project:this})},getSelectedItems:function(){var t=[];for(var e in this._selectedItems){var n=this._selectedItems[e];n.isInserted()&&t.push(n)}return t},insertChild:function(t,n,i){return n instanceof w?(n._remove(!1,!0),e.splice(this.layers,[n],t,0),n._setProject(this,!0),this._changes&&n._changed(5),this._activeLayer||(this._activeLayer=n)):n instanceof m?(this._activeLayer||this.insertChild(t,new w(m.NO_INSERT))).insertChild(t,n,i):n=null,n},addChild:function(e,n){return this.insertChild(t,e,n)},_updateSelection:function(t){var e=t._id,n=this._selectedItems;t._selected?n[e]!==t&&(this._selectedItemCount++,n[e]=t):n[e]===t&&(this._selectedItemCount--,delete n[e])},selectAll:function(){for(var t=this.layers,e=0,n=t.length;n>e;e++)t[e].setFullySelected(!0)},deselectAll:function(){var t=this._selectedItems;for(var e in t)t[e].setFullySelected(!1)},hitTest:function(){for(var t=h.read(arguments),n=S.getOptions(e.read(arguments)),i=this.layers.length-1;i>=0;i--){var r=this.layers[i]._hitTest(t,n);if(r)return r}return null},getItems:function(t){return m._getItems(this.layers,t)},getItem:function(t){return m._getItems(this.layers,t,null,null,!0)[0]||null},importJSON:function(t){this.activate();var n=this._activeLayer;return e.importJSON(t,n&&n.isEmpty()&&n)},draw:function(t,n,i){this._updateVersion++,t.save(),n.applyToContext(t);for(var r=new e({offset:new h(0,0),pixelRatio:i,viewMatrix:n.isIdentity()?null:n,matrices:[new g],updateMatrix:!0}),s=0,a=this.layers,o=a.length;o>s;s++)a[s].draw(t,r);if(t.restore(),this._selectedItemCount>0){t.save(),t.strokeWidth=1;var u=this._selectedItems,l=this._scope.settings.handleSize,c=this._updateVersion;for(var d in u)u[d]._drawSelection(t,n,l,u,c);t.restore()}}}),p=e.extend({_class:"Symbol",initialize:function(t,e){this._id=o.get(),this.project=paper.project,this.project.symbols.push(this),t&&this.setDefinition(t,e)},_serialize:function(t,n){return n.add(this,function(){return e.serialize([this._class,this._definition],t,!1,n)})},_changed:function(t){8&t&&m._clearBoundsCache(this),1&t&&(this.project._needsUpdate=!0)},getDefinition:function(){return this._definition},setDefinition:function(t,e){t._parentSymbol&&(t=t.clone()),this._definition&&(this._definition._parentSymbol=null),this._definition=t,t.remove(),t.setSelected(!1),e||t.setPosition(new h),t._parentSymbol=this,this._changed(9)},place:function(t){return new C(this,t)},clone:function(){return new p(this._definition.clone(!1))},equals:function(t){return t===this||t&&this.definition.equals(t.definition)||!1}}),m=e.extend(n,{statics:{extend:function at(t){return t._serializeFields&&(t._serializeFields=new e(this.prototype._serializeFields,t._serializeFields)),at.base.apply(this,arguments)},NO_INSERT:{insert:!1}},_class:"Item",_applyMatrix:!0,_canApplyMatrix:!0,_boundsSelected:!1,_selectChildren:!1,_serializeFields:{name:null,applyMatrix:null,matrix:new g,pivot:null,locked:!1,visible:!0,blendMode:"normal",opacity:1,guide:!1,selected:!1,clipMask:!1,data:{}},initialize:function(){},_initialize:function(t,n){var i=t&&e.isPlainObject(t),r=i&&t.internal===!0,s=this._matrix=new g,a=i&&t.project||paper.project;return r||(this._id=o.get()),this._applyMatrix=this._canApplyMatrix&&paper.settings.applyMatrix,n&&s.translate(n),s._owner=this,this._style=new D(a._currentStyle,this,a),this._project||(r||i&&t.insert===!1?this._setProject(a):i&&t.parent?this.setParent(t.parent):(a._activeLayer||new w).addChild(this)),i&&t!==m.NO_INSERT&&this._set(t,{insert:!0,project:!0,parent:!0},!0),i},_events:e.each(["onMouseDown","onMouseUp","onMouseDrag","onClick","onDoubleClick","onMouseMove","onMouseEnter","onMouseLeave"],function(t){this[t]={install:function(t){this.getView()._installEvent(t)},uninstall:function(t){this.getView()._uninstallEvent(t)}}},{onFrame:{install:function(){this.getView()._animateItem(this,!0)},uninstall:function(){this.getView()._animateItem(this,!1)}},onLoad:{}}),_serialize:function(t,n){function i(i){for(var a in i){var o=s[a];e.equals(o,"leading"===a?1.2*i.fontSize:i[a])||(r[a]=e.serialize(o,t,"data"!==a,n))}}var r={},s=this;return i(this._serializeFields),this instanceof y||i(this._style._defaults),[this._class,r]},_changed:function(e){var n=this._parentSymbol,i=this._parent||n,r=this._project;if(8&e&&(this._bounds=this._position=this._decomposed=this._globalMatrix=this._currentPath=t),i&&40&e&&m._clearBoundsCache(i),2&e&&m._clearBoundsCache(this),r&&(1&e&&(r._needsUpdate=!0),r._changes)){var s=r._changesById[this._id];s?s.flags|=e:(s={item:this,flags:e},r._changesById[this._id]=s,r._changes.push(s))}n&&n._changed(e)},set:function(t){return t&&this._set(t),this},getId:function(){return this._id},getName:function(){return this._name},setName:function(e,n){if(this._name&&this._removeNamed(),e===+e+"")throw Error("Names consisting only of numbers are not supported.");var i=this._parent;if(e&&i){for(var r=i._children,s=i._namedChildren,a=e,o=1;n&&r[e];)e=a+" "+o++;(s[e]=s[e]||[]).push(this),r[e]=this}this._name=e||t,this._changed(128)},getStyle:function(){return this._style},setStyle:function(t){this.getStyle().set(t)}},e.each(["locked","visible","blendMode","opacity","guide"],function(t){var n=e.capitalize(t),t="_"+t;this["get"+n]=function(){return this[t]},this["set"+n]=function(e){e!=this[t]&&(this[t]=e,this._changed("_locked"===t?128:129))}},{}),{beans:!0,_locked:!1,_visible:!0,_blendMode:"normal",_opacity:1,_guide:!1,isSelected:function(){if(this._selectChildren)for(var t=this._children,e=0,n=t.length;n>e;e++)if(t[e].isSelected())return!0;return this._selected},setSelected:function(t,e){if(!e&&this._selectChildren)for(var n=this._children,i=0,r=n.length;r>i;i++)n[i].setSelected(t);(t=!!t)^this._selected&&(this._selected=t,this._project._updateSelection(this),this._changed(129))},_selected:!1,isFullySelected:function(){var t=this._children;if(t&&this._selected){for(var e=0,n=t.length;n>e;e++)if(!t[e].isFullySelected())return!1;return!0}return this._selected},setFullySelected:function(t){var e=this._children;if(e)for(var n=0,i=e.length;i>n;n++)e[n].setFullySelected(t);this.setSelected(t,!0)},isClipMask:function(){return this._clipMask},setClipMask:function(t){this._clipMask!=(t=!!t)&&(this._clipMask=t,t&&(this.setFillColor(null),this.setStrokeColor(null)),this._changed(129),this._parent&&this._parent._changed(1024))},_clipMask:!1,getData:function(){return this._data||(this._data={}),this._data},setData:function(t){this._data=t},getPosition:function(t){var e=this._position,n=t?h:u;if(!e){var i=this._pivot;e=this._position=i?this._matrix._transformPoint(i):this.getBounds().getCenter(!0)}return new n(e.x,e.y,this,"setPosition")},setPosition:function(){this.translate(h.read(arguments).subtract(this.getPosition(!0)))},getPivot:function(t){var e=this._pivot;if(e){var n=t?h:u;e=new n(e.x,e.y,this,"setPivot")}return e},setPivot:function(){this._pivot=h.read(arguments,0,{clone:!0,readNull:!0}),this._position=t},_pivot:null},e.each(["bounds","strokeBounds","handleBounds","roughBounds","internalBounds","internalRoughBounds"],function(t){var n="get"+e.capitalize(t),i=t.match(/^internal(.*)$/),r=i?"get"+i[1]:null;this[n]=function(e){var i=this._boundsGetter,s=!r&&("string"==typeof i?i:i&&i[n])||n,a=this._getCachedBounds(s,e,this,r);return"bounds"===t?new f(a.x,a.y,a.width,a.height,this,"setBounds"):a}},{beans:!0,_getBounds:function(t,e,n){var i=this._children;if(!i||0==i.length)return new d;m._updateBoundsCache(this,n);for(var r=1/0,s=-r,a=r,o=s,h=0,u=i.length;u>h;h++){var l=i[h];if(l._visible&&!l.isEmpty()){var c=l._getCachedBounds(t,e&&e.chain(l._matrix),n);r=Math.min(c.x,r),a=Math.min(c.y,a),s=Math.max(c.x+c.width,s),o=Math.max(c.y+c.height,o)}}return isFinite(r)?new d(r,a,s-r,o-a):new d},setBounds:function(){var t=d.read(arguments),e=this.getBounds(),n=new g,i=t.getCenter();n.translate(i),(t.width!=e.width||t.height!=e.height)&&n.scale(0!=e.width?t.width/e.width:1,0!=e.height?t.height/e.height:1),i=e.getCenter(),n.translate(-i.x,-i.y),this.transform(n)},_getCachedBounds:function(t,e,n,i){e=e&&e.orNullIfIdentity();var r=i?null:this._matrix.orNullIfIdentity(),s=(!e||e.equals(r))&&t;if(m._updateBoundsCache(this._parent||this._parentSymbol,n),s&&this._bounds&&this._bounds[s])return this._bounds[s].clone();var a=this._getBounds(i||t,e||r,n);if(s){this._bounds||(this._bounds={});var o=this._bounds[s]=a.clone();o._internal=!!i}return a},statics:{_updateBoundsCache:function(t,e){if(t){var n=e._id,i=t._boundsCache=t._boundsCache||{ids:{},list:[]};i.ids[n]||(i.list.push(e),i.ids[n]=e)}},_clearBoundsCache:function(e){var n=e._boundsCache;if(n){e._bounds=e._position=e._boundsCache=t;for(var i=0,r=n.list,s=r.length;s>i;i++){var a=r[i];a!==e&&(a._bounds=a._position=t,a._boundsCache&&m._clearBoundsCache(a))}}}}}),{beans:!0,_decompose:function(){return this._decomposed=this._matrix.decompose()},getRotation:function(){var t=this._decomposed||this._decompose();return t&&t.rotation},setRotation:function(t){var e=this.getRotation();if(null!=e&&null!=t){var n=this._decomposed;this.rotate(t-e),n.rotation=t,this._decomposed=n}},getScaling:function(t){var e=this._decomposed||this._decompose(),n=e&&e.scaling,i=t?h:u;return n&&new i(n.x,n.y,this,"setScaling")},setScaling:function(){var t=this.getScaling();if(t){var e=h.read(arguments,0,{clone:!0}),n=this._decomposed;this.scale(e.x/t.x,e.y/t.y),n.scaling=e,this._decomposed=n}},getMatrix:function(){return this._matrix},setMatrix:function(){var t=this._matrix;t.initialize.apply(t,arguments),this._applyMatrix?this.transform(null,!0):this._changed(9)},getGlobalMatrix:function(t){var e=this._globalMatrix,n=this._project._updateVersion;if(e&&e._updateVersion!==n&&(e=null),!e){e=this._globalMatrix=this._matrix.clone();var i=this._parent;i&&e.preConcatenate(i.getGlobalMatrix(!0)),e._updateVersion=n}return t?e:e.clone()},getApplyMatrix:function(){return this._applyMatrix},setApplyMatrix:function(t){(this._applyMatrix=this._canApplyMatrix&&!!t)&&this.transform(null,!0)},getTransformContent:"#getApplyMatrix",setTransformContent:"#setApplyMatrix"},{getProject:function(){return this._project},_setProject:function(t,e){if(this._project!==t){this._project&&this._installEvents(!1),this._project=t;for(var n=this._children,i=0,r=n&&n.length;r>i;i++)n[i]._setProject(t);e=!0}e&&this._installEvents(!0)},getView:function(){return this._project.getView()},_installEvents:function ot(t){ot.base.call(this,t);for(var e=this._children,n=0,i=e&&e.length;i>n;n++)e[n]._installEvents(t)},getLayer:function(){for(var t=this;t=t._parent;)if(t instanceof w)return t;return null},getParent:function(){return this._parent},setParent:function(t){return t.addChild(this)},getChildren:function(){return this._children},setChildren:function(t){this.removeChildren(),this.addChildren(t)},getFirstChild:function(){return this._children&&this._children[0]||null},getLastChild:function(){return this._children&&this._children[this._children.length-1]||null},getNextSibling:function(){return this._parent&&this._parent._children[this._index+1]||null},getPreviousSibling:function(){return this._parent&&this._parent._children[this._index-1]||null},getIndex:function(){return this._index},equals:function(t){return t===this||t&&this._class===t._class&&this._style.equals(t._style)&&this._matrix.equals(t._matrix)&&this._locked===t._locked&&this._visible===t._visible&&this._blendMode===t._blendMode&&this._opacity===t._opacity&&this._clipMask===t._clipMask&&this._guide===t._guide&&this._equals(t)||!1},_equals:function(t){return e.equals(this._children,t._children)},clone:function(t){return this._clone(new this.constructor(m.NO_INSERT),t)},_clone:function(n,i,r){var s=["_locked","_visible","_blendMode","_opacity","_clipMask","_guide"],a=this._children;n.setStyle(this._style);for(var o=0,h=a&&a.length;h>o;o++)n.addChild(a[o].clone(!1),!0);for(var o=0,h=s.length;h>o;o++){var u=s[o];this.hasOwnProperty(u)&&(n[u]=this[u])}return r!==!1&&n._matrix.initialize(this._matrix),n.setApplyMatrix(this._applyMatrix),n.setPivot(this._pivot),n.setSelected(this._selected),n._data=this._data?e.clone(this._data):null,(i||i===t)&&n.insertAbove(this),this._name&&n.setName(this._name,!0),n},copyTo:function(t){return t.addChild(this.clone(!1))},rasterize:function(t){var n=this.getStrokeBounds(),i=(t||this.getView().getResolution())/72,r=n.getTopLeft().floor(),s=n.getBottomRight().ceil(),a=new l(s.subtract(r)),o=Y.getCanvas(a.multiply(i)),h=o.getContext("2d"),u=(new g).scale(i).translate(r.negate());h.save(),u.applyToContext(h),this.draw(h,new e({matrices:[u]})),h.restore();var c=new b(m.NO_INSERT);return c.setCanvas(o),c.transform((new g).translate(r.add(a.divide(2))).scale(1/i)),c.insertAbove(this),c},contains:function(){return!!this._contains(this._matrix._inverseTransform(h.read(arguments)))},_contains:function(t){if(this._children){for(var e=this._children.length-1;e>=0;e--)if(this._children[e].contains(t))return!0;return!1}return t.isInside(this.getInternalBounds())},isInside:function(){return d.read(arguments).contains(this.getBounds())},_asPathItem:function(){return new A.Rectangle({rectangle:this.getInternalBounds(),matrix:this._matrix,insert:!1})},intersects:function(t,e){return t instanceof m?this._asPathItem().getIntersections(t._asPathItem(),null,e||t._matrix,!0).length>0:!1},hitTest:function(){return this._hitTest(h.read(arguments),S.getOptions(e.read(arguments)))},_hitTest:function(n,i){function r(i,r){var s=g["get"+r]();return n.subtract(s).divide(u).length<=1?new S(i,f,{name:e.hyphenate(r),point:s}):t}if(this._locked||!this._visible||this._guide&&!i.guides||this.isEmpty())return null;var s=this._matrix,a=i._totalMatrix,o=this.getView(),h=i._totalMatrix=a?a.chain(s):this.getGlobalMatrix().preConcatenate(o._matrix),u=i._tolerancePadding=new l(A._getPenPadding(1,h.inverted())).multiply(Math.max(i.tolerance,1e-6));if(n=s._inverseTransform(n),!this._children&&!this.getInternalRoughBounds().expand(u.multiply(2))._containsPoint(n))return null;var c,d=!(i.guides&&!this._guide||i.selected&&!this._selected||i.type&&i.type!==e.hyphenate(this._class)||i["class"]&&!(this instanceof i["class"])),f=this;if(d&&(i.center||i.bounds)&&this._parent){var g=this.getInternalBounds();if(i.center&&(c=r("center","Center")),!c&&i.bounds)for(var _=["TopLeft","TopRight","BottomLeft","BottomRight","LeftCenter","TopCenter","RightCenter","BottomCenter"],v=0;8>v&&!c;v++)c=r("bounds",_[v])}var p=!c&&this._children;if(p)for(var m=this._getChildHitTestOptions(i),v=p.length-1;v>=0&&!c;v--)c=p[v]._hitTest(n,m);return!c&&d&&(c=this._hitTestSelf(n,i)),c&&c.point&&(c.point=s.transform(c.point)),i._totalMatrix=a,c},_getChildHitTestOptions:function(t){return t},_hitTestSelf:function(e,n){return n.fill&&this.hasFill()&&this._contains(e)?new S("fill",this):t},matches:function(t,n){function i(t,n){for(var r in t)if(t.hasOwnProperty(r)){var s=t[r],a=n[r];if(e.isPlainObject(s)&&e.isPlainObject(a)){if(!i(s,a))return!1}else if(!e.equals(s,a))return!1}return!0}var r=typeof t;if("object"===r){for(var s in t)if(t.hasOwnProperty(s)&&!this.matches(s,t[s]))return!1}else{if("function"===r)return t(this);var a=/^(empty|editable)$/.test(t)?this["is"+e.capitalize(t)]():"type"===t?e.hyphenate(this._class):this[t];if(/^(constructor|class)$/.test(t)){if(!(this instanceof n))return!1}else if(n instanceof RegExp){if(!n.test(a))return!1}else if("function"==typeof n){if(!n(a))return!1}else if(e.isPlainObject(n)){if(!i(n,a))return!1}else if(!e.equals(a,n))return!1}return!0},getItems:function(t){return m._getItems(this._children,t,this._matrix)},getItem:function(t){return m._getItems(this._children,t,this._matrix,null,!0)[0]||null},statics:{_getItems:function ht(t,n,i,r,s){if(!r&&"object"==typeof n){var a=n.overlapping,o=n.inside,h=a||o,u=h&&d.read([h]);r={items:[],inside:!!o,overlapping:!!a,rect:u,path:a&&new A.Rectangle({rectangle:u,insert:!1})},h&&(n=e.set({},n,{inside:!0,overlapping:!0}))}var l=r&&r.items,u=r&&r.rect;i=u&&(i||new g);for(var c=0,f=t&&t.length;f>c;c++){var _=t[c],v=i&&i.chain(_._matrix),p=!0;if(u){var h=_.getBounds(v);if(!u.intersects(h))continue;r.inside&&u.contains(h)||r.overlapping&&(h.contains(u)||r.path.intersects(_,v))||(p=!1)}if(p&&_.matches(n)&&(l.push(_),s))break;if(ht(_._children,n,v,r,s),s&&l.length>0)break}return l}}},{importJSON:function(t){var n=e.importJSON(t,this);return n!==this?this.addChild(n):n},addChild:function(e,n){return this.insertChild(t,e,n)},insertChild:function(t,e,n){var i=e?this.insertChildren(t,[e],n):null;return i&&i[0]},addChildren:function(t,e){return this.insertChildren(this._children.length,t,e)},insertChildren:function(t,n,i,r){var s=this._children;if(s&&n&&n.length>0){n=Array.prototype.slice.apply(n);for(var a=n.length-1;a>=0;a--){var o=n[a];if(!r||o instanceof r){var h=o._parent===this&&o._index<t;o._remove(!1,!0)&&h&&t--}else n.splice(a,1)}e.splice(s,n,t,0);for(var u=this._project,l=u&&u._changes,a=0,c=n.length;c>a;a++){var o=n[a];o._parent=this,o._setProject(this._project,!0),o._name&&o.setName(o._name),l&&this._changed(5)}this._changed(11)}else n=null;return n},_insertSibling:function(t,e,n){return this._parent?this._parent.insertChild(t,e,n):null},insertAbove:function(t,e){return t._insertSibling(t._index+1,this,e)},insertBelow:function(t,e){return t._insertSibling(t._index,this,e)},sendToBack:function(){return(this._parent||this instanceof w&&this._project).insertChild(0,this)},bringToFront:function(){return(this._parent||this instanceof w&&this._project).addChild(this)},appendTop:"#addChild",appendBottom:function(t){return this.insertChild(0,t)},moveAbove:"#insertAbove",moveBelow:"#insertBelow",reduce:function(){if(this._children&&1===this._children.length){var t=this._children[0].reduce();return t.insertAbove(this),t.setStyle(this._style),this.remove(),t}return this},_removeNamed:function(){var t=this._parent;if(t){var e=t._children,n=t._namedChildren,i=this._name,r=n[i],s=r?r.indexOf(this):-1;-1!==s&&(e[i]==this&&delete e[i],r.splice(s,1),r.length?e[i]=r[r.length-1]:delete n[i])}},_remove:function(t,n){var i=this._parent;if(i){if(this._name&&this._removeNamed(),null!=this._index&&e.splice(i._children,null,this._index,1),this._installEvents(!1),t){var r=this._project;r&&r._changes&&this._changed(5)}return n&&i._changed(11),this._parent=null,!0}return!1},remove:function(){return this._remove(!0,!0)},replaceWith:function(t){var e=t&&t.insertBelow(this);return e&&this.remove(),e},removeChildren:function(t,n){if(!this._children)return null;t=t||0,n=e.pick(n,this._children.length);for(var i=e.splice(this._children,null,t,n-t),r=i.length-1;r>=0;r--)i[r]._remove(!0,!1);return i.length>0&&this._changed(11),i},clear:"#removeChildren",reverseChildren:function(){if(this._children){this._children.reverse();for(var t=0,e=this._children.length;e>t;t++)this._children[t]._index=t;this._changed(11)}},isEmpty:function(){return!this._children||0===this._children.length},isEditable:function(){for(var t=this;t;){if(!t._visible||t._locked)return!1;t=t._parent}return!0},hasFill:function(){return this.getStyle().hasFill()},hasStroke:function(){return this.getStyle().hasStroke()},hasShadow:function(){return this.getStyle().hasShadow()},_getOrder:function(t){function e(t){var e=[];do e.unshift(t);while(t=t._parent);return e}for(var n=e(this),i=e(t),r=0,s=Math.min(n.length,i.length);s>r;r++)if(n[r]!=i[r])return n[r]._index<i[r]._index?1:-1;return 0},hasChildren:function(){return this._children&&this._children.length>0},isInserted:function(){return this._parent?this._parent.isInserted():!1},isAbove:function(t){return-1===this._getOrder(t)},isBelow:function(t){return 1===this._getOrder(t)},isParent:function(t){return this._parent===t},isChild:function(t){return t&&t._parent===this},isDescendant:function(t){for(var e=this;e=e._parent;)if(e==t)return!0;return!1},isAncestor:function(t){return t?t.isDescendant(this):!1},isSibling:function(t){return this._parent===t._parent},isGroupedWith:function(t){for(var e=this._parent;e;){if(e._parent&&/^(Group|Layer|CompoundPath)$/.test(e._class)&&t.isDescendant(e))return!0;e=e._parent}return!1},translate:function(){var t=new g;return this.transform(t.translate.apply(t,arguments))},rotate:function(t){return this.transform((new g).rotate(t,h.read(arguments,1,{readNull:!0})||this.getPosition(!0)))}},e.each(["scale","shear","skew"],function(t){this[t]=function(){var e=h.read(arguments),n=h.read(arguments,0,{readNull:!0});return this.transform((new g)[t](e,n||this.getPosition(!0)))}},{}),{transform:function(t,e,n,i){t&&t.isIdentity()&&(t=null);var r=this._matrix,s=(e||this._applyMatrix)&&(!r.isIdentity()||t||e&&n&&this._children);if(!t&&!s)return this;if(t&&r.preConcatenate(t),s=s&&this._transformContent(r,n,i)){var a=this._pivot,o=this._style,h=o.getFillColor(!0),u=o.getStrokeColor(!0);a&&r._transformPoint(a,a,!0),h&&h.transform(r),u&&u.transform(r),r.reset(!0),i&&this._canApplyMatrix&&(this._applyMatrix=!0)}var l=this._bounds,c=this._position;this._changed(9);var d=l&&t&&t.decompose();if(d&&!d.shearing&&d.rotation%90===0){for(var f in l){var g=l[f];(s||!g._internal)&&t._transformBounds(g,g)}var _=this._boundsGetter,g=l[_&&_.getBounds||_||"getBounds"];g&&(this._position=g.getCenter(!0)),this._bounds=l}else t&&c&&(this._position=t._transformPoint(c,c));return this},_transformContent:function(t,e,n){var i=this._children;if(i){for(var r=0,s=i.length;s>r;r++)i[r].transform(t,!0,e,n);return!0}},globalToLocal:function(){return this.getGlobalMatrix(!0)._inverseTransform(h.read(arguments))},localToGlobal:function(){return this.getGlobalMatrix(!0)._transformPoint(h.read(arguments))},parentToLocal:function(){return this._matrix._inverseTransform(h.read(arguments))},localToParent:function(){return this._matrix._transformPoint(h.read(arguments))},fitBounds:function(t,e){t=d.read(arguments);var n=this.getBounds(),i=n.height/n.width,r=t.height/t.width,s=(e?i>r:r>i)?t.width/n.width:t.height/n.height,a=new d(new h,new l(n.width*s,n.height*s));a.setCenter(t.getCenter()),this.setBounds(a)},_setStyles:function(t){var e=this._style,n=e.getFillColor(),i=e.getStrokeColor(),r=e.getShadowColor();if(n&&(t.fillStyle=n.toCanvasStyle(t)),i){var s=e.getStrokeWidth();if(s>0){t.strokeStyle=i.toCanvasStyle(t),t.lineWidth=s;var a=e.getStrokeJoin(),o=e.getStrokeCap(),h=e.getMiterLimit();if(a&&(t.lineJoin=a),o&&(t.lineCap=o),h&&(t.miterLimit=h),paper.support.nativeDash){var u=e.getDashArray(),l=e.getDashOffset();u&&u.length&&("setLineDash"in t?(t.setLineDash(u),t.lineDashOffset=l):(t.mozDash=u,t.mozDashOffset=l))}}}if(r){var c=e.getShadowBlur();if(c>0){t.shadowColor=r.toCanvasStyle(t),t.shadowBlur=c;var d=this.getShadowOffset();t.shadowOffsetX=d.x,t.shadowOffsetY=d.y}}},draw:function(t,e,n){function i(t){return a?a.chain(t):t}var r=this._updateVersion=this._project._updateVersion;if(this._visible&&0!==this._opacity){var s=e.matrices,a=e.viewMatrix,o=this._matrix,h=s[s.length-1].chain(o);if(h.isInvertible()){s.push(h),e.updateMatrix&&(h._updateVersion=r,this._globalMatrix=h);var u,l,c,d=this._blendMode,f=this._opacity,g="normal"===d,_=K.nativeModes[d],v=g&&1===f||e.dontStart||e.clip||(_||g&&1>f)&&this._canComposite(),p=e.pixelRatio||1;if(!v){var m=this.getStrokeBounds(i(h));if(!m.width||!m.height)return;c=e.offset,l=e.offset=m.getTopLeft().floor(),u=t,t=Y.getContext(m.getSize().ceil().add(1).multiply(p)),1!==p&&t.scale(p,p)}t.save();var y=n?n.chain(o):!this.getStrokeScaling(!0)&&i(h),w=!v&&e.clipItem,x=!y||w;if(v?(t.globalAlpha=f,_&&(t.globalCompositeOperation=d)):x&&t.translate(-l.x,-l.y),x&&(v?o:i(h)).applyToContext(t),w&&e.clipItem.draw(t,e.extend({clip:!0})),y){t.setTransform(p,0,0,p,0,0);var b=e.offset;b&&t.translate(-b.x,-b.y)}this._draw(t,e,y),t.restore(),s.pop(),e.clip&&!e.dontFinish&&t.clip(),v||(K.process(d,t,u,f,l.subtract(c).multiply(p)),Y.release(t),e.offset=c)}}},_isUpdated:function(t){var e=this._parent;if(e instanceof O)return e._isUpdated(t);var n=this._updateVersion===t;return!n&&e&&e._visible&&e._isUpdated(t)&&(this._updateVersion=t,n=!0),n},_drawSelection:function(t,e,n,i,r){if((this._drawSelected||this._boundsSelected)&&this._isUpdated(r)){var s=this.getSelectedColor(!0)||this.getLayer().getSelectedColor(!0),a=e.chain(this.getGlobalMatrix(!0));if(t.strokeStyle=t.fillStyle=s?s.toCanvasStyle(t):"#009dec",this._drawSelected&&this._drawSelected(t,a,i),this._boundsSelected){var o=n/2,h=a._transformCorners(this.getInternalBounds());t.beginPath();for(var u=0;8>u;u++)t[0===u?"moveTo":"lineTo"](h[u],h[++u]);t.closePath(),t.stroke();for(var u=0;8>u;u++)t.fillRect(h[u]-o,h[++u]-o,n,n)}}},_canComposite:function(){return!1}},e.each(["down","drag","up","move"],function(t){this["removeOn"+e.capitalize(t)]=function(){var e={};return e[t]=!0,this.removeOn(e)}},{removeOn:function(t){for(var e in t)if(t[e]){var n="mouse"+e,i=this._project,r=i._removeSets=i._removeSets||{};r[n]=r[n]||{},r[n][this._id]=this}return this}})),y=m.extend({_class:"Group",_selectChildren:!0,_serializeFields:{children:[]},initialize:function(t){this._children=[],this._namedChildren={},this._initialize(t)||this.addChildren(Array.isArray(t)?t:arguments)},_changed:function ut(e){ut.base.call(this,e),1026&e&&(this._clipItem=t)},_getClipItem:function(){var e=this._clipItem;if(e===t){e=null;for(var n=0,i=this._children.length;i>n;n++){var r=this._children[n];if(r._clipMask){e=r;break}}this._clipItem=e}return e},isClipped:function(){return!!this._getClipItem()},setClipped:function(t){var e=this.getFirstChild();e&&e.setClipMask(t)},_draw:function(t,e){var n=e.clip,i=!n&&this._getClipItem(),r=!0;if(e=e.extend({clipItem:i,clip:!1}),n?this._currentPath?(t.currentPath=this._currentPath,r=!1):(t.beginPath(),e.dontStart=e.dontFinish=!0):i&&i.draw(t,e.extend({clip:!0})),r)for(var s=0,a=this._children.length;a>s;s++){var o=this._children[s];o!==i&&o.draw(t,e)}n&&(this._currentPath=t.currentPath)}}),w=y.extend({_class:"Layer",initialize:function(n){var i=e.isPlainObject(n)?new e(n):{children:Array.isArray(n)?n:arguments},r=i.insert;i.insert=!1,y.call(this,i),(r||r===t)&&(this._project.addChild(this),this.activate())},_remove:function lt(t,n){if(this._parent)return lt.base.call(this,t,n);if(null!=this._index){var i=this._project;return i._activeLayer===this&&(i._activeLayer=this.getNextSibling()||this.getPreviousSibling()),e.splice(i.layers,null,this._index,1),this._installEvents(!1),t&&i._changes&&this._changed(5),n&&(i._needsUpdate=!0),!0}return!1},getNextSibling:function ct(){return this._parent?ct.base.call(this):this._project.layers[this._index+1]||null},getPreviousSibling:function dt(){return this._parent?dt.base.call(this):this._project.layers[this._index-1]||null;
-},isInserted:function ft(){return this._parent?ft.base.call(this):null!=this._index},activate:function(){this._project._activeLayer=this},_insertSibling:function gt(t,e,n){return this._parent?gt.base.call(this,t,e,n):this._project.insertChild(t,e,n)}}),x=m.extend({_class:"Shape",_applyMatrix:!1,_canApplyMatrix:!1,_boundsSelected:!0,_serializeFields:{type:null,size:null,radius:null},initialize:function(t){this._initialize(t)},_equals:function(t){return this._type===t._type&&this._size.equals(t._size)&&e.equals(this._radius,t._radius)},clone:function(t){var e=new x(m.NO_INSERT);return e.setType(this._type),e.setSize(this._size),e.setRadius(this._radius),this._clone(e,t)},getType:function(){return this._type},setType:function(t){this._type=t},getShape:"#getType",setShape:"#setType",getSize:function(){var t=this._size;return new c(t.width,t.height,this,"setSize")},setSize:function(){var t=l.read(arguments);if(this._size){if(!this._size.equals(t)){var e=this._type,n=t.width,i=t.height;if("rectangle"===e){var r=l.min(this._radius,t.divide(2));this._radius.set(r.width,r.height)}else"circle"===e?(n=i=(n+i)/2,this._radius=n/2):"ellipse"===e&&this._radius.set(n/2,i/2);this._size.set(n,i),this._changed(9)}}else this._size=t.clone()},getRadius:function(){var t=this._radius;return"circle"===this._type?t:new c(t.width,t.height,this,"setRadius")},setRadius:function(t){var e=this._type;if("circle"===e){if(t===this._radius)return;var n=2*t;this._radius=t,this._size.set(n,n)}else if(t=l.read(arguments),this._radius){if(this._radius.equals(t))return;if(this._radius.set(t.width,t.height),"rectangle"===e){var n=l.max(this._size,t.multiply(2));this._size.set(n.width,n.height)}else"ellipse"===e&&this._size.set(2*t.width,2*t.height)}else this._radius=t.clone();this._changed(9)},isEmpty:function(){return!1},toPath:function(t){var n=this._clone(new(A[e.capitalize(this._type)])({center:new h,size:this._size,radius:this._radius,insert:!1}),t);return paper.settings.applyMatrix&&n.setApplyMatrix(!0),n},_draw:function(t,e,n){var i=this._style,r=i.hasFill(),s=i.hasStroke(),a=e.dontFinish||e.clip,o=!n;if(r||s||a){var h=this._type,u=this._radius,l="circle"===h;if(e.dontStart||t.beginPath(),o&&l)t.arc(0,0,u,0,2*Math.PI,!0);else{var c=l?u:u.width,d=l?u:u.height,f=this._size,g=f.width,_=f.height;if(o&&"rectangle"===h&&0===c&&0===d)t.rect(-g/2,-_/2,g,_);else{var v=g/2,p=_/2,m=.44771525016920644,y=c*m,w=d*m,x=[-v,-p+d,-v,-p+w,-v+y,-p,-v+c,-p,v-c,-p,v-y,-p,v,-p+w,v,-p+d,v,p-d,v,p-w,v-y,p,v-c,p,-v+c,p,-v+y,p,-v,p-w,-v,p-d];n&&n.transform(x,x,32),t.moveTo(x[0],x[1]),t.bezierCurveTo(x[2],x[3],x[4],x[5],x[6],x[7]),v!==c&&t.lineTo(x[8],x[9]),t.bezierCurveTo(x[10],x[11],x[12],x[13],x[14],x[15]),p!==d&&t.lineTo(x[16],x[17]),t.bezierCurveTo(x[18],x[19],x[20],x[21],x[22],x[23]),v!==c&&t.lineTo(x[24],x[25]),t.bezierCurveTo(x[26],x[27],x[28],x[29],x[30],x[31])}}t.closePath()}a||!r&&!s||(this._setStyles(t),r&&(t.fill(i.getWindingRule()),t.shadowColor="rgba(0,0,0,0)"),s&&t.stroke())},_canComposite:function(){return!(this.hasFill()&&this.hasStroke())},_getBounds:function(t,e){var n=new d(this._size).setCenter(0,0);return"getBounds"!==t&&this.hasStroke()&&(n=n.expand(this.getStrokeWidth())),e?e._transformBounds(n):n}},new function(){function t(t,e,n){var i=t._radius;if(!i.isZero())for(var r=t._size.divide(2),s=0;4>s;s++){var a=new h(1&s?1:-1,s>1?1:-1),o=a.multiply(r),u=o.subtract(a.multiply(i)),l=new d(o,u);if((n?l.expand(n):l).contains(e))return u}}function e(t,e){var n=t.getAngleInRadians(),i=2*e.width,r=2*e.height,s=i*Math.sin(n),a=r*Math.cos(n);return i*r/(2*Math.sqrt(s*s+a*a))}return{_contains:function n(e){if("rectangle"===this._type){var i=t(this,e);return i?e.subtract(i).divide(this._radius).getLength()<=1:n.base.call(this,e)}return e.divide(this.size).getLength()<=.5},_hitTestSelf:function i(n,r){var s=!1;if(this.hasStroke()){var a=this._type,o=this._radius,h=this.getStrokeWidth()+2*r.tolerance;if("rectangle"===a){var u=t(this,n,h);if(u){var l=n.subtract(u);s=2*Math.abs(l.getLength()-e(l,o))<=h}else{var c=new d(this._size).setCenter(0,0),f=c.expand(h),g=c.expand(-h);s=f._containsPoint(n)&&!g._containsPoint(n)}}else"ellipse"===a&&(o=e(n,o)),s=2*Math.abs(n.getLength()-o)<=h}return s?new S("stroke",this):i.base.apply(this,arguments)}}},{statics:new function(){function t(t,n,i,r,s){var a=new x(e.getNamed(s));return a._type=t,a._size=i,a._radius=r,a.translate(n)}return{Circle:function(){var n=h.readNamed(arguments,"center"),i=e.readNamed(arguments,"radius");return t("circle",n,new l(2*i),i,arguments)},Rectangle:function(){var e=d.readNamed(arguments,"rectangle"),n=l.min(l.readNamed(arguments,"radius"),e.getSize(!0).divide(2));return t("rectangle",e.getCenter(!0),e.getSize(!0),n,arguments)},Ellipse:function(){var e=x._readEllipse(arguments),n=e.radius;return t("ellipse",e.center,n.multiply(2),n,arguments)},_readEllipse:function(t){var n,i;if(e.hasNamed(t,"radius"))n=h.readNamed(t,"center"),i=l.readNamed(t,"radius");else{var r=d.readNamed(t,"rectangle");n=r.getCenter(!0),i=r.getSize(!0).divide(2)}return{center:n,radius:i}}}}}),b=m.extend({_class:"Raster",_applyMatrix:!1,_canApplyMatrix:!1,_boundsGetter:"getBounds",_boundsSelected:!0,_serializeFields:{crossOrigin:null,source:null},initialize:function(e,n){this._initialize(e,n!==t&&h.read(arguments,1))||("string"==typeof e?this.setSource(e):this.setImage(e)),this._size||(this._size=new l,this._loaded=!1)},_equals:function(t){return this.getSource()===t.getSource()},clone:function(t){var e=new b(m.NO_INSERT),n=this._image,i=this._canvas;if(n)e.setImage(n);else if(i){var r=Y.getCanvas(this._size);r.getContext("2d").drawImage(i,0,0),e.setImage(r)}return e._crossOrigin=this._crossOrigin,this._clone(e,t)},getSize:function(){var t=this._size;return new c(t?t.width:0,t?t.height:0,this,"setSize")},setSize:function(){var t=l.read(arguments);if(!t.equals(this._size))if(t.width>0&&t.height>0){var e=this.getElement();this.setImage(Y.getCanvas(t)),e&&this.getContext(!0).drawImage(e,0,0,t.width,t.height)}else this._canvas&&Y.release(this._canvas),this._size=t.clone()},getWidth:function(){return this._size?this._size.width:0},setWidth:function(t){this.setSize(t,this.getHeight())},getHeight:function(){return this._size?this._size.height:0},setHeight:function(t){this.setSize(this.getWidth(),t)},isEmpty:function(){var t=this._size;return!t||0===t.width&&0===t.height},getResolution:function(){var t=this._matrix,e=new h(0,0).transform(t),n=new h(1,0).transform(t).subtract(e),i=new h(0,1).transform(t).subtract(e);return new l(72/n.getLength(),72/i.getLength())},getPpi:"#getResolution",getImage:function(){return this._image},setImage:function(t){this._canvas&&Y.release(this._canvas),t&&t.getContext?(this._image=null,this._canvas=t,this._loaded=!0):(this._image=t,this._canvas=null,this._loaded=t&&t.complete),this._size=new l(t?t.naturalWidth||t.width:0,t?t.naturalHeight||t.height:0),this._context=null,this._changed(521)},getCanvas:function(){if(!this._canvas){var t=Y.getContext(this._size);try{this._image&&t.drawImage(this._image,0,0),this._canvas=t.canvas}catch(e){Y.release(t)}}return this._canvas},setCanvas:"#setImage",getContext:function(t){return this._context||(this._context=this.getCanvas().getContext("2d")),t&&(this._image=null,this._changed(513)),this._context},setContext:function(t){this._context=t},getSource:function(){return this._image&&this._image.src||this.toDataURL()},setSource:function(t){function e(){var t=i.getView();t&&(paper=t._scope,i.setImage(n),i.emit("load"),t.update())}var n,i=this,r=this._crossOrigin;n=document.getElementById(t)||new Image,r&&(n.crossOrigin=r),n.naturalWidth&&n.naturalHeight?setTimeout(e,0):(q.add(n,{load:e}),n.src||(n.src=t)),this.setImage(n)},getCrossOrigin:function(){return this._image&&this._image.crossOrigin||this._crossOrigin||""},setCrossOrigin:function(t){this._crossOrigin=t,this._image&&(this._image.crossOrigin=t)},getElement:function(){return this._canvas||this._loaded&&this._image}},{beans:!1,getSubCanvas:function(){var t=d.read(arguments),e=Y.getContext(t.getSize());return e.drawImage(this.getCanvas(),t.x,t.y,t.width,t.height,0,0,t.width,t.height),e.canvas},getSubRaster:function(){var t=d.read(arguments),e=new b(m.NO_INSERT);return e.setImage(this.getSubCanvas(t)),e.translate(t.getCenter().subtract(this.getSize().divide(2))),e._matrix.preConcatenate(this._matrix),e.insertAbove(this),e},toDataURL:function(){var t=this._image&&this._image.src;if(/^data:/.test(t))return t;var e=this.getCanvas();return e?e.toDataURL.apply(e,arguments):null},drawImage:function(t){var e=h.read(arguments,1);this.getContext(!0).drawImage(t,e.x,e.y)},getAverageColor:function(t){var n,i;t?t instanceof z?(i=t,n=t.getBounds()):t.width?n=new d(t):t.x&&(n=new d(t.x-.5,t.y-.5,1,1)):n=this.getBounds();var r=32,s=Math.min(n.width,r),a=Math.min(n.height,r),o=b._sampleContext;o?o.clearRect(0,0,r+1,r+1):o=b._sampleContext=Y.getContext(new l(r)),o.save();var h=(new g).scale(s/n.width,a/n.height).translate(-n.x,-n.y);h.applyToContext(o),i&&i.draw(o,new e({clip:!0,matrices:[h]})),this._matrix.applyToContext(o);var u=this.getElement(),c=this._size;u&&o.drawImage(u,-c.width/2,-c.height/2),o.restore();for(var f=o.getImageData(.5,.5,Math.ceil(s),Math.ceil(a)).data,_=[0,0,0],v=0,p=0,m=f.length;m>p;p+=4){var y=f[p+3];v+=y,y/=255,_[0]+=f[p]*y,_[1]+=f[p+1]*y,_[2]+=f[p+2]*y}for(var p=0;3>p;p++)_[p]/=v;return v?j.read(_):null},getPixel:function(){var t=h.read(arguments),e=this.getContext().getImageData(t.x,t.y,1,1).data;return new j("rgb",[e[0]/255,e[1]/255,e[2]/255],e[3]/255)},setPixel:function(){var t=h.read(arguments),e=j.read(arguments),n=e._convert("rgb"),i=e._alpha,r=this.getContext(!0),s=r.createImageData(1,1),a=s.data;a[0]=255*n[0],a[1]=255*n[1],a[2]=255*n[2],a[3]=null!=i?255*i:255,r.putImageData(s,t.x,t.y)},createImageData:function(){var t=l.read(arguments);return this.getContext().createImageData(t.width,t.height)},getImageData:function(){var t=d.read(arguments);return t.isEmpty()&&(t=new d(this._size)),this.getContext().getImageData(t.x,t.y,t.width,t.height)},setImageData:function(t){var e=h.read(arguments,1);this.getContext(!0).putImageData(t,e.x,e.y)},_getBounds:function(t,e){var n=new d(this._size).setCenter(0,0);return e?e._transformBounds(n):n},_hitTestSelf:function(t){if(this._contains(t)){var e=this;return new S("pixel",e,{offset:t.add(e._size.divide(2)).round(),color:{get:function(){return e.getPixel(this.offset)}}})}},_draw:function(t){var e=this.getElement();e&&(t.globalAlpha=this._opacity,t.drawImage(e,-this._size.width/2,-this._size.height/2))},_canComposite:function(){return!0}}),C=m.extend({_class:"PlacedSymbol",_applyMatrix:!1,_canApplyMatrix:!1,_boundsGetter:{getBounds:"getStrokeBounds"},_boundsSelected:!0,_serializeFields:{symbol:null},initialize:function(e,n){this._initialize(e,n!==t&&h.read(arguments,1))||this.setSymbol(e instanceof p?e:new p(e))},_equals:function(t){return this._symbol===t._symbol},getSymbol:function(){return this._symbol},setSymbol:function(t){this._symbol=t,this._changed(9)},clone:function(t){var e=new C(m.NO_INSERT);return e.setSymbol(this._symbol),this._clone(e,t)},isEmpty:function(){return this._symbol._definition.isEmpty()},_getBounds:function(t,e,n){var i=this.symbol._definition;return i._getCachedBounds(t,e&&e.chain(i._matrix),n)},_hitTestSelf:function(t,e){var n=this._symbol._definition._hitTest(t,e);return n&&(n.item=this),n},_draw:function(t,e){this.symbol._definition.draw(t,e)}}),S=e.extend({_class:"HitResult",initialize:function(t,e,n){this.type=t,this.item=e,n&&(n.enumerable=!0,this.inject(n))},statics:{getOptions:function(t){return new e({type:null,tolerance:paper.settings.hitTolerance,fill:!t,stroke:!t,segments:!t,handles:!1,ends:!1,center:!1,bounds:!1,guides:!1,selected:!1},t)}}}),P=e.extend({_class:"Segment",beans:!0,initialize:function(e,n,i,r,s,a){var o,h,u,l=arguments.length;0===l||(1===l?"point"in e?(o=e.point,h=e.handleIn,u=e.handleOut):o=e:2===l&&"number"==typeof e?o=arguments:3>=l?(o=e,h=n,u=i):(o=e!==t?[e,n]:null,h=i!==t?[i,r]:null,u=s!==t?[s,a]:null)),new k(o,this,"_point"),new k(h,this,"_handleIn"),new k(u,this,"_handleOut")},_serialize:function(t){return e.serialize(this.hasHandles()?[this._point,this._handleIn,this._handleOut]:this._point,t,!0)},_changed:function(t){var e=this._path;if(e){var n,i=e._curves,r=this._index;i&&(t&&t!==this._point&&t!==this._handleIn||!(n=r>0?i[r-1]:e._closed?i[i.length-1]:null)||n._changed(),t&&t!==this._point&&t!==this._handleOut||!(n=i[r])||n._changed()),e._changed(25)}},getPoint:function(){return this._point},setPoint:function(){var t=h.read(arguments);this._point.set(t.x,t.y)},getHandleIn:function(){return this._handleIn},setHandleIn:function(){var t=h.read(arguments);this._handleIn.set(t.x,t.y)},getHandleOut:function(){return this._handleOut},setHandleOut:function(){var t=h.read(arguments);this._handleOut.set(t.x,t.y)},hasHandles:function(){return!this._handleIn.isZero()||!this._handleOut.isZero()},clearHandles:function(){this._handleIn.set(0,0),this._handleOut.set(0,0)},_selectionState:0,isSelected:function(t){var e=this._selectionState;return t?t===this._point?!!(4&e):t===this._handleIn?!!(1&e):t===this._handleOut?!!(2&e):!1:!!(7&e)},setSelected:function(t,e){var n=this._path,t=!!t,i=this._selectionState,r=i,s=e?e===this._point?4:e===this._handleIn?1:e===this._handleOut?2:0:7;t?i|=s:i&=~s,this._selectionState=i,n&&i!==r&&(n._updateSelection(this,r,i),n._changed(129))},getIndex:function(){return this._index!==t?this._index:null},getPath:function(){return this._path||null},getCurve:function(){var t=this._path,e=this._index;return t?(e>0&&!t._closed&&e===t._segments.length-1&&e--,t.getCurves()[e]||null):null},getLocation:function(){var t=this.getCurve();return t?new M(t,this===t._segment1?0:1):null},getNext:function(){var t=this._path&&this._path._segments;return t&&(t[this._index+1]||this._path._closed&&t[0])||null},getPrevious:function(){var t=this._path&&this._path._segments;return t&&(t[this._index-1]||this._path._closed&&t[t.length-1])||null},isFirst:function(){return 0===this._index},isLast:function(){var t=this._path;return t&&this._index===t._segments.length-1||!1},reverse:function(){var t=this._handleIn,e=this._handleOut,n=t._x,i=t._y;t.set(e._x,e._y),e.set(n,i)},reversed:function(){return new P(this._point,this._handleOut,this._handleIn)},remove:function(){return this._path?!!this._path.removeSegment(this._index):!1},clone:function(){return new P(this._point,this._handleIn,this._handleOut)},equals:function(t){return t===this||t&&this._class===t._class&&this._point.equals(t._point)&&this._handleIn.equals(t._handleIn)&&this._handleOut.equals(t._handleOut)||!1},toString:function(){var t=["point: "+this._point];return this._handleIn.isZero()||t.push("handleIn: "+this._handleIn),this._handleOut.isZero()||t.push("handleOut: "+this._handleOut),"{ "+t.join(", ")+" }"},transform:function(t){this._transformCoordinates(t,Array(6),!0),this._changed()},_transformCoordinates:function(t,e,n){var i=this._point,r=n&&this._handleIn.isZero()?null:this._handleIn,s=n&&this._handleOut.isZero()?null:this._handleOut,a=i._x,o=i._y,h=2;return e[0]=a,e[1]=o,r&&(e[h++]=r._x+a,e[h++]=r._y+o),s&&(e[h++]=s._x+a,e[h++]=s._y+o),t&&(t._transformCoordinates(e,e,h/2),a=e[0],o=e[1],n?(i._x=a,i._y=o,h=2,r&&(r._x=e[h++]-a,r._y=e[h++]-o),s&&(s._x=e[h++]-a,s._y=e[h++]-o)):(r||(e[h++]=a,e[h++]=o),s||(e[h++]=a,e[h++]=o))),e}}),k=h.extend({initialize:function(e,n,i){var r,s,a;if(e)if((r=e[0])!==t)s=e[1];else{var o=e;(r=o.x)===t&&(o=h.read(arguments),r=o.x),s=o.y,a=o.selected}else r=s=0;this._x=r,this._y=s,this._owner=n,n[i]=this,a&&this.setSelected(!0)},set:function(t,e){return this._x=t,this._y=e,this._owner._changed(this),this},_serialize:function(t){var e=t.formatter,n=e.number(this._x),i=e.number(this._y);return this.isSelected()?{x:n,y:i,selected:!0}:[n,i]},getX:function(){return this._x},setX:function(t){this._x=t,this._owner._changed(this)},getY:function(){return this._y},setY:function(t){this._y=t,this._owner._changed(this)},isZero:function(){return a.isZero(this._x)&&a.isZero(this._y)},setSelected:function(t){this._owner.setSelected(t,this)},isSelected:function(){return this._owner.isSelected(this)}}),I=e.extend({_class:"Curve",initialize:function(t,e,n,i,r,s,a,o){var h,u,l,c,d,f,g=arguments.length;3===g?(this._path=t,h=e,u=n):0===g?(h=new P,u=new P):1===g?"segment1"in t?(h=new P(t.segment1),u=new P(t.segment2)):"point1"in t?(l=t.point1,d=t.handle1,f=t.handle2,c=t.point2):Array.isArray(t)&&(l=[t[0],t[1]],c=[t[6],t[7]],d=[t[2]-t[0],t[3]-t[1]],f=[t[4]-t[6],t[5]-t[7]]):2===g?(h=new P(t),u=new P(e)):4===g?(l=t,d=e,f=n,c=i):8===g&&(l=[t,e],c=[a,o],d=[n-t,i-e],f=[r-a,s-o]),this._segment1=h||new P(l,null,d),this._segment2=u||new P(c,f,null)},_serialize:function(t){return e.serialize(this.hasHandles()?[this.getPoint1(),this.getHandle1(),this.getHandle2(),this.getPoint2()]:[this.getPoint1(),this.getPoint2()],t,!0)},_changed:function(){this._length=this._bounds=t},clone:function(){return new I(this._segment1,this._segment2)},toString:function(){var t=["point1: "+this._segment1._point];return this._segment1._handleOut.isZero()||t.push("handle1: "+this._segment1._handleOut),this._segment2._handleIn.isZero()||t.push("handle2: "+this._segment2._handleIn),t.push("point2: "+this._segment2._point),"{ "+t.join(", ")+" }"},remove:function(){var t=!1;if(this._path){var e=this._segment2,n=e._handleOut;t=e.remove(),t&&this._segment1._handleOut.set(n.x,n.y)}return t},getPoint1:function(){return this._segment1._point},setPoint1:function(){var t=h.read(arguments);this._segment1._point.set(t.x,t.y)},getPoint2:function(){return this._segment2._point},setPoint2:function(){var t=h.read(arguments);this._segment2._point.set(t.x,t.y)},getHandle1:function(){return this._segment1._handleOut},setHandle1:function(){var t=h.read(arguments);this._segment1._handleOut.set(t.x,t.y)},getHandle2:function(){return this._segment2._handleIn},setHandle2:function(){var t=h.read(arguments);this._segment2._handleIn.set(t.x,t.y)},getSegment1:function(){return this._segment1},getSegment2:function(){return this._segment2},getPath:function(){return this._path},getIndex:function(){return this._segment1._index},getNext:function(){var t=this._path&&this._path._curves;return t&&(t[this._segment1._index+1]||this._path._closed&&t[0])||null},getPrevious:function(){var t=this._path&&this._path._curves;return t&&(t[this._segment1._index-1]||this._path._closed&&t[t.length-1])||null},isFirst:function(){return 0===this._segment1._index},isLast:function(){var t=this._path;return t&&this._segment1._index===t._curves.length-1||!1},isSelected:function(){return this.getPoint1().isSelected()&&this.getHandle2().isSelected()&&this.getHandle2().isSelected()&&this.getPoint2().isSelected()},setSelected:function(t){this.getPoint1().setSelected(t),this.getHandle1().setSelected(t),this.getHandle2().setSelected(t),this.getPoint2().setSelected(t)},getValues:function(t){return I.getValues(this._segment1,this._segment2,t)},getPoints:function(){for(var t=this.getValues(),e=[],n=0;8>n;n+=2)e.push(new h(t[n],t[n+1]));return e},getLength:function(){return null==this._length&&(this._length=I.getLength(this.getValues(),0,1)),this._length},getArea:function(){return I.getArea(this.getValues())},getLine:function(){return new _(this._segment1._point,this._segment2._point)},getPart:function(t,e){return new I(I.getPart(this.getValues(),t,e))},getPartLength:function(t,e){return I.getLength(this.getValues(),t,e)},getIntersections:function(t){return I._getIntersections(this.getValues(),t&&t!==this?t.getValues():null,this,t,[],{})},_getParameter:function(e,n){return n?e:e&&e.curve===this?e.parameter:e===t&&n===t?.5:this.getParameterAt(e,0)},divide:function(t,e,n){var i=this._getParameter(t,e),r=4e-7,s=1-r,a=null;if(i>=r&&s>=i){var o=I.subdivide(this.getValues(),i),u=o[0],l=o[1],c=n||this.hasHandles(),d=this._segment1,f=this._segment2,g=this._path;c&&(d._handleOut.set(u[2]-u[0],u[3]-u[1]),f._handleIn.set(l[4]-l[6],l[5]-l[7]));var _=u[6],v=u[7],p=new P(new h(_,v),c&&new h(u[4]-_,u[5]-v),c&&new h(l[2]-_,l[3]-v));g?(g.insert(d._index+1,p),a=this.getNext()):(this._segment2=p,a=new I(p,f))}return a},split:function(t,e){return this._path?this._path.split(this._segment1._index,this._getParameter(t,e)):null},reversed:function(){return new I(this._segment2.reversed(),this._segment1.reversed())},clearHandles:function(){this._segment1._handleOut.set(0,0),this._segment2._handleIn.set(0,0)},statics:{getValues:function(t,e,n){var i=t._point,r=t._handleOut,s=e._handleIn,a=e._point,o=[i._x,i._y,i._x+r._x,i._y+r._y,a._x+s._x,a._y+s._y,a._x,a._y];return n&&n._transformCoordinates(o,o,4),o},subdivide:function(e,n){var i=e[0],r=e[1],s=e[2],a=e[3],o=e[4],h=e[5],u=e[6],l=e[7];n===t&&(n=.5);var c=1-n,d=c*i+n*s,f=c*r+n*a,g=c*s+n*o,_=c*a+n*h,v=c*o+n*u,p=c*h+n*l,m=c*d+n*g,y=c*f+n*_,w=c*g+n*v,x=c*_+n*p,b=c*m+n*w,C=c*y+n*x;return[[i,r,d,f,m,y,b,C],[b,C,w,x,v,p,u,l]]},solveCubic:function(t,e,n,i,r,s){var o=t[e],h=t[e+2],u=t[e+4],l=t[e+6],c=3*(h-o),d=3*(u-h)-c,f=l-o-c-d;return a.solveCubic(f,d,c,o-n,i,r,s)},getParameterOf:function(t,e){var n=new h(t[0],t[1]),i=new h(t[6],t[7]),r=1e-12,s=e.isClose(n,r)?0:e.isClose(i,r)?1:null;if(null!==s)return s;for(var a=[e.x,e.y],o=[],u=2e-7,l=0;2>l;l++)for(var c=I.solveCubic(t,l,a[l],o,0,1),d=0;c>d;d++)if(s=o[d],e.isClose(I.getPoint(t,s),u))return s;return e.isClose(n,u)?0:e.isClose(i,u)?1:null},getNearestParameter:function(t,e){function n(n){if(n>=0&&1>=n){var i=e.getDistance(I.getPoint(t,n),!0);if(f>i)return f=i,g=n,!0}}if(I.isStraight(t)){var i=t[0],r=t[1],s=t[6],a=t[7],o=s-i,u=a-r,l=o*o+u*u;if(0===l)return 0;var c=((e.x-i)*o+(e.y-r)*u)/l;return 1e-12>c?0:c>.999999999999?1:I.getParameterOf(t,new h(i+c*o,r+c*u))}for(var d=100,f=1/0,g=0,_=0;d>=_;_++)n(_/d);for(var v=1/(2*d);v>4e-7;)n(g-v)||n(g+v)||(v/=2);return g},getPart:function(t,e,n){var i=e>n;if(i){var r=e;e=n,n=r}return e>0&&(t=I.subdivide(t,e)[1]),1>n&&(t=I.subdivide(t,(n-e)/(1-e))[0]),i?[t[6],t[7],t[4],t[5],t[2],t[3],t[0],t[1]]:t},hasHandles:function(t){var e=a.isZero;return!(e(t[0]-t[2])&&e(t[1]-t[3])&&e(t[4]-t[6])&&e(t[5]-t[7]))},isFlatEnough:function(t,e){var n=t[0],i=t[1],r=t[2],s=t[3],a=t[4],o=t[5],h=t[6],u=t[7],l=3*r-2*n-h,c=3*s-2*i-u,d=3*a-2*h-n,f=3*o-2*u-i;return Math.max(l*l,d*d)+Math.max(c*c,f*f)<10*e*e},getArea:function(t){var e=t[0],n=t[1],i=t[6],r=t[7],s=(t[2]+e)/2,a=(t[3]+n)/2,o=(t[4]+t[6])/2,h=(t[5]+t[7])/2;return 6*((e-s)*(a+n)+(s-o)*(h+a)+(o-i)*(r+h))/10},getBounds:function(t){for(var e=t.slice(0,2),n=e.slice(),i=[0,0],r=0;2>r;r++)I._addBounds(t[r],t[r+2],t[r+4],t[r+6],r,0,e,n,i);return new d(e[0],e[1],n[0]-e[0],n[1]-e[1])},_addBounds:function(t,e,n,i,r,s,o,h,u){function l(t,e){var n=t-e,i=t+e;n<o[r]&&(o[r]=n),i>h[r]&&(h[r]=i)}var c=3*(e-n)-t+i,d=2*(t+n)-4*e,f=e-t,g=a.solveQuadratic(c,d,f,u),_=4e-7,v=1-_;l(i,0);for(var p=0;g>p;p++){var m=u[p],y=1-m;m>_&&v>m&&l(y*y*y*t+3*y*y*m*e+3*y*m*m*n+m*m*m*i,s)}}}},e.each(["getBounds","getStrokeBounds","getHandleBounds","getRoughBounds"],function(t){this[t]=function(){this._bounds||(this._bounds={});var e=this._bounds[t];if(!e){var n=this._path;e=this._bounds[t]=A[t]([this._segment1,this._segment2],!1,n&&n.getStyle())}return e.clone()}},{}),e.each({isStraight:function(t,e,n){if(e.isZero()&&n.isZero())return!0;if(t.isZero())return!1;if(e.isCollinear(t)&&n.isCollinear(t)){var i=t.dot(t),r=t.dot(e)/i,s=t.dot(n)/i;return r>=0&&1>=r&&0>=s&&s>=-1}return!1},isLinear:function(t,e,n){var i=t.divide(3);return e.equals(i)&&n.negate().equals(i)}},function(t,e){this[e]=function(){var e=this._segment1,n=this._segment2;return t(n._point.subtract(e._point),e._handleOut,n._handleIn)},this.statics[e]=function(e){var n=e[0],i=e[1],r=e[6],s=e[7];return t(new h(r-n,s-i),new h(e[2]-n,e[3]-i),new h(e[4]-r,e[5]-s))}},{statics:{},hasHandles:function(){return!this._segment1._handleOut.isZero()||!this._segment2._handleIn.isZero()},isCollinear:function(t){return t&&this.isStraight()&&t.isStraight()&&this.getLine().isCollinear(t.getLine())},isHorizontal:function(){return this.isStraight()&&Math.abs(this.getTangentAt(.5,!0).y)<1e-7},isVertical:function(){return this.isStraight()&&Math.abs(this.getTangentAt(.5,!0).x)<1e-7}}),{beans:!1,getParameterAt:function(t,e){return I.getParameterAt(this.getValues(),t,e)},getParameterOf:function(){return I.getParameterOf(this.getValues(),h.read(arguments))},getLocationAt:function(t,e){var n=e?t:this.getParameterAt(t);return null!=n&&n>=0&&1>=n?new M(this,n):null},getLocationOf:function(){return this.getLocationAt(this.getParameterOf(h.read(arguments)),!0)},getOffsetOf:function(){var t=this.getLocationOf.apply(this,arguments);return t?t.getOffset():null},getNearestLocation:function(){var t=h.read(arguments),e=this.getValues(),n=I.getNearestParameter(e,t),i=I.getPoint(e,n);return new M(this,n,i,null,t.getDistance(i))},getNearestPoint:function(){return this.getNearestLocation.apply(this,arguments).getPoint()}},new function(){var t=["getPoint","getTangent","getNormal","getWeightedTangent","getWeightedNormal","getCurvature"];return e.each(t,function(t){this[t+"At"]=function(e,n){var i=this.getValues();return I[t](i,n?e:I.getParameterAt(i,e,0))}},{statics:{evaluateMethods:t}})},new function(){function e(t){var e=t[0],n=t[1],i=t[2],r=t[3],s=t[4],a=t[5],o=t[6],h=t[7],u=9*(i-s)+3*(o-e),l=6*(e+s)-12*i,c=3*(i-e),d=9*(r-a)+3*(h-n),f=6*(n+a)-12*r,g=3*(r-n);return function(t){var e=(u*t+l)*t+c,n=(d*t+f)*t+g;return Math.sqrt(e*e+n*n)}}function n(t,e){return Math.max(2,Math.min(16,Math.ceil(32*Math.abs(e-t))))}function i(t,e,n,i){if(null==e||0>e||e>1)return null;var r,s,a=t[0],o=t[1],u=t[2],l=t[3],c=t[4],d=t[5],f=t[6],g=t[7],_=4e-7,v=1-_;if(0===n&&(_>e||e>v)){var p=_>e;r=p?a:f,s=p?o:g}else{var m=3*(u-a),y=3*(c-u)-m,w=f-a-m-y,x=3*(l-o),b=3*(d-l)-x,C=g-o-x-b;if(0===n)r=((w*e+y)*e+m)*e+a,s=((C*e+b)*e+x)*e+o;else{if(_>e?(r=m,s=x):e>v?(r=3*(f-c),s=3*(g-d)):(r=(3*w*e+2*y)*e+m,s=(3*C*e+2*b)*e+x),i){0===r&&0===s&&(_>e||e>v)&&(r=c-u,s=d-l);var S=Math.sqrt(r*r+s*s);S&&(r/=S,s/=S)}if(3===n){var P=6*w*e+2*y,k=6*C*e+2*b,I=Math.pow(r*r+s*s,1.5);r=0!==I?(r*k-s*P)/I:0,s=0}}}return 2===n?new h(s,-r):new h(r,s)}return{statics:{getLength:function(i,r,s){if(r===t&&(r=0),s===t&&(s=1),0===r&&1===s&&I.isStraight(i)){var o=i[6]-i[0],h=i[7]-i[1];return Math.sqrt(o*o+h*h)}var u=e(i);return a.integrate(u,r,s,n(r,s))},getParameterAt:function(i,r,s){function o(t){return _+=a.integrate(d,s,t,n(s,t)),s=t,_-r}if(s===t&&(s=0>r?1:0),0===r)return s;var h=Math.abs,u=r>0,l=u?s:0,c=u?1:s,d=e(i),f=a.integrate(d,l,c,n(l,c));if(h(r-f)<1e-12)return u?c:l;if(h(r)>f)return null;var g=r/f,_=0;return a.findRoot(o,d,s+g,l,c,32,1e-12)},getPoint:function(t,e){return i(t,e,0,!1)},getTangent:function(t,e){return i(t,e,1,!0)},getWeightedTangent:function(t,e){return i(t,e,1,!1)},getNormal:function(t,e){return i(t,e,2,!0)},getWeightedNormal:function(t,e){return i(t,e,2,!1)},getCurvature:function(t,e){return i(t,e,3,!1).x}}}},new function(){function t(t,e,n,i,r,s,a,o,h,u,l){var c=e.startConnected,d=e.endConnected,f=4e-7,g=1-f;if(null==r&&(r=I.getParameterOf(n,s)),null!==r&&r>=(c?f:0)&&(d?g:1)>=r&&(null==h&&(h=I.getParameterOf(a,u)),null!==h&&h>=(d?f:0)&&(c?g:1)>=h)){var _=e.renormalize;if(_){var v=_(r,h);r=v[0],h=v[1]}var p=new M(i,r,s||I.getPoint(n,r),l),m=new M(o,h,u||I.getPoint(a,h),l),y=p.getPath()===m.getPath()&&p.getIndex()>m.getIndex(),w=y?m:p,x=e.include;p._intersection=m,m._intersection=p,(!x||x(w))&&M.insert(t,w,!0)}}function e(r,s,a,o,h,u,l,c,d,f,g,v,p){if(!(++p>=24)){var m,y,w=s[0],x=s[1],b=s[6],C=s[7],S=_.getSignedDistance,P=S(w,x,b,C,s[2],s[3]),k=S(w,x,b,C,s[4],s[5]),M=P*k>0?.75:4/9,z=M*Math.min(0,P,k),A=M*Math.max(0,P,k),O=S(w,x,b,C,r[0],r[1]),T=S(w,x,b,C,r[2],r[3]),E=S(w,x,b,C,r[4],r[5]),L=S(w,x,b,C,r[6],r[7]),N=n(O,T,E,L),j=N[0],B=N[1];if(null!=(m=i(j,B,z,A))&&null!=(y=i(j.reverse(),B.reverse(),z,A))){r=I.getPart(r,m,y);var R=y-m,D=l+(c-l)*m,F=l+(c-l)*y;if(g>.5&&R>.5)if(F-D>f-d){var q=I.subdivide(r,.5),V=D+(F-D)/2;e(s,q[0],o,a,h,u,d,f,D,V,R,!v,p),e(s,q[1],o,a,h,u,d,f,V,F,R,!v,p)}else{var q=I.subdivide(s,.5),V=d+(f-d)/2;e(q[0],r,o,a,h,u,d,V,D,F,R,!v,p),e(q[1],r,o,a,h,u,V,f,D,F,R,!v,p)}else if(Math.max(f-d,F-D)<1e-7){var H=D+(F-D)/2,Z=d+(f-d)/2;r=a.getValues(),s=o.getValues(),t(h,u,v?s:r,v?o:a,v?Z:H,null,v?r:s,v?a:o,v?H:Z,null)}else R>1e-12&&e(s,r,o,a,h,u,d,f,D,F,R,!v,p)}}}function n(t,e,n,i){var r,s=[0,t],a=[1/3,e],o=[2/3,n],h=[1,i],u=e-(2*t+i)/3,l=n-(t+2*i)/3;if(0>u*l)r=[[s,a,h],[s,o,h]];else{var c=u/l;r=[c>=2?[s,a,h]:.5>=c?[s,o,h]:[s,a,o,h],[s,h]]}return 0>(u||l)?r.reverse():r}function i(t,e,n,i){return t[0][1]<n?r(t,!0,n):e[0][1]>i?r(e,!1,i):t[0][0]}function r(t,e,n){for(var i=t[0][0],r=t[0][1],s=1,a=t.length;a>s;s++){var o=t[s][0],h=t[s][1];if(e?h>=n:n>=h)return h===n?o:i+(n-r)*(o-i)/(h-r);i=o,r=h}return null}function s(e,n,i,r,s,o){for(var h=I.isStraight(e),u=h?n:e,l=h?e:n,c=l[0],d=l[1],f=l[6],g=l[7],_=f-c,v=g-d,p=Math.atan2(-v,_),m=Math.sin(p),y=Math.cos(p),w=[],x=0;8>x;x+=2){var b=u[x]-c,C=u[x+1]-d;w.push(b*y-C*m,b*m+C*y)}for(var S=[],P=I.solveCubic(w,1,0,S,0,1),x=0;P>x;x++){var k=S[x],M=I.getPoint(u,k),z=I.getParameterOf(l,M);if(null!==z){var A=I.getPoint(l,z),O=h?z:k,T=h?k:z;(!o.endConnected||T>a.CURVETIME_EPSILON)&&t(s,o,e,i,O,h?A:M,n,r,T,h?M:A)}}}function o(e,n,i,r,s,a){var o=_.intersect(e[0],e[1],e[6],e[7],n[0],n[1],n[6],n[7]);o&&t(s,a,e,i,null,o,n,r,null,o)}return{statics:{_getIntersections:function(n,i,r,a,u,l){if(!i)return I._getSelfIntersection(n,r,u,l);var c=n[0],d=n[1],f=n[6],g=n[7],_=i[0],v=i[1],p=i[6],m=i[7],y=(3*n[2]+c)/4,w=(3*n[3]+d)/4,x=(3*n[4]+f)/4,b=(3*n[5]+g)/4,C=(3*i[2]+_)/4,S=(3*i[3]+v)/4,P=(3*i[4]+p)/4,k=(3*i[5]+m)/4,M=Math.min,z=Math.max;if(!(z(c,y,x,f)>=M(_,C,P,p)&&M(c,y,x,f)<=z(_,C,P,p)&&z(d,w,b,g)>=M(v,S,k,m)&&M(d,w,b,g)<=z(v,S,k,m)))return u;if(!l.startConnected&&!l.endConnected){var A=I.getOverlaps(n,i);if(A){for(var O=0;2>O;O++){var T=A[O];t(u,l,n,r,T[0],null,i,a,T[1],null,!0)}return u}}var E=I.isStraight(n),L=I.isStraight(i),N=E&&L,j=1e-12,B=u.length;if((N?o:E||L?s:e)(n,i,r,a,u,l,0,1,0,1,0,!1,0),N&&u.length>B)return u;var R=new h(c,d),D=new h(f,g),F=new h(_,v),q=new h(p,m);return R.isClose(F,j)&&t(u,l,n,r,0,R,i,a,0,F),!l.startConnected&&R.isClose(q,j)&&t(u,l,n,r,0,R,i,a,1,q),!l.endConnected&&D.isClose(F,j)&&t(u,l,n,r,1,D,i,a,0,F),D.isClose(q,j)&&t(u,l,n,r,1,D,i,a,1,q),u},_getSelfIntersection:function(t,e,n,i){var r=t[0],s=t[1],o=t[2],u=t[3],l=t[4],c=t[5],d=t[6],f=t[7],g=new _(r,s,d,f,!1),v=g.getSide(new h(o,u),!0),p=g.getSide(new h(l,c),!0);if(v===p){var m=(r-l)*(u-f)+(o-d)*(c-s);if(m*v>0)return n}var y=d-3*l+3*o-r,w=l-2*o+r,x=o-r,b=f-3*c+3*u-s,C=c-2*u+s,S=u-s,P=b*x-y*S,k=b*w-y*C,M=C*x-w*S;if(0>P*P-4*k*M){var z,A=[],O=a.solveCubic(y*y+b*b,3*(y*w+b*C),2*(w*w+C*C)+y*x+b*S,w*x+C*S,A,0,1);if(O>0){for(var T=0,E=0;O>T;T++){var L=Math.abs(e.getCurvatureAt(A[T],!0));L>E&&(E=L,z=A[T])}var N=I.subdivide(t,z);i.endConnected=!0,i.renormalize=function(t,e){return[t*z,e*(1-z)+z]},I._getIntersections(N[0],N[1],e,e,n,i)}}return n},getOverlaps:function(t,e){function n(t){var e=t[6]-t[0],n=t[7]-t[1];return e*e+n*n}var i=Math.abs,r=4e-7,s=2e-7,a=I.isStraight(t),o=I.isStraight(e),u=a&&o;if(u){var l=n(t)<n(e),c=l?e:t,d=l?t:e,f=new _(c[0],c[1],c[6],c[7]);if(f.getDistance(new h(d[0],d[1]))>s||f.getDistance(new h(d[6],d[7]))>s)return null}else if(a^o)return null;for(var g=[t,e],v=[],p=0,m=0;2>p&&v.length<2;p+=0===m?0:1,m=1^m){var y=I.getParameterOf(g[1^p],new h(g[p][0===m?0:6],g[p][0===m?1:7]));if(null!=y){var w=0===p?[m,y]:[y,m];(0===v.length||i(w[0]-v[0][0])>r&&i(w[1]-v[0][1])>r)&&v.push(w)}if(1===p&&0===v.length)break}if(2!==v.length)v=null;else if(!u){var x=I.getPart(t,v[0][0],v[1][0]),b=I.getPart(e,v[0][1],v[1][1]);(i(b[2]-x[2])>s||i(b[3]-x[3])>s||i(b[4]-x[4])>s||i(b[5]-x[5])>s)&&(v=null)}return v}}}}),M=e.extend({_class:"CurveLocation",beans:!0,initialize:function _t(t,e,n,i,r){if(e>.9999996){var s=t.getNext();s&&(e=0,t=s)}this._id=o.get(_t),this._setCurve(t),this._parameter=e,this._point=n||t.getPointAt(e,!0),this._overlap=i,this._distance=r,this._intersection=this._next=this._prev=null},_setCurve:function(t){var e=t._path;
-this._version=e?e._version:0,this._curve=t,this._segment=null,this._segment1=t._segment1,this._segment2=t._segment2},_setSegment:function(t){this._setCurve(t.getCurve()),this._segment=t,this._parameter=t===this._segment1?0:1,this._point=t._point.clone()},getSegment:function(){var t=this.getCurve(),e=this._segment;if(!e){var n=this.getParameter();0===n?e=t._segment1:1===n?e=t._segment2:null!=n&&(e=t.getPartLength(0,n)<t.getPartLength(n,1)?t._segment1:t._segment2),this._segment=e}return e},getCurve:function(){function e(e){var n=e&&e.getCurve();return n&&null!=(r._parameter=n.getParameterOf(r._point))?(r._setCurve(n),r._segment=e,n):t}var n=this._curve,i=n&&n._path,r=this;return i&&i._version!==this._version&&(n=this._parameter=this._curve=this._offset=null),n||e(this._segment)||e(this._segment1)||e(this._segment2.getPrevious())},getPath:function(){var t=this.getCurve();return t&&t._path},getIndex:function(){var t=this.getCurve();return t&&t.getIndex()},getParameter:function(){var t=this.getCurve(),e=this._parameter;return t&&null==e?this._parameter=t.getParameterOf(this._point):e},getPoint:function(){return this._point},getOffset:function(){var t=this._offset;if(null==t){t=0;var e=this.getPath(),n=this.getIndex();if(e&&null!=n)for(var i=e.getCurves(),r=0;n>r;r++)t+=i[r].getLength();this._offset=t+=this.getCurveOffset()}return t},getCurveOffset:function(){var t=this.getCurve(),e=this.getParameter();return null!=e&&t&&t.getPartLength(0,e)},getIntersection:function(){return this._intersection},getDistance:function(){return this._distance},divide:function(){var t=this.getCurve(),e=null;return t&&(e=t.divide(this.getParameter(),!0),e&&this._setSegment(e._segment1)),e},split:function(){var t=this.getCurve();return t?t.split(this.getParameter(),!0):null},equals:function(t,e){var n=this===t,i=2e-7;if(!n&&t instanceof M&&this.getPath()===t.getPath()&&this.getPoint().isClose(t.getPoint(),i)){var r=this.getCurve(),s=t.getCurve(),a=Math.abs,o=a((r.isLast()&&s.isFirst()?-1:r.getIndex())+this.getParameter()-((s.isLast()&&r.isFirst()?-1:s.getIndex())+t.getParameter()));n=(4e-7>o||(o=a(this.getOffset()-t.getOffset()))<i||a(this.getPath().getLength()-o)<i)&&(e||!this._intersection&&!t._intersection||this._intersection&&this._intersection.equals(t._intersection,!0))}return n},toString:function(){var t=[],e=this.getPoint(),n=s.instance;e&&t.push("point: "+e);var i=this.getIndex();null!=i&&t.push("index: "+i);var r=this.getParameter();return null!=r&&t.push("parameter: "+n.number(r)),null!=this._distance&&t.push("distance: "+n.number(this._distance)),"{ "+t.join(", ")+" }"},isTouching:function(){var t=this._intersection;if(t&&this.getTangent().isCollinear(t.getTangent())){var e=this.getCurve(),n=t.getCurve();return!(e.isStraight()&&n.isStraight()&&e.getLine().intersect(n.getLine()))}return!1},isCrossing:function(){function t(t,e,n){return n>e?t>e&&n>t:t>e&&l>=t||t>=-l&&n>t}var e=this._intersection;if(!e)return!1;var n=this.getParameter(),i=e.getParameter(),r=4e-7,s=1-r;if(n>=r&&s>=n||i>=r&&s>=i)return!this.isTouching();var a=this.getCurve(),o=a.getPrevious(),h=e.getCurve(),u=h.getPrevious(),l=Math.PI;if(!o||!u)return!1;var c=o.getTangentAt(s,!0).negate().getAngleInRadians(),d=a.getTangentAt(r,!0).getAngleInRadians(),f=u.getTangentAt(s,!0).negate().getAngleInRadians(),g=h.getTangentAt(r,!0).getAngleInRadians();return t(f,c,d)^t(g,c,d)&&t(f,d,c)^t(g,d,c)},isOverlap:function(){return!!this._overlap}},e.each(I.evaluateMethods,function(t){var e=t+"At";this[t]=function(){var t=this.getParameter(),n=this.getCurve();return null!=t&&n&&n[e](t,!0)}},{preserve:!0}),new function(){function t(t,e,n){function i(n,i){for(var s=n+i;s>=-1&&r>=s;s+=i){var a=t[(s%r+r)%r];if(!e.getPoint().isClose(a.getPoint(),2e-7))break;if(e.equals(a))return a}return null}for(var r=t.length,s=0,a=r-1;a>=s;){var o,h=s+a>>>1,u=t[h];if(n&&(o=e.equals(u)?u:i(h,-1)||i(h,1)))return e._overlap&&(o._overlap=o._intersection._overlap=!0),o;var l=e.getPath(),c=u.getPath(),d=l===c?e.getIndex()+e.getParameter()-(u.getIndex()+u.getParameter()):l._id-c._id;0>d?a=h-1:s=h+1}return t.splice(s,0,e),e}return{statics:{insert:t,expand:function(e){for(var n=e.slice(),i=0,r=e.length;r>i;i++)t(n,e[i]._intersection,!1);return n}}}}),z=m.extend({_class:"PathItem",initialize:function(){},getIntersections:function(t,e,n,i){var r=this===t||!t,s=this._matrix.orNullIfIdentity(),a=r?s:(n||t._matrix).orNullIfIdentity();if(!r&&!this.getBounds(s).touches(t.getBounds(a)))return[];for(var o,t,h=this.getCurves(),u=r?h:t.getCurves(),l=h.length,c=r?l:u.length,d=[],f=[],g=0;c>g;g++)d[g]=u[g].getValues(a);for(var g=0;l>g;g++){var _=h[g],v=r?d[g]:_.getValues(s),p=_.getPath();p!==t&&(t=p,o=[],f.push(o)),r&&I._getSelfIntersection(v,_,o,{include:e,startConnected:1===l&&_.getPoint1().equals(_.getPoint2())});for(var m=r?g+1:0;c>m;m++){if(i&&o.length)return o;var y=u[m];I._getIntersections(v,d[m],_,y,o,{include:e,startConnected:r&&_.getPrevious()===y,endConnected:r&&_.getNext()===y})}}o=[];for(var g=0,w=f.length;w>g;g++)o.push.apply(o,f[g]);return o},getCrossings:function(t){return this.getIntersections(t,function(t){return t.isCrossing()})},_asPathItem:function(){return this},setPathData:function(t){function e(t,e){var n=+i[t];return o&&(n+=u[e]),n}function n(t){return new h(e(t,"x"),e(t+1,"y"))}var i,r,s,a=t.match(/[mlhvcsqtaz][^mlhvcsqtaz]*/gi),o=!1,u=new h,c=new h;this.clear();for(var d=0,f=a&&a.length;f>d;d++){var g=a[d],_=g[0],v=_.toLowerCase();i=g.match(/[+-]?(?:\d*\.\d+|\d+\.?)(?:[eE][+-]?\d+)?/g);var p=i&&i.length;switch(o=_===v,"z"!==r||/[mz]/.test(v)||this.moveTo(u=c),v){case"m":case"l":for(var m="m"===v,y=0;p>y;y+=2)this[0===y&&m?"moveTo":"lineTo"](u=n(y));s=u,m&&(c=u);break;case"h":case"v":for(var w="h"===v?"x":"y",y=0;p>y;y++)u[w]=e(y,w),this.lineTo(u);s=u;break;case"c":for(var y=0;p>y;y+=6)this.cubicCurveTo(n(y),s=n(y+2),u=n(y+4));break;case"s":for(var y=0;p>y;y+=4)this.cubicCurveTo(/[cs]/.test(r)?u.multiply(2).subtract(s):u,s=n(y),u=n(y+2)),r=v;break;case"q":for(var y=0;p>y;y+=4)this.quadraticCurveTo(s=n(y),u=n(y+2));break;case"t":for(var y=0;p>y;y+=2)this.quadraticCurveTo(s=/[qt]/.test(r)?u.multiply(2).subtract(s):u,u=n(y)),r=v;break;case"a":for(var y=0;p>y;y+=7)this.arcTo(u=n(y+5),new l(+i[y],+i[y+1]),+i[y+2],+i[y+4],+i[y+3]);break;case"z":this.closePath(!0)}r=v}},_canComposite:function(){return!(this.hasFill()&&this.hasStroke())},_contains:function(t){var e=this._getWinding(t,!1,!0);return!!("evenodd"===this.getWindingRule()?1&e:e)}}),A=z.extend({_class:"Path",_serializeFields:{segments:[],closed:!1},initialize:function(e){this._closed=!1,this._segments=[],this._version=0;var n=Array.isArray(e)?"object"==typeof e[0]?e:arguments:!e||e.size!==t||e.x===t&&e.point===t?null:arguments;n&&n.length>0?this.setSegments(n):(this._curves=t,this._selectedSegmentState=0,n||"string"!=typeof e||(this.setPathData(e),e=null)),this._initialize(!n&&e)},_equals:function(t){return this._closed===t._closed&&e.equals(this._segments,t._segments)},clone:function(e){var n=new A(m.NO_INSERT);return n.setSegments(this._segments),n._closed=this._closed,this._clockwise!==t&&(n._clockwise=this._clockwise),this._clone(n,e)},_changed:function vt(e){if(vt.base.call(this,e),8&e){var n=this._parent;if(n&&(n._currentPath=t),this._length=this._area=this._clockwise=this._monoCurves=t,16&e)this._version++;else if(this._curves)for(var i=0,r=this._curves.length;r>i;i++)this._curves[i]._changed()}else 32&e&&(this._bounds=t)},getStyle:function(){var t=this._parent;return(t instanceof O?t:this)._style},getSegments:function(){return this._segments},setSegments:function(e){var n=this.isFullySelected();this._segments.length=0,this._selectedSegmentState=0,this._curves=t,e&&e.length>0&&this._add(P.readAll(e)),n&&this.setFullySelected(!0)},getFirstSegment:function(){return this._segments[0]},getLastSegment:function(){return this._segments[this._segments.length-1]},getCurves:function(){var t=this._curves,e=this._segments;if(!t){var n=this._countCurves();t=this._curves=Array(n);for(var i=0;n>i;i++)t[i]=new I(this,e[i],e[i+1]||e[0])}return t},getFirstCurve:function(){return this.getCurves()[0]},getLastCurve:function(){var t=this.getCurves();return t[t.length-1]},isClosed:function(){return this._closed},setClosed:function(t){if(this._closed!=(t=!!t)){if(this._closed=t,this._curves){var e=this._curves.length=this._countCurves();t&&(this._curves[e-1]=new I(this,this._segments[e-1],this._segments[0]))}this._changed(25)}}},{beans:!0,getPathData:function(t,e){function n(e,n){e._transformCoordinates(t,_,!1),i=_[0],r=_[1],v?(p.push("M"+g.pair(i,r)),v=!1):(h=_[2],u=_[3],h===i&&u===r&&l===a&&c===o?n||p.push("l"+g.pair(i-a,r-o)):p.push("c"+g.pair(l-a,c-o)+" "+g.pair(h-a,u-o)+" "+g.pair(i-a,r-o))),a=i,o=r,l=_[4],c=_[5]}var i,r,a,o,h,u,l,c,d=this._segments,f=d.length,g=new s(e),_=Array(6),v=!0,p=[];if(0===f)return"";for(var m=0;f>m;m++)n(d[m]);return this._closed&&f>0&&(n(d[0],!0),p.push("z")),p.join("")}},{isEmpty:function(){return 0===this._segments.length},_transformContent:function(t){for(var e=Array(6),n=0,i=this._segments.length;i>n;n++)this._segments[n]._transformCoordinates(t,e,!0);return!0},_add:function(t,e){for(var n=this._segments,i=this._curves,r=t.length,s=null==e,e=s?n.length:e,a=0;r>a;a++){var o=t[a];o._path&&(o=t[a]=o.clone()),o._path=this,o._index=e+a,o._selectionState&&this._updateSelection(o,0,o._selectionState)}if(s)n.push.apply(n,t);else{n.splice.apply(n,[e,0].concat(t));for(var a=e+r,h=n.length;h>a;a++)n[a]._index=a}if(i){var u=this._countCurves(),l=e+r-1===u?e-1:e,c=l,d=Math.min(l+r,u);t._curves&&(i.splice.apply(i,[l,0].concat(t._curves)),c+=t._curves.length);for(var a=c;d>a;a++)i.splice(a,0,new I(this,null,null));this._adjustCurves(l,d)}return this._changed(25),t},_adjustCurves:function(t,e){for(var n,i=this._segments,r=this._curves,s=t;e>s;s++)n=r[s],n._path=this,n._segment1=i[s],n._segment2=i[s+1]||i[0],n._changed();(n=r[this._closed&&0===t?i.length-1:t-1])&&(n._segment2=i[t]||i[0],n._changed()),(n=r[e])&&(n._segment1=i[e],n._changed())},_countCurves:function(){var t=this._segments.length;return!this._closed&&t>0?t-1:t},add:function(t){return arguments.length>1&&"number"!=typeof t?this._add(P.readAll(arguments)):this._add([P.read(arguments)])[0]},insert:function(t,e){return arguments.length>2&&"number"!=typeof e?this._add(P.readAll(arguments,1),t):this._add([P.read(arguments,1)],t)[0]},addSegment:function(){return this._add([P.read(arguments)])[0]},insertSegment:function(t){return this._add([P.read(arguments,1)],t)[0]},addSegments:function(t){return this._add(P.readAll(t))},insertSegments:function(t,e){return this._add(P.readAll(e),t)},removeSegment:function(t){return this.removeSegments(t,t+1)[0]||null},removeSegments:function(t,n,i){t=t||0,n=e.pick(n,this._segments.length);var r=this._segments,s=this._curves,a=r.length,o=r.splice(t,n-t),h=o.length;if(!h)return o;for(var u=0;h>u;u++){var l=o[u];l._selectionState&&this._updateSelection(l,l._selectionState,0),l._index=l._path=null}for(var u=t,c=r.length;c>u;u++)r[u]._index=u;if(s){var d=t>0&&n===a+(this._closed?1:0)?t-1:t,s=s.splice(d,h);i&&(o._curves=s.slice(1)),this._adjustCurves(d,d)}return this._changed(25),o},clear:"#removeSegments",hasHandles:function(){for(var t=this._segments,e=0,n=t.length;n>e;e++)if(t[e].hasHandles())return!0;return!1},clearHandles:function(){for(var t=this._segments,e=0,n=t.length;n>e;e++)t[e].clearHandles()},getLength:function(){if(null==this._length){for(var t=this.getCurves(),e=0,n=0,i=t.length;i>n;n++)e+=t[n].getLength();this._length=e}return this._length},getArea:function(){if(null==this._area){for(var t=this._segments,e=t.length,n=e-1,i=0,r=0,s=this._closed?e:n;s>r;r++)i+=I.getArea(I.getValues(t[r],t[n>r?r+1:0]));this._area=i}return this._area},isClockwise:function(){return this._clockwise!==t?this._clockwise:this.getArea()>=0},setClockwise:function(t){this.isClockwise()!=(t=!!t)&&this.reverse(),this._clockwise=t},isFullySelected:function(){var t=this._segments.length;return this._selected&&t>0&&this._selectedSegmentState===7*t},setFullySelected:function(t){t&&this._selectSegments(!0),this.setSelected(t)},setSelected:function pt(t){t||this._selectSegments(!1),pt.base.call(this,t)},_selectSegments:function(t){var e=this._segments.length;this._selectedSegmentState=t?7*e:0;for(var n=0;e>n;n++)this._segments[n]._selectionState=t?7:0},_updateSelection:function(t,e,n){t._selectionState=n;var i=this._selectedSegmentState+=n-e;i>0&&this.setSelected(!0)},flatten:function(t){for(var e=new T(this,64,.1),n=0,i=e.length/Math.ceil(e.length/t),r=e.length+(this._closed?-i:i)/2,s=[];r>=n;)s.push(new P(e.getPointAt(n))),n+=i;this.setSegments(s)},reduce:function(){for(var t=this.getCurves(),e=t.length-1;e>=0;e--){var n=t[e];n.hasHandles()||0!==n.getLength()&&!n.isCollinear(n.getNext())||n.remove()}return this},simplify:function(t){if(this._segments.length>2){var e=new E(this,t||2.5);this.setSegments(e.fit())}},split:function(t,e){if(null===e)return null;if(1===arguments.length){var n=t;if("number"==typeof n&&(n=this.getLocationAt(n)),!n)return null;t=n.index,e=n.parameter}var i=4e-7,r=1-i;e>=r&&(t++,e--);var s=this.getCurves();if(t>=0&&t<s.length){e>=i&&s[t++].divide(e,!0);var a,o=this.removeSegments(t,this._segments.length,!0);return this._closed?(this.setClosed(!1),a=this):(a=new A(m.NO_INSERT),a.insertAbove(this,!0),this._clone(a)),a._add(o,0),this.addSegment(o[0]),a}return null},reverse:function(){this._segments.reverse();for(var e=0,n=this._segments.length;n>e;e++){var i=this._segments[e],r=i._handleIn;i._handleIn=i._handleOut,i._handleOut=r,i._index=e}this._curves=null,this._clockwise!==t&&(this._clockwise=!this._clockwise),this._changed(9)},join:function(t){if(t){var e=t._segments,n=this.getLastSegment(),i=t.getLastSegment();if(!i)return this;n&&n._point.equals(i._point)&&t.reverse();var r=t.getFirstSegment();if(n&&n._point.equals(r._point))n.setHandleOut(r._handleOut),this._add(e.slice(1));else{var s=this.getFirstSegment();s&&s._point.equals(r._point)&&t.reverse(),i=t.getLastSegment(),s&&s._point.equals(i._point)?(s.setHandleIn(i._handleIn),this._add(e.slice(0,e.length-1),0)):this._add(e.slice())}t._closed&&this._add([e[0]]),t.remove()}var a=this.getFirstSegment(),o=this.getLastSegment();return a!==o&&a._point.equals(o._point)&&(a.setHandleIn(o._handleIn),o.remove(),this.setClosed(!0)),this},toShape:function(t){function e(t,e){var n=c[t],i=n.getNext(),r=c[e],s=r.getNext();return n._handleOut.isZero()&&i._handleIn.isZero()&&r._handleOut.isZero()&&s._handleIn.isZero()&&i._point.subtract(n._point).isCollinear(s._point.subtract(r._point))}function n(t){var e=c[t],n=e.getPrevious(),i=e.getNext();return n._handleOut.isZero()&&e._handleIn.isZero()&&e._handleOut.isZero()&&i._handleIn.isZero()&&e._point.subtract(n._point).isOrthogonal(i._point.subtract(e._point))}function i(t){var e=c[t],n=e.getNext(),i=e._handleOut,r=n._handleIn,s=.5522847498307936;if(i.isOrthogonal(r)){var o=e._point,h=n._point,u=new _(o,i,!0).intersect(new _(h,r,!0),!0);return u&&a.isZero(i.getLength()/u.subtract(o).getLength()-s)&&a.isZero(r.getLength()/u.subtract(h).getLength()-s)}return!1}function r(t,e){return c[t]._point.getDistance(c[e]._point)}if(!this._closed)return null;var s,o,h,u,c=this._segments;if(!this.hasHandles()&&4===c.length&&e(0,2)&&e(1,3)&&n(1)?(s=x.Rectangle,o=new l(r(0,3),r(0,1)),u=c[1]._point.add(c[2]._point).divide(2)):8===c.length&&i(0)&&i(2)&&i(4)&&i(6)&&e(1,5)&&e(3,7)?(s=x.Rectangle,o=new l(r(1,6),r(0,3)),h=o.subtract(new l(r(0,7),r(1,2))).divide(2),u=c[3]._point.add(c[4]._point).divide(2)):4===c.length&&i(0)&&i(1)&&i(2)&&i(3)&&(a.isZero(r(0,2)-r(1,3))?(s=x.Circle,h=r(0,2)/2):(s=x.Ellipse,h=new l(r(2,0)/2,r(3,1)/2)),u=c[1]._point),s){var d=this.getPosition(!0),f=this._clone(new s({center:d,size:o,radius:h,insert:!1}),t,!1);return f.rotate(u.subtract(d).getAngle()+90),f}return null},_hitTestSelf:function(t,e){function n(e,n){return t.subtract(e).divide(n).length<=1}function i(t,i,r){if(!e.selected||i.isSelected()){var s=t._point;if(i!==s&&(i=i.add(s)),n(i,w))return new S(r,g,{segment:t,point:i})}}function r(t,n){return(n||e.segments)&&i(t,t._point,"segment")||!n&&e.handles&&(i(t,t._handleIn,"handle-in")||i(t,t._handleOut,"handle-out"))}function s(t){c.add(t)}function a(e){if(("round"!==o||"round"!==u)&&(c=new A({internal:!0,closed:!0}),m||e._index>0&&e._index<p-1?"round"!==o&&(e._handleIn.isZero()||e._handleOut.isZero())&&A._addBevelJoin(e,o,P,l,s,!0):"round"!==u&&A._addSquareCap(e,u,P,s,!0),!c.isEmpty())){var i;return c.contains(t)||(i=c.getNearestLocation(t))&&n(i.getPoint(),y)}return n(e._point,w)}var o,u,l,c,d,f,g=this,_=this.getStyle(),v=this._segments,p=v.length,m=this._closed,y=e._tolerancePadding,w=y,x=e.stroke&&_.hasStroke(),b=e.fill&&_.hasFill(),C=e.curves,P=x?_.getStrokeWidth()/2:b&&e.tolerance>0||C?0:null;if(null!==P&&(P>0?(o=_.getStrokeJoin(),u=_.getStrokeCap(),l=P*_.getMiterLimit(),w=y.add(new h(P,P))):o=u="round"),!e.ends||e.segments||m){if(e.segments||e.handles)for(var k=0;p>k;k++)if(f=r(v[k]))return f}else if(f=r(v[0],!0)||r(v[p-1],!0))return f;if(null!==P){if(d=this.getNearestLocation(t)){var I=d.getParameter();0===I||1===I&&p>1?a(d.getSegment())||(d=null):n(d.getPoint(),w)||(d=null)}if(!d&&"miter"===o&&p>1)for(var k=0;p>k;k++){var M=v[k];if(t.getDistance(M._point)<=l&&a(M)){d=M.getLocation();break}}}return!d&&b&&this._contains(t)||d&&!x&&!C?new S("fill",this):d?new S(x?"stroke":"curve",this,{location:d,point:d.getPoint()}):null}},e.each(I.evaluateMethods,function(t){this[t+"At"]=function(e,n){var i=this.getLocationAt(e,n);return i&&i[t]()}},{beans:!1,getLocationOf:function(){for(var t=h.read(arguments),e=this.getCurves(),n=0,i=e.length;i>n;n++){var r=e[n].getLocationOf(t);if(r)return r}return null},getOffsetOf:function(){var t=this.getLocationOf.apply(this,arguments);return t?t.getOffset():null},getLocationAt:function(t,e){var n=this.getCurves(),i=0;if(e){var r=~~t,s=n[r];return s?s.getLocationAt(t-r,!0):null}for(var a=0,o=n.length;o>a;a++){var h=i,s=n[a];if(i+=s.getLength(),i>t)return s.getLocationAt(t-h)}return n.length>0&&t<=this.getLength()?new M(n[n.length-1],1):null},getNearestLocation:function(){for(var t=h.read(arguments),e=this.getCurves(),n=1/0,i=null,r=0,s=e.length;s>r;r++){var a=e[r].getNearestLocation(t);a._distance<n&&(n=a._distance,i=a)}return i},getNearestPoint:function(){return this.getNearestLocation.apply(this,arguments).getPoint()}}),new function(){function t(t,e,n,i){function r(e){var n=a[e],i=a[e+1];(c!=n||d!=i)&&(t.beginPath(),t.moveTo(c,d),t.lineTo(n,i),t.stroke(),t.beginPath(),t.arc(n,i,s,0,2*Math.PI,!0),t.fill())}for(var s=i/2,a=Array(6),o=0,h=e.length;h>o;o++){var u=e[o];u._transformCoordinates(n,a,!1);var l=u._selectionState,c=a[0],d=a[1];if(1&l&&r(2),2&l&&r(4),t.fillRect(c-s,d-s,i,i),!(4&l)){var f=t.fillStyle;t.fillStyle="#ffffff",t.fillRect(c-s+1,d-s+1,i-2,i-2),t.fillStyle=f}}}function e(t,e,n){function i(e){if(n)e._transformCoordinates(n,g,!1),r=g[0],s=g[1];else{var i=e._point;r=i._x,s=i._y}if(_)t.moveTo(r,s),_=!1;else{if(n)h=g[2],u=g[3];else{var d=e._handleIn;h=r+d._x,u=s+d._y}h===r&&u===s&&l===a&&c===o?t.lineTo(r,s):t.bezierCurveTo(l,c,h,u,r,s)}if(a=r,o=s,n)l=g[4],c=g[5];else{var d=e._handleOut;l=a+d._x,c=o+d._y}}for(var r,s,a,o,h,u,l,c,d=e._segments,f=d.length,g=Array(6),_=!0,v=0;f>v;v++)i(d[v]);e._closed&&f>0&&i(d[0])}return{_draw:function(t,n,i){function r(t){return l[(t%c+c)%c]}var s=n.dontStart,a=n.dontFinish||n.clip,o=this.getStyle(),h=o.hasFill(),u=o.hasStroke(),l=o.getDashArray(),c=!paper.support.nativeDash&&u&&l&&l.length;if(s||t.beginPath(),!s&&this._currentPath?t.currentPath=this._currentPath:(h||u&&!c||a)&&(e(t,this,i),this._closed&&t.closePath(),s||(this._currentPath=t.currentPath)),!a&&(h||u)&&(this._setStyles(t),h&&(t.fill(o.getWindingRule()),t.shadowColor="rgba(0,0,0,0)"),u)){if(c){s||t.beginPath();var d,f=new T(this,32,.25,i),g=f.length,_=-o.getDashOffset(),v=0;for(_%=g;_>0;)_-=r(v--)+r(v--);for(;g>_;)d=_+r(v++),(_>0||d>0)&&f.drawPart(t,Math.max(_,0),Math.max(d,0)),_=d+r(v++)}t.stroke()}},_drawSelected:function(n,i){n.beginPath(),e(n,this,i),n.stroke(),t(n,this._segments,i,paper.settings.handleSize)}}},new function(){function t(t){var e=t.length,n=[],i=[],r=2;n[0]=t[0]/r;for(var s=1;e>s;s++)i[s]=1/r,r=(e-1>s?4:2)-i[s],n[s]=(t[s]-n[s-1])/r;for(var s=1;e>s;s++)n[e-s-1]-=i[e-s]*n[e-s];return n}return{smooth:function(){var e=this._segments,n=e.length,i=this._closed,r=n,s=0;if(!(2>=n)){i&&(s=Math.min(n,4),r+=2*Math.min(n,s));for(var a=[],o=0;n>o;o++)a[o+s]=e[o]._point;if(i)for(var o=0;s>o;o++)a[o]=e[o+n-s]._point,a[o+n+s]=e[o]._point;else r--;for(var u=[],o=1;r-1>o;o++)u[o]=4*a[o]._x+2*a[o+1]._x;u[0]=a[0]._x+2*a[1]._x,u[r-1]=3*a[r-1]._x;for(var l=t(u),o=1;r-1>o;o++)u[o]=4*a[o]._y+2*a[o+1]._y;u[0]=a[0]._y+2*a[1]._y,u[r-1]=3*a[r-1]._y;var c=t(u);if(i){for(var o=0,d=n;s>o;o++,d++){var f=o/s,g=1-f,_=o+s,v=d+s;l[d]=l[o]*f+l[d]*g,c[d]=c[o]*f+c[d]*g,l[v]=l[_]*g+l[v]*f,c[v]=c[_]*g+c[v]*f}r--}for(var p=null,o=s;r-s>=o;o++){var m=e[o-s];p&&m.setHandleIn(p.subtract(m._point)),r>o&&(m.setHandleOut(new h(l[o],c[o]).subtract(m._point)),p=r-1>o?new h(2*a[o+1]._x-l[o+1],2*a[o+1]._y-c[o+1]):new h((a[r]._x+l[r-1])/2,(a[r]._y+c[r-1])/2))}if(i&&p){var m=this._segments[0];m.setHandleIn(p.subtract(m._point))}}}}},new function(){function t(t){var e=t._segments;if(0===e.length)throw Error("Use a moveTo() command first");return e[e.length-1]}return{moveTo:function(){var t=this._segments;1===t.length&&this.removeSegment(0),t.length||this._add([new P(h.read(arguments))])},moveBy:function(){throw Error("moveBy() is unsupported on Path items.")},lineTo:function(){this._add([new P(h.read(arguments))])},cubicCurveTo:function(){var e=h.read(arguments),n=h.read(arguments),i=h.read(arguments),r=t(this);r.setHandleOut(e.subtract(r._point)),this._add([new P(i,n.subtract(i))])},quadraticCurveTo:function(){var e=h.read(arguments),n=h.read(arguments),i=t(this)._point;this.cubicCurveTo(e.add(i.subtract(e).multiply(1/3)),e.add(n.subtract(e).multiply(1/3)),n)},curveTo:function(){var n=h.read(arguments),i=h.read(arguments),r=e.pick(e.read(arguments),.5),s=1-r,a=t(this)._point,o=n.subtract(a.multiply(s*s)).subtract(i.multiply(r*r)).divide(2*r*s);if(o.isNaN())throw Error("Cannot put a curve through points with parameter = "+r);this.quadraticCurveTo(o,i)},arcTo:function(){var n,i,r,s,a,o=t(this),u=o._point,c=h.read(arguments),d=e.peek(arguments),f=e.pick(d,!0);if("boolean"==typeof f)var v=u.add(c).divide(2),n=v.add(v.subtract(u).rotate(f?-90:90));else if(e.remain(arguments)<=2)n=c,c=h.read(arguments);else{var p=l.read(arguments);if(p.isZero())return this.lineTo(c);var m=e.read(arguments),f=!!e.read(arguments),y=!!e.read(arguments),v=u.add(c).divide(2),w=u.subtract(v).rotate(-m),x=w.x,b=w.y,C=Math.abs,S=C(p.width),k=C(p.height),I=S*S,M=k*k,z=x*x,A=b*b,O=Math.sqrt(z/I+A/M);if(O>1&&(S*=O,k*=O,I=S*S,M=k*k),O=(I*M-I*A-M*z)/(I*A+M*z),C(O)<1e-12&&(O=0),0>O)throw Error("Cannot create an arc with the given arguments");i=new h(S*b/k,-k*x/S).multiply((y===f?-1:1)*Math.sqrt(O)).rotate(m).add(v),a=(new g).translate(i).rotate(m).scale(S,k),s=a._inverseTransform(u),r=s.getDirectedAngle(a._inverseTransform(c)),!f&&r>0?r-=360:f&&0>r&&(r+=360)}if(n){var T=new _(u.add(n).divide(2),n.subtract(u).rotate(90),!0),E=new _(n.add(c).divide(2),c.subtract(n).rotate(90),!0),L=new _(u,c),N=L.getSide(n);if(i=T.intersect(E,!0),!i){if(!N)return this.lineTo(c);throw Error("Cannot create an arc with the given arguments")}s=u.subtract(i),r=s.getDirectedAngle(c.subtract(i));var j=L.getSide(i);0===j?r=N*Math.abs(r):N===j&&(r+=0>r?360:-360)}for(var B=Math.abs(r),R=B>=360?4:Math.ceil(B/90),D=r/R,F=D*Math.PI/360,q=4/3*Math.sin(F)/(1+Math.cos(F)),V=[],H=0;R>=H;H++){var w=c,Z=null;if(R>H&&(Z=s.rotate(90).multiply(q),a?(w=a._transformPoint(s),Z=a._transformPoint(s.add(Z)).subtract(w)):w=i.add(s)),0===H)o.setHandleOut(Z);else{var U=s.rotate(-90).multiply(q);a&&(U=a._transformPoint(s.add(U)).subtract(w)),V.push(new P(w,U,Z))}s=s.rotate(D)}this._add(V)},lineBy:function(){var e=h.read(arguments),n=t(this)._point;this.lineTo(n.add(e))},curveBy:function(){var n=h.read(arguments),i=h.read(arguments),r=e.read(arguments),s=t(this)._point;this.curveTo(s.add(n),s.add(i),r)},cubicCurveBy:function(){var e=h.read(arguments),n=h.read(arguments),i=h.read(arguments),r=t(this)._point;this.cubicCurveTo(r.add(e),r.add(n),r.add(i))},quadraticCurveBy:function(){var e=h.read(arguments),n=h.read(arguments),i=t(this)._point;this.quadraticCurveTo(i.add(e),i.add(n))},arcBy:function(){var n=t(this)._point,i=n.add(h.read(arguments)),r=e.pick(e.peek(arguments),!0);"boolean"==typeof r?this.arcTo(i,r):this.arcTo(i,n.add(h.read(arguments)))},closePath:function(t){this.setClosed(!0),t&&this.join()}}},{_getBounds:function(t,e){return A[t](this._segments,this._closed,this.getStyle(),e)},statics:{getBounds:function(t,e,n,i,r){function s(t){t._transformCoordinates(i,o,!1);for(var e=0;2>e;e++)I._addBounds(h[e],h[e+4],o[e+2],o[e],e,r?r[e]:0,u,l,c);var n=h;h=o,o=n}var a=t[0];if(!a)return new d;for(var o=Array(6),h=a._transformCoordinates(i,Array(6),!1),u=h.slice(0,2),l=u.slice(),c=Array(2),f=1,g=t.length;g>f;f++)s(t[f]);return e&&s(a),new d(u[0],u[1],l[0]-u[0],l[1]-u[1])},getStrokeBounds:function(t,e,n,i){function r(t){f=f.include(i?i._transformPoint(t,t):t)}function s(t){f=f.unite(p.setCenter(i?i._transformPoint(t._point):t._point))}function a(t,e){var n=t._handleIn,i=t._handleOut;"round"===e||!n.isZero()&&!i.isZero()&&n.isCollinear(i)?s(t):A._addBevelJoin(t,e,u,v,r)}function o(t,e){"round"===e?s(t):A._addSquareCap(t,e,u,r)}if(!n.hasStroke())return A.getBounds(t,e,n,i);for(var h=t.length-(e?0:1),u=n.getStrokeWidth()/2,c=A._getPenPadding(u,i),f=A.getBounds(t,e,n,i,c),g=n.getStrokeJoin(),_=n.getStrokeCap(),v=u*n.getMiterLimit(),p=new d(new l(c).multiply(2)),m=1;h>m;m++)a(t[m],g);return e?a(t[0],g):h>0&&(o(t[0],_),o(t[t.length-1],_)),f},_getPenPadding:function(t,e){if(!e)return[t,t];var n=e.shiftless(),i=n.transform(new h(t,0)),r=n.transform(new h(0,t)),s=i.getAngleInRadians(),a=i.getLength(),o=r.getLength(),u=Math.sin(s),l=Math.cos(s),c=Math.tan(s),d=-Math.atan(o*c/a),f=Math.atan(o/(c*a));return[Math.abs(a*Math.cos(d)*l-o*Math.sin(d)*u),Math.abs(o*Math.sin(f)*l+a*Math.cos(f)*u)]},_addBevelJoin:function(t,e,n,i,r,s){var a=t.getCurve(),o=a.getPrevious(),u=a.getPointAt(0,!0),l=o.getNormalAt(1,!0),c=a.getNormalAt(0,!0),d=l.getDirectedAngle(c)<0?-n:n;if(l.setLength(d),c.setLength(d),s&&(r(u),r(u.add(l))),"miter"===e){var f=new _(u.add(l),new h(-l.y,l.x),!0).intersect(new _(u.add(c),new h(-c.y,c.x),!0),!0);if(f&&u.getDistance(f)<=i&&(r(f),!s))return}s||r(u.add(l)),r(u.add(c))},_addSquareCap:function(t,e,n,i,r){var s=t._point,a=t.getLocation(),o=a.getNormal().multiply(n);r&&(i(s.subtract(o)),i(s.add(o))),"square"===e&&(s=s.add(o.rotate(0===a.getParameter()?-90:90))),i(s.add(o)),i(s.subtract(o))},getHandleBounds:function(t,e,n,i,r,s){for(var a=Array(6),o=1/0,h=-o,u=o,l=h,c=0,f=t.length;f>c;c++){var g=t[c];g._transformCoordinates(i,a,!1);for(var _=0;6>_;_+=2){var v=0===_?s:r,p=v?v[0]:0,m=v?v[1]:0,y=a[_],w=a[_+1],x=y-p,b=y+p,C=w-m,S=w+m;o>x&&(o=x),b>h&&(h=b),u>C&&(u=C),S>l&&(l=S)}}return new d(o,u,h-o,l-u)},getRoughBounds:function(t,e,n,i){var r=n.hasStroke()?n.getStrokeWidth()/2:0,s=r;return r>0&&("miter"===n.getStrokeJoin()&&(s=r*n.getMiterLimit()),"square"===n.getStrokeCap()&&(s=Math.max(s,r*Math.sqrt(2)))),A.getHandleBounds(t,e,n,i,A._getPenPadding(r,i),A._getPenPadding(s,i))}}});A.inject({statics:new function(){function t(t,n,i){var r=e.getNamed(i),s=new A(r&&r.insert===!1&&m.NO_INSERT);return s._add(t),s._closed=n,s.set(r)}function n(e,n,i){for(var s=Array(4),a=0;4>a;a++){var o=r[a];s[a]=new P(o._point.multiply(n).add(e),o._handleIn.multiply(n),o._handleOut.multiply(n))}return t(s,!0,i)}var i=.5522847498307936,r=[new P([-1,0],[0,i],[0,-i]),new P([0,-1],[-i,0],[i,0]),new P([1,0],[0,-i],[0,i]),new P([0,1],[i,0],[-i,0])];return{Line:function(){return t([new P(h.readNamed(arguments,"from")),new P(h.readNamed(arguments,"to"))],!1,arguments)},Circle:function(){var t=h.readNamed(arguments,"center"),i=e.readNamed(arguments,"radius");return n(t,new l(i),arguments)},Rectangle:function(){var e,n=d.readNamed(arguments,"rectangle"),r=l.readNamed(arguments,"radius",0,{readNull:!0}),s=n.getBottomLeft(!0),a=n.getTopLeft(!0),o=n.getTopRight(!0),h=n.getBottomRight(!0);if(!r||r.isZero())e=[new P(s),new P(a),new P(o),new P(h)];else{r=l.min(r,n.getSize(!0).divide(2));var u=r.width,c=r.height,f=u*i,g=c*i;e=[new P(s.add(u,0),null,[-f,0]),new P(s.subtract(0,c),[0,g]),new P(a.add(0,c),null,[0,-g]),new P(a.add(u,0),[-f,0],null),new P(o.subtract(u,0),null,[f,0]),new P(o.add(0,c),[0,-g],null),new P(h.subtract(0,c),null,[0,g]),new P(h.subtract(u,0),[f,0])]}return t(e,!0,arguments)},RoundRectangle:"#Rectangle",Ellipse:function(){var t=x._readEllipse(arguments);return n(t.center,t.radius,arguments)},Oval:"#Ellipse",Arc:function(){var t=h.readNamed(arguments,"from"),n=h.readNamed(arguments,"through"),i=h.readNamed(arguments,"to"),r=e.getNamed(arguments),s=new A(r&&r.insert===!1&&m.NO_INSERT);return s.moveTo(t),s.arcTo(n,i),s.set(r)},RegularPolygon:function(){for(var n=h.readNamed(arguments,"center"),i=e.readNamed(arguments,"sides"),r=e.readNamed(arguments,"radius"),s=360/i,a=!(i%3),o=new h(0,a?-r:r),u=a?-1:.5,l=Array(i),c=0;i>c;c++)l[c]=new P(n.add(o.rotate((c+u)*s)));return t(l,!0,arguments)},Star:function(){for(var n=h.readNamed(arguments,"center"),i=2*e.readNamed(arguments,"points"),r=e.readNamed(arguments,"radius1"),s=e.readNamed(arguments,"radius2"),a=360/i,o=new h(0,-1),u=Array(i),l=0;i>l;l++)u[l]=new P(n.add(o.rotate(a*l).multiply(l%2?s:r)));return t(u,!0,arguments)}}}});var O=z.extend({_class:"CompoundPath",_serializeFields:{children:[]},initialize:function(t){this._children=[],this._namedChildren={},this._initialize(t)||("string"==typeof t?this.setPathData(t):this.addChildren(Array.isArray(t)?t:arguments))},insertChildren:function mt(e,n,i){for(var r=n.length-1;r>=0;r--){var s=n[r];s instanceof O&&(n.splice.apply(n,[r,1].concat(s.removeChildren())),s.remove())}n=mt.base.call(this,e,n,i,A);for(var r=0,a=!i&&n&&n.length;a>r;r++){var s=n[r];s._clockwise===t&&s.setClockwise(0===s._index)}return n},reverse:function(){for(var t=this._children,e=0,n=t.length;n>e;e++)t[e].reverse()},smooth:function(){for(var t=0,e=this._children.length;e>t;t++)this._children[t].smooth()},reduce:function yt(){for(var t=this._children,e=t.length-1;e>=0;e--){var n=t[e].reduce();n.isEmpty()&&t.splice(e,1)}if(0===t.length){var n=new A(m.NO_INSERT);return n.insertAbove(this),n.setStyle(this._style),this.remove(),n}return yt.base.call(this)},isClockwise:function(){var t=this.getFirstChild();return t&&t.isClockwise()},setClockwise:function(t){this.isClockwise()!==!!t&&this.reverse()},getFirstSegment:function(){var t=this.getFirstChild();return t&&t.getFirstSegment()},getLastSegment:function(){var t=this.getLastChild();return t&&t.getLastSegment()},getCurves:function(){for(var t=this._children,e=[],n=0,i=t.length;i>n;n++)e.push.apply(e,t[n].getCurves());return e},getFirstCurve:function(){var t=this.getFirstChild();return t&&t.getFirstCurve()},getLastCurve:function(){var t=this.getLastChild();return t&&t.getFirstCurve()},getArea:function(){for(var t=this._children,e=0,n=0,i=t.length;i>n;n++)e+=t[n].getArea();return e}},{beans:!0,getPathData:function(t,e){for(var n=this._children,i=[],r=0,s=n.length;s>r;r++){var a=n[r],o=a._matrix;i.push(a.getPathData(t&&!o.isIdentity()?t.chain(o):t,e))}return i.join(" ")}},{_getChildHitTestOptions:function(t){return t["class"]===A||"path"===t.type?t:new e(t,{fill:!1})},_draw:function(t,e,n){var i=this._children;if(0!==i.length){if(this._currentPath)t.currentPath=this._currentPath;else{e=e.extend({dontStart:!0,dontFinish:!0}),t.beginPath();for(var r=0,s=i.length;s>r;r++)i[r].draw(t,e,n);this._currentPath=t.currentPath}if(!e.clip){this._setStyles(t);var a=this._style;a.hasFill()&&(t.fill(a.getWindingRule()),t.shadowColor="rgba(0,0,0,0)"),a.hasStroke()&&t.stroke()}}},_drawSelected:function(t,e,n){for(var i=this._children,r=0,s=i.length;s>r;r++){
-var a=i[r],o=a._matrix;n[a._id]||a._drawSelected(t,o.isIdentity()?e:e.chain(o))}}},new function(){function t(t,e){var n=t._children;if(e&&0===n.length)throw Error("Use a moveTo() command first");return n[n.length-1]}var n={moveTo:function(){var e=t(this),n=e&&e.isEmpty()?e:new A(m.NO_INSERT);n!==e&&this.addChild(n),n.moveTo.apply(n,arguments)},moveBy:function(){var e=t(this,!0),n=e&&e.getLastSegment(),i=h.read(arguments);this.moveTo(n?i.add(n._point):i)},closePath:function(e){t(this,!0).closePath(e)}};return e.each(["lineTo","cubicCurveTo","quadraticCurveTo","curveTo","arcTo","lineBy","cubicCurveBy","quadraticCurveBy","curveBy","arcBy"],function(e){n[e]=function(){var n=t(this,!0);n[e].apply(n,arguments)}}),n});z.inject(new function(){function e(t,e){var n=t.clone(!1).reduce().transform(null,!0,!0);return e?n.resolveCrossings().reorient():n}function n(t,e,n,i,r){var s=new t(m.NO_INSERT);return s.addChildren(e,!0),r&&(s=s.reduce()),s.insertAbove(i&&n.isSibling(i)&&n.getIndex()<i.getIndex()?i:n),s.setStyle(n._style),s}function i(t,i,s){function a(t){for(var e=0,n=t.length;n>e;e++){var i=t[e];f.push.apply(f,i._segments),g.push.apply(g,i._getMonoCurves())}}if(!t._children&&!t._closed)return r(t,i,s);var h=e(t,!0),u=i&&t!==i&&e(i,!0);u&&/^(subtract|exclude)$/.test(s)^u.isClockwise()!==h.isClockwise()&&u.reverse();var d=M.expand(h.getIntersections(u,function(t){return u&&t.isOverlap()||t.isCrossing()}));o(d);var f=[],g=[];a(h._children||[h]),u&&a(u._children||[u]);for(var _=0,v=d.length;v>_;_++)l(d[_]._segment,h,u,g,s);for(var _=0,v=f.length;v>_;_++){var p=f[_];null==p._winding&&l(p,h,u,g,s)}return n(O,c(f,s),t,i,!0)}function r(i,r,s){function a(e){return h.contains(e.getPointAt(e.getLength()/2))^l?(c.unshift(e),!0):t}if(!r||!r._children&&!r._closed||!/^(subtract|intersect)$/.test(s))return null;for(var o=e(i,!1),h=e(r,!1),u=o.getIntersections(h,function(t){return t.isOverlap()||t.isCrossing()}),l="subtract"===s,c=[],d=u.length-1;d>=0;d--){var f=u[d].split();f&&(a(f)&&f.getFirstSegment().setHandleIn(0,0),o.getLastSegment().setHandleOut(0,0))}return a(o),n(y,c,i,r)}function s(t,e){for(var n=t;n;){if(n===e)return;n=n._prev}for(;t._next&&t._next!==e;)t=t._next;if(!t._next){for(;e._prev;)e=e._prev;t._next=e,e._prev=t}}function o(t){for(var e,n,i=4e-7,r=1-i,a=!1,o=[],h=t.length-1;h>=0;h--){var u=t[h],l=u._curve,c=u._parameter,d=c;l!==e?a=!l.hasHandles():n>0&&(c/=n);var f;i>c?f=l._segment1:c>r?f=l._segment2:(f=l.divide(c,!0,!0)._segment1,a&&o.push(f)),u._setSegment(f);var g=f._intersection,_=u._intersection;if(g){s(g,_);for(var v=g;v;)s(v._intersection,g),v=v._next}else f._intersection=_;e=l,n=d}for(var h=0,p=o.length;p>h;h++)o[h].clearHandles()}function u(t,e,n,i){var r=2e-7,s=4e-7,o=1-s,l=t.x,c=t.y,d=0,f=0,g=[],_=Math.abs;if(n){for(var v=-(1/0),p=1/0,m=c-r,y=c+r,w=0,x=e.length;x>w;w++){var b=e[w].values;if(I.solveCubic(b,0,l,g,0,1)>0)for(var C=g.length-1;C>=0;C--){var S=I.getPoint(b,g[C]).y;m>S&&S>v?v=S:S>y&&p>S&&(p=S)}}v=(v+c)/2,p=(p+c)/2,v>-(1/0)&&(d=u(new h(l,v),e,!1,i)),1/0>p&&(f=u(new h(l,p),e,!1,i))}else for(var P,k,M=l-r,z=l+r,A=!1,w=0,x=e.length;x>w;w++){var O=e[w],b=O.values,T=O.winding;if(T&&(1===T&&c>=b[1]&&c<=b[7]||c>=b[7]&&c<=b[1])&&1===I.solveCubic(b,1,c,g,0,1)){var E=g[0];if(!(E>o&&A&&O.next!==e[w+1]||s>E&&k>o&&O.previous===P)){var L=I.getPoint(b,E).x,N=I.getTangent(b,E).y,j=!1;a.isZero(N)&&!I.isStraight(b)||s>E&&N*I.getTangent(O.previous.values,1).y<0||E>o&&N*I.getTangent(O.next.values,0).y<0?i&&L>=M&&z>=L&&(++d,++f,j=!0):M>=L?(d+=T,j=!0):L>=z&&(f+=T,j=!0),O.previous!==e[w-1]&&(A=s>E&&j)}P=O,k=E}}return Math.max(_(d),_(f))}function l(t,e,n,i,r){var s=2e-7,a=[],o=t,h=0,l=0;do{var c=t.getCurve(),d=c.getLength();a.push({segment:t,curve:c,length:d}),h+=d,t=t.getNext()}while(t&&!t._intersection&&t!==o);for(var f=0;3>f;f++)for(var d=h*(f+1)/4,g=0,_=a.length;_>g;g++){var v=a[g],p=v.length;if(p>=d){(s>d||s>p-d)&&(d=p/2);var c=v.curve,m=c._path,y=m._parent,w=c.getPointAt(d),x=c.isHorizontal();y instanceof O&&(m=y),l+="subtract"===r&&n&&(m===e&&n._getWinding(w,x)||m===n&&!e._getWinding(w,x))?0:u(w,i,x);break}d-=p}for(var b=Math.round(l/3),C=a.length-1;C>=0;C--)a[C].segment._winding=b}function c(t,e){function n(t,e){if(t._visited)return!1;if(!l)return!0;var n=t._winding,i=t._intersection;return i&&e&&c&&i.isOverlap()&&(n=c[n]||n),l(n)}function i(t){return t===o||t===h}function r(t,e){if(!t._next)return t;for(;t;){var r=t._segment,s=r.getNext(),a=s._intersection;if(i(s)||!r._visited&&!s._visited&&(!l||(!e||n(r))&&(!(e&&a&&a.isOverlap())&&n(s)||!e&&a&&n(a._segment))))return t;t=t._next}return null}function s(t,e){for(;t;){var n=t._segment;if(i(n))return n;t=t[e?"_next":"_prev"]}}for(var o,h,u=[],l=d[e],c={unite:{1:2},intersect:{2:1}}[e],f=0,g=t.length;g>f;f++){var _=t[f],v=null,p=!1;if(n(_,!0)){for(o=h=null;!p;){var y=_._intersection,w=v&&_._handleIn;y=y&&(r(y,!0)||r(y,!1))||y;var x=y&&y._segment;if(x&&n(x)&&(_=x),_._visited){if(p=i(_),!p&&y){var b=s(y,!0)||s(y,!1);b&&(_=b,p=!0)}break}v||(v=new A(m.NO_INSERT),o=_,h=x),v.add(new P(_._point,w,_._handleOut)),_._visited=!0,_=_.getNext(),p=i(_)}p?(v.firstSegment.setHandleIn(_._handleIn),v.setClosed(!0)):v&&(console.error("Boolean operation resulted in open path","segments =",v._segments.length,"length =",v.getLength()),v=null),v&&(v._segments.length>8||!a.isZero(v.getArea()))&&(u.push(v),v=null)}}return u}var d={unite:function(t){return 1===t||0===t},intersect:function(t){return 2===t},subtract:function(t){return 1===t},exclude:function(t){return 1===t}};return{_getWinding:function(t,e,n){return u(t,this._getMonoCurves(),e,n)},unite:function(t){return i(this,t,"unite")},intersect:function(t){return i(this,t,"intersect")},subtract:function(t){return i(this,t,"subtract")},exclude:function(t){return i(this,t,"exclude")},divide:function(t){return n(y,[this.subtract(t),this.intersect(t)],this,t,!0)},resolveCrossings:function(){var t=this.getCrossings();if(!t.length)return this;o(M.expand(t));for(var e=this._children||[this],i=[],r=0,s=e.length;s>r;r++)i.push.apply(i,e[r]._segments);return n(O,c(i),this,null,!1)}}}),A.inject({_getMonoCurves:function(){function t(t){var e=t[1],r=t[7],s={values:t,winding:e===r?0:e>r?-1:1,previous:n,next:null};n&&(n.next=s),i.push(s),n=s}function e(e){if(0!==I.getLength(e)){var n=e[1],i=e[3],r=e[5],s=e[7];if(I.isStraight(e))t(e);else{var o=3*(i-r)-n+s,h=2*(n+r)-4*i,u=i-n,l=4e-7,c=1-l,d=[],f=a.solveQuadratic(o,h,u,d,l,c);if(0===f)t(e);else{d.sort();var g=d[0],_=I.subdivide(e,g);t(_[0]),f>1&&(g=(d[1]-g)/(1-g),_=I.subdivide(_[1],g),t(_[0])),t(_[1])}}}}var n,i=this._monoCurves;if(!i){i=this._monoCurves=[];for(var r=this.getCurves(),s=this._segments,o=0,h=r.length;h>o;o++)e(r[o].getValues());if(!this._closed&&s.length>1){var u=s[s.length-1]._point,l=s[0]._point,c=u._x,d=u._y,f=l._x,g=l._y;e([c,d,c,d,f,g,f,g])}if(i.length>0){var _=i[0],v=i[i.length-1];_.previous=v,v.next=_}}return i},getInteriorPoint:function(){var t=this.getBounds(),e=t.getCenter(!0);if(!this.contains(e)){for(var n=this._getMonoCurves(),i=[],r=e.y,s=[],a=0,o=n.length;o>a;a++){var h=n[a].values;if((1===n[a].winding&&r>=h[1]&&r<=h[7]||r>=h[7]&&r<=h[1])&&I.solveCubic(h,1,r,i,0,1)>0)for(var u=i.length-1;u>=0;u--)s.push(I.getPoint(h,i[u]).x);if(s.length>1)break}e.x=(s[0]+s[1])/2}return e},reorient:function(){return this.setClockwise(!0),this}}),O.inject({_getMonoCurves:function(){for(var t=this._children,e=[],n=0,i=t.length;i>n;n++)e.push.apply(e,t[n]._getMonoCurves());return e},reorient:function(){var t=this.removeChildren().sort(function(t,e){return e.getBounds().getArea()-t.getBounds().getArea()});if(t.length>0){this.addChildren(t);for(var e=t[0].isClockwise(),n=1,i=t.length;i>n;n++){for(var r=t[n].getInteriorPoint(),s=0,a=n-1;a>=0;a--)t[a].contains(r)&&s++;t[n].setClockwise(s%2===0&&e)}}return this}});var T=e.extend({_class:"PathIterator",initialize:function(t,e,n,i){function r(t,e){var n=I.getValues(t,e,i);o.push(n),s(n,t._index,0,1)}function s(t,e,i,r){if(r-i>l&&!I.isFlatEnough(t,n||.25)){var a=I.subdivide(t,.5),o=(i+r)/2;s(a[0],e,i,o),s(a[1],e,o,r)}else{var c=t[6]-t[0],d=t[7]-t[1],f=Math.sqrt(c*c+d*d);f>1e-6&&(u+=f,h.push({offset:u,value:r,index:e}))}}for(var a,o=[],h=[],u=0,l=1/(e||32),c=t._segments,d=c[0],f=1,g=c.length;g>f;f++)a=c[f],r(d,a),d=a;t._closed&&r(a,c[0]),this.curves=o,this.parts=h,this.length=u,this.index=0},getParameterAt:function(t){for(var e,n=this.index;e=n,!(0==n||this.parts[--n].offset<t););for(var i=this.parts.length;i>e;e++){var r=this.parts[e];if(r.offset>=t){this.index=e;var s=this.parts[e-1],a=s&&s.index==r.index?s.value:0,o=s?s.offset:0;return{value:a+(r.value-a)*(t-o)/(r.offset-o),index:r.index}}}var r=this.parts[this.parts.length-1];return{value:1,index:r.index}},drawPart:function(t,e,n){e=this.getParameterAt(e),n=this.getParameterAt(n);for(var i=e.index;i<=n.index;i++){var r=I.getPart(this.curves[i],i==e.index?e.value:0,i==n.index?n.value:1);i==e.index&&t.moveTo(r[0],r[1]),t.bezierCurveTo.apply(t,r.slice(2))}}},e.each(I.evaluateMethods,function(t){this[t+"At"]=function(e,n){var i=this.getParameterAt(e);return I[t](this.curves[i.index],i.value,n)}},{})),E=e.extend({initialize:function(t,e){for(var n,i=this.points=[],r=t._segments,s=0,a=r.length;a>s;s++){var o=r[s].point.clone();n&&n.equals(o)||(i.push(o),n=o)}t._closed&&(this.closed=!0,i.unshift(i[i.length-1]),i.push(i[1])),this.error=e},fit:function(){var t=this.points,e=t.length,n=this.segments=e>0?[new P(t[0])]:[];return e>1&&this.fitCubic(0,e-1,t[1].subtract(t[0]).normalize(),t[e-2].subtract(t[e-1]).normalize()),this.closed&&(n.shift(),n.pop()),n},fitCubic:function(e,n,i,r){if(n-e==1){var s=this.points[e],a=this.points[n],o=s.getDistance(a)/3;return this.addCurve([s,s.add(i.normalize(o)),a.add(r.normalize(o)),a]),t}for(var h,u=this.chordLengthParameterize(e,n),l=Math.max(this.error,this.error*this.error),c=!0,d=0;4>=d;d++){var f=this.generateBezier(e,n,u,i,r),g=this.findMaxError(e,n,f,u);if(g.error<this.error&&c)return this.addCurve(f),t;if(h=g.index,g.error>=l)break;c=this.reparameterize(e,n,u,f),l=g.error}var _=this.points[h-1].subtract(this.points[h]),v=this.points[h].subtract(this.points[h+1]),p=_.add(v).divide(2).normalize();this.fitCubic(e,h,i,p),this.fitCubic(h,n,p.negate(),r)},addCurve:function(t){var e=this.segments[this.segments.length-1];e.setHandleOut(t[1].subtract(t[0])),this.segments.push(new P(t[3],t[2].subtract(t[3])))},generateBezier:function(t,e,n,i,r){for(var s=1e-12,a=this.points[t],o=this.points[e],h=[[0,0],[0,0]],u=[0,0],l=0,c=e-t+1;c>l;l++){var d=n[l],f=1-d,g=3*d*f,_=f*f*f,v=g*f,p=g*d,m=d*d*d,y=i.normalize(v),w=r.normalize(p),x=this.points[t+l].subtract(a.multiply(_+v)).subtract(o.multiply(p+m));h[0][0]+=y.dot(y),h[0][1]+=y.dot(w),h[1][0]=h[0][1],h[1][1]+=w.dot(w),u[0]+=y.dot(x),u[1]+=w.dot(x)}var b,C,S=h[0][0]*h[1][1]-h[1][0]*h[0][1];if(Math.abs(S)>s){var P=h[0][0]*u[1]-h[1][0]*u[0],k=u[0]*h[1][1]-u[1]*h[0][1];b=k/S,C=P/S}else{var I=h[0][0]+h[0][1],M=h[1][0]+h[1][1];b=C=Math.abs(I)>s?u[0]/I:Math.abs(M)>s?u[1]/M:0}var z,A,O=o.getDistance(a),T=s*O;if(T>b||T>C)b=C=O/3;else{var E=o.subtract(a);z=i.normalize(b),A=r.normalize(C),z.dot(E)-A.dot(E)>O*O&&(b=C=O/3,z=A=null)}return[a,a.add(z||i.normalize(b)),o.add(A||r.normalize(C)),o]},reparameterize:function(t,e,n,i){for(var r=t;e>=r;r++)n[r-t]=this.findRoot(i,this.points[r],n[r-t]);for(var r=1,s=n.length;s>r;r++)if(n[r]<=n[r-1])return!1;return!0},findRoot:function(t,e,n){for(var i=[],r=[],s=0;2>=s;s++)i[s]=t[s+1].subtract(t[s]).multiply(3);for(var s=0;1>=s;s++)r[s]=i[s+1].subtract(i[s]).multiply(2);var a=this.evaluate(3,t,n),o=this.evaluate(2,i,n),h=this.evaluate(1,r,n),u=a.subtract(e),l=o.dot(o)+u.dot(h);return Math.abs(l)<1e-6?n:n-u.dot(o)/l},evaluate:function(t,e,n){for(var i=e.slice(),r=1;t>=r;r++)for(var s=0;t-r>=s;s++)i[s]=i[s].multiply(1-n).add(i[s+1].multiply(n));return i[0]},chordLengthParameterize:function(t,e){for(var n=[0],i=t+1;e>=i;i++)n[i-t]=n[i-t-1]+this.points[i].getDistance(this.points[i-1]);for(var i=1,r=e-t;r>=i;i++)n[i]/=n[r];return n},findMaxError:function(t,e,n,i){for(var r=Math.floor((e-t+1)/2),s=0,a=t+1;e>a;a++){var o=this.evaluate(3,n,i[a-t]),h=o.subtract(this.points[a]),u=h.x*h.x+h.y*h.y;u>=s&&(s=u,r=a)}return{error:s,index:r}}}),L=m.extend({_class:"TextItem",_boundsSelected:!0,_applyMatrix:!1,_canApplyMatrix:!1,_serializeFields:{content:null},_boundsGetter:"getBounds",initialize:function(n){this._content="",this._lines=[];var i=n&&e.isPlainObject(n)&&n.x===t&&n.y===t;this._initialize(i&&n,!i&&h.read(arguments))},_equals:function(t){return this._content===t._content},_clone:function wt(t,e,n){return t.setContent(this._content),wt.base.call(this,t,e,n)},getContent:function(){return this._content},setContent:function(t){this._content=""+t,this._lines=this._content.split(/\r\n|\n|\r/gm),this._changed(265)},isEmpty:function(){return!this._content},getCharacterStyle:"#getStyle",setCharacterStyle:"#setStyle",getParagraphStyle:"#getStyle",setParagraphStyle:"#setStyle"}),N=L.extend({_class:"PointText",initialize:function(){L.apply(this,arguments)},clone:function(t){return this._clone(new N(m.NO_INSERT),t)},getPoint:function(){var t=this._matrix.getTranslation();return new u(t.x,t.y,this,"setPoint")},setPoint:function(){var t=h.read(arguments);this.translate(t.subtract(this._matrix.getTranslation()))},_draw:function(t){if(this._content){this._setStyles(t);var e=this._style,n=this._lines,i=e.getLeading(),r=t.shadowColor;t.font=e.getFontStyle(),t.textAlign=e.getJustification();for(var s=0,a=n.length;a>s;s++){t.shadowColor=r;var o=n[s];e.hasFill()&&(t.fillText(o,0,0),t.shadowColor="rgba(0,0,0,0)"),e.hasStroke()&&t.strokeText(o,0,0),t.translate(0,i)}}},_getBounds:function(t,e){var n=this._style,i=this._lines,r=i.length,s=n.getJustification(),a=n.getLeading(),o=this.getView().getTextWidth(n.getFontStyle(),i),h=0;"left"!==s&&(h-=o/("center"===s?2:1));var u=new d(h,r?-.75*a:0,o,r*a);return e?e._transformBounds(u,u):u}}),j=e.extend(new function(){function t(t){var e,i=t.match(/^#(\w{1,2})(\w{1,2})(\w{1,2})$/);if(i){e=[0,0,0];for(var r=0;3>r;r++){var s=i[r+1];e[r]=parseInt(1==s.length?s+s:s,16)/255}}else if(i=t.match(/^rgba?\((.*)\)$/)){e=i[1].split(",");for(var r=0,o=e.length;o>r;r++){var s=+e[r];e[r]=3>r?s/255:s}}else{var h=a[t];if(!h){n||(n=Y.getContext(1,1),n.globalCompositeOperation="copy"),n.fillStyle="rgba(0,0,0,0)",n.fillStyle=t,n.fillRect(0,0,1,1);var u=n.getImageData(0,0,1,1).data;h=a[t]=[u[0]/255,u[1]/255,u[2]/255]}e=h.slice()}return e}var n,i={gray:["gray"],rgb:["red","green","blue"],hsb:["hue","saturation","brightness"],hsl:["hue","saturation","lightness"],gradient:["gradient","origin","destination","highlight"]},r={},a={},u=[[0,3,1],[2,0,1],[1,0,3],[1,2,0],[3,1,0],[0,1,2]],l={"rgb-hsb":function(t,e,n){var i=Math.max(t,e,n),r=Math.min(t,e,n),s=i-r,a=0===s?0:60*(i==t?(e-n)/s+(n>e?6:0):i==e?(n-t)/s+2:(t-e)/s+4);return[a,0===i?0:s/i,i]},"hsb-rgb":function(t,e,n){t=(t/60%6+6)%6;var i=Math.floor(t),r=t-i,i=u[i],s=[n,n*(1-e),n*(1-e*r),n*(1-e*(1-r))];return[s[i[0]],s[i[1]],s[i[2]]]},"rgb-hsl":function(t,e,n){var i=Math.max(t,e,n),r=Math.min(t,e,n),s=i-r,a=0===s,o=a?0:60*(i==t?(e-n)/s+(n>e?6:0):i==e?(n-t)/s+2:(t-e)/s+4),h=(i+r)/2,u=a?0:.5>h?s/(i+r):s/(2-i-r);return[o,u,h]},"hsl-rgb":function(t,e,n){if(t=(t/360%1+1)%1,0===e)return[n,n,n];for(var i=[t+1/3,t,t-1/3],r=.5>n?n*(1+e):n+e-n*e,s=2*n-r,a=[],o=0;3>o;o++){var h=i[o];0>h&&(h+=1),h>1&&(h-=1),a[o]=1>6*h?s+6*(r-s)*h:1>2*h?r:2>3*h?s+(r-s)*(2/3-h)*6:s}return a},"rgb-gray":function(t,e,n){return[.2989*t+.587*e+.114*n]},"gray-rgb":function(t){return[t,t,t]},"gray-hsb":function(t){return[0,0,t]},"gray-hsl":function(t){return[0,0,t]},"gradient-rgb":function(){return[]},"rgb-gradient":function(){return[]}};return e.each(i,function(t,n){r[n]=[],e.each(t,function(t,s){var a=e.capitalize(t),o=/^(hue|saturation)$/.test(t),u=r[n][s]="gradient"===t?function(t){var e=this._components[0];return t=B.read(Array.isArray(t)?t:arguments,0,{readNull:!0}),e!==t&&(e&&e._removeOwner(this),t&&t._addOwner(this)),t}:"gradient"===n?function(){return h.read(arguments,0,{readNull:"highlight"===t,clone:!0})}:function(t){return null==t||isNaN(t)?0:t};this["get"+a]=function(){return this._type===n||o&&/^hs[bl]$/.test(this._type)?this._components[s]:this._convert(n)[s]},this["set"+a]=function(t){this._type===n||o&&/^hs[bl]$/.test(this._type)||(this._components=this._convert(n),this._properties=i[n],this._type=n),this._components[s]=u.call(this,t),this._changed()}},this)},{_class:"Color",_readIndex:!0,initialize:function c(e){var n,s,a,h,u=Array.prototype.slice,l=arguments,d=0;Array.isArray(e)&&(l=e,e=l[0]);var f=null!=e&&typeof e;if("string"===f&&e in i&&(n=e,e=l[1],Array.isArray(e)?(s=e,a=l[2]):(this.__read&&(d=1),l=u.call(l,1),f=typeof e)),!s){if(h="number"===f?l:"object"===f&&null!=e.length?e:null){n||(n=h.length>=3?"rgb":"gray");var g=i[n].length;a=h[g],this.__read&&(d+=h===arguments?g+(null!=a?1:0):1),h.length>g&&(h=u.call(h,0,g))}else if("string"===f)n="rgb",s=t(e),4===s.length&&(a=s[3],s.length--);else if("object"===f)if(e.constructor===c){if(n=e._type,s=e._components.slice(),a=e._alpha,"gradient"===n)for(var _=1,v=s.length;v>_;_++){var p=s[_];p&&(s[_]=p.clone())}}else if(e.constructor===B)n="gradient",h=l;else{n="hue"in e?"lightness"in e?"hsl":"hsb":"gradient"in e||"stops"in e||"radial"in e?"gradient":"gray"in e?"gray":"rgb";var m=i[n],y=r[n];this._components=s=[];for(var _=0,v=m.length;v>_;_++){var w=e[m[_]];null==w&&0===_&&"gradient"===n&&"stops"in e&&(w={stops:e.stops,radial:e.radial}),w=y[_].call(this,w),null!=w&&(s[_]=w)}a=e.alpha}this.__read&&n&&(d=1)}if(this._type=n||"rgb",this._id=o.get(c),!s){this._components=s=[];for(var y=r[this._type],_=0,v=y.length;v>_;_++){var w=y[_].call(this,h&&h[_]);null!=w&&(s[_]=w)}}this._components=s,this._properties=i[this._type],this._alpha=a,this.__read&&(this.__read=d)},_serialize:function(t,n){var i=this.getComponents();return e.serialize(/^(gray|rgb)$/.test(this._type)?i:[this._type].concat(i),t,!0,n)},_changed:function(){this._canvasStyle=null,this._owner&&this._owner._changed(65)},_convert:function(t){var e;return this._type===t?this._components.slice():(e=l[this._type+"-"+t])?e.apply(this,this._components):l["rgb-"+t].apply(this,l[this._type+"-rgb"].apply(this,this._components))},convert:function(t){return new j(t,this._convert(t),this._alpha)},getType:function(){return this._type},setType:function(t){this._components=this._convert(t),this._properties=i[t],this._type=t},getComponents:function(){var t=this._components.slice();return null!=this._alpha&&t.push(this._alpha),t},getAlpha:function(){return null!=this._alpha?this._alpha:1},setAlpha:function(t){this._alpha=null==t?null:Math.min(Math.max(t,0),1),this._changed()},hasAlpha:function(){return null!=this._alpha},equals:function(t){var n=e.isPlainValue(t,!0)?j.read(arguments):t;return n===this||n&&this._class===n._class&&this._type===n._type&&this._alpha===n._alpha&&e.equals(this._components,n._components)||!1},toString:function(){for(var t=this._properties,e=[],n="gradient"===this._type,i=s.instance,r=0,a=t.length;a>r;r++){var o=this._components[r];null!=o&&e.push(t[r]+": "+(n?o:i.number(o)))}return null!=this._alpha&&e.push("alpha: "+i.number(this._alpha)),"{ "+e.join(", ")+" }"},toCSS:function(t){function e(t){return Math.round(255*(0>t?0:t>1?1:t))}var n=this._convert("rgb"),i=t||null==this._alpha?1:this._alpha;return n=[e(n[0]),e(n[1]),e(n[2])],1>i&&n.push(0>i?0:i),t?"#"+((1<<24)+(n[0]<<16)+(n[1]<<8)+n[2]).toString(16).slice(1):(4==n.length?"rgba(":"rgb(")+n.join(",")+")"},toCanvasStyle:function(t){if(this._canvasStyle)return this._canvasStyle;if("gradient"!==this._type)return this._canvasStyle=this.toCSS();var e,n=this._components,i=n[0],r=i._stops,s=n[1],a=n[2];if(i._radial){var o=a.getDistance(s),h=n[3];if(h){var u=h.subtract(s);u.getLength()>o&&(h=s.add(u.normalize(o-.1)))}var l=h||s;e=t.createRadialGradient(l.x,l.y,0,s.x,s.y,o)}else e=t.createLinearGradient(s.x,s.y,a.x,a.y);for(var c=0,d=r.length;d>c;c++){var f=r[c];e.addColorStop(f._rampPoint,f._color.toCanvasStyle())}return this._canvasStyle=e},transform:function(t){if("gradient"===this._type){for(var e=this._components,n=1,i=e.length;i>n;n++){var r=e[n];t._transformPoint(r,r,!0)}this._changed()}},statics:{_types:i,random:function(){var t=Math.random;return new j(t(),t(),t())}}})},new function(){var t={add:function(t,e){return t+e},subtract:function(t,e){return t-e},multiply:function(t,e){return t*e},divide:function(t,e){return t/e}};return e.each(t,function(t,e){this[e]=function(e){e=j.read(arguments);for(var n=this._type,i=this._components,r=e._convert(n),s=0,a=i.length;a>s;s++)r[s]=t(i[s],r[s]);return new j(n,r,null!=this._alpha?t(this._alpha,e.getAlpha()):null)}},{})}),B=e.extend({_class:"Gradient",initialize:function(t,e){this._id=o.get(),t&&this._set(t)&&(t=e=null),this._stops||this.setStops(t||["white","black"]),null==this._radial&&this.setRadial("string"==typeof e&&"radial"===e||e||!1)},_serialize:function(t,n){return n.add(this,function(){return e.serialize([this._stops,this._radial],t,!0,n)})},_changed:function(){for(var t=0,e=this._owners&&this._owners.length;e>t;t++)this._owners[t]._changed()},_addOwner:function(t){this._owners||(this._owners=[]),this._owners.push(t)},_removeOwner:function(e){var n=this._owners?this._owners.indexOf(e):-1;-1!=n&&(this._owners.splice(n,1),0===this._owners.length&&(this._owners=t))},clone:function(){for(var t=[],e=0,n=this._stops.length;n>e;e++)t[e]=this._stops[e].clone();return new B(t,this._radial)},getStops:function(){return this._stops},setStops:function(e){if(this.stops)for(var n=0,i=this._stops.length;i>n;n++)this._stops[n]._owner=t;if(e.length<2)throw Error("Gradient stop list needs to contain at least two stops.");this._stops=R.readAll(e,0,{clone:!0});for(var n=0,i=this._stops.length;i>n;n++){var r=this._stops[n];r._owner=this,r._defaultRamp&&r.setRampPoint(n/(i-1))}this._changed()},getRadial:function(){return this._radial},setRadial:function(t){this._radial=t,this._changed()},equals:function(t){if(t===this)return!0;if(t&&this._class===t._class&&this._stops.length===t._stops.length){for(var e=0,n=this._stops.length;n>e;e++)if(!this._stops[e].equals(t._stops[e]))return!1;return!0}return!1}}),R=e.extend({_class:"GradientStop",initialize:function(e,n){if(e){var i,r;n===t&&Array.isArray(e)?(i=e[0],r=e[1]):e.color?(i=e.color,r=e.rampPoint):(i=e,r=n),this.setColor(i),this.setRampPoint(r)}},clone:function(){return new R(this._color.clone(),this._rampPoint)},_serialize:function(t,n){return e.serialize([this._color,this._rampPoint],t,!0,n)},_changed:function(){this._owner&&this._owner._changed(65)},getRampPoint:function(){return this._rampPoint},setRampPoint:function(t){this._defaultRamp=null==t,this._rampPoint=t||0,this._changed()},getColor:function(){return this._color},setColor:function(t){this._color=j.read(arguments),this._color===t&&(this._color=t.clone()),this._color._owner=this,this._changed()},equals:function(t){return t===this||t&&this._class===t._class&&this._color.equals(t._color)&&this._rampPoint==t._rampPoint||!1}}),D=e.extend(new function(){var n={fillColor:t,strokeColor:t,strokeWidth:1,strokeCap:"butt",strokeJoin:"miter",strokeScaling:!0,miterLimit:10,dashOffset:0,dashArray:[],windingRule:"nonzero",shadowColor:t,shadowBlur:0,shadowOffset:new h,selectedColor:t,fontFamily:"sans-serif",fontWeight:"normal",fontSize:12,font:"sans-serif",leading:null,justification:"left"},i={strokeWidth:97,strokeCap:97,strokeJoin:97,strokeScaling:105,miterLimit:97,fontFamily:9,fontWeight:9,fontSize:9,font:9,leading:9,justification:9},r={beans:!0},s={_defaults:n,_textDefaults:new e(n,{fillColor:new j}),beans:!0};return e.each(n,function(n,a){var o=/Color$/.test(a),u="shadowOffset"===a,l=e.capitalize(a),c=i[a],d="set"+l,f="get"+l;s[d]=function(e){var n=this._owner,i=n&&n._children;if(i&&i.length>0&&!(n instanceof O))for(var r=0,s=i.length;s>r;r++)i[r]._style[d](e);else{var h=this._values[a];h!==e&&(o&&(h&&(h._owner=t),e&&e.constructor===j&&(e._owner&&(e=e.clone()),e._owner=n)),this._values[a]=e,n&&n._changed(c||65))}},s[f]=function(n){var i,r=this._owner,s=r&&r._children;if(!s||0===s.length||n||r instanceof O){var i=this._values[a];if(i===t)i=this._defaults[a],i&&i.clone&&(i=i.clone());else{var l=o?j:u?h:null;!l||i&&i.constructor===l||(this._values[a]=i=l.read([i],0,{readNull:!0,clone:!0}),i&&o&&(i._owner=r))}return i}for(var c=0,d=s.length;d>c;c++){var g=s[c]._style[f]();if(0===c)i=g;else if(!e.equals(i,g))return t}return i},r[f]=function(t){return this._style[f](t)},r[d]=function(t){this._style[d](t)}}),m.inject(r),s},{_class:"Style",initialize:function(t,e,n){this._values={},this._owner=e,this._project=e&&e._project||n||paper.project,e instanceof L&&(this._defaults=this._textDefaults),t&&this.set(t)},set:function(t){var e=t instanceof D,n=e?t._values:t;if(n)for(var i in n)if(i in this._defaults){var r=n[i];this[i]=r&&e&&r.clone?r.clone():r}},equals:function(t){return t===this||t&&this._class===t._class&&e.equals(this._values,t._values)||!1},hasFill:function(){return!!this.getFillColor()},hasStroke:function(){return!!this.getStrokeColor()&&this.getStrokeWidth()>0},hasShadow:function(){return!!this.getShadowColor()&&this.getShadowBlur()>0},getView:function(){return this._project.getView()},getFontStyle:function(){var t=this.getFontSize();return this.getFontWeight()+" "+t+(/[a-z]/i.test(t+"")?" ":"px ")+this.getFontFamily()},getFont:"#getFontFamily",setFont:"#setFontFamily",getLeading:function xt(){var t=xt.base.call(this),e=this.getFontSize();return/pt|em|%|px/.test(e)&&(e=this.getView().getPixelSize(e)),null!=t?t:1.2*e}}),F=new function(){function t(t,e,n,i){for(var r=["","webkit","moz","Moz","ms","o"],s=e[0].toUpperCase()+e.substring(1),a=0;6>a;a++){var o=r[a],h=o?o+s:e;if(h in t){if(!n)return t[h];t[h]=i;break}}}return{getStyles:function(t){var e=t&&9!==t.nodeType?t.ownerDocument:t,n=e&&e.defaultView;return n&&n.getComputedStyle(t,"")},getBounds:function(t,e){var n,i=t.ownerDocument,r=i.body,s=i.documentElement;try{n=t.getBoundingClientRect()}catch(a){n={left:0,top:0,width:0,height:0}}var o=n.left-(s.clientLeft||r.clientLeft||0),h=n.top-(s.clientTop||r.clientTop||0);if(!e){var u=i.defaultView;o+=u.pageXOffset||s.scrollLeft||r.scrollLeft,h+=u.pageYOffset||s.scrollTop||r.scrollTop}return new d(o,h,n.width,n.height)},getViewportBounds:function(t){var e=t.ownerDocument,n=e.defaultView,i=e.documentElement;return new d(0,0,n.innerWidth||i.clientWidth,n.innerHeight||i.clientHeight)},getOffset:function(t,e){return F.getBounds(t,e).getPoint()},getSize:function(t){return F.getBounds(t,!0).getSize()},isInvisible:function(t){return F.getSize(t).equals(new l(0,0))},isInView:function(t){return!F.isInvisible(t)&&F.getViewportBounds(t).intersects(F.getBounds(t,!0))},getPrefixed:function(e,n){return t(e,n)},setPrefixed:function(e,n,i){if("object"==typeof n)for(var r in n)t(e,r,!0,n[r]);else t(e,n,!0,i)}}},q={add:function(t,e){for(var n in e)for(var i=e[n],r=n.split(/[\s,]+/g),s=0,a=r.length;a>s;s++)t.addEventListener(r[s],i,!1)},remove:function(t,e){for(var n in e)for(var i=e[n],r=n.split(/[\s,]+/g),s=0,a=r.length;a>s;s++)t.removeEventListener(r[s],i,!1)},getPoint:function(t){var e=t.targetTouches?t.targetTouches.length?t.targetTouches[0]:t.changedTouches[0]:t;return new h(e.pageX||e.clientX+document.documentElement.scrollLeft,e.pageY||e.clientY+document.documentElement.scrollTop)},getTarget:function(t){return t.target||t.srcElement},getRelatedTarget:function(t){return t.relatedTarget||t.toElement},getOffset:function(t,e){return q.getPoint(t).subtract(F.getOffset(e||q.getTarget(t)))},stop:function(t){t.stopPropagation(),t.preventDefault()}};q.requestAnimationFrame=new function(){function t(){for(var e=s.length-1;e>=0;e--){var o=s[e],h=o[0],u=o[1];(!u||("true"==i.getAttribute(u,"keepalive")||a)&&F.isInView(u))&&(s.splice(e,1),h())}n&&(s.length?n(t):r=!1)}var e,n=F.getPrefixed(window,"requestAnimationFrame"),r=!1,s=[],a=!0;return q.add(window,{focus:function(){a=!0},blur:function(){a=!1}}),function(i,a){s.push([i,a]),n?r||(n(t),r=!0):e||(e=setInterval(t,1e3/60))}};var V=e.extend(n,{_class:"View",initialize:function bt(t,e){function n(t){return e[t]||parseInt(e.getAttribute(t),10)}function r(){var t=F.getSize(e);return t.isNaN()||t.isZero()?new l(n("width"),n("height")):t}this._project=t,this._scope=t._scope,this._element=e;var s;this._pixelRatio||(this._pixelRatio=window.devicePixelRatio||1),this._id=e.getAttribute("id"),null==this._id&&e.setAttribute("id",this._id="view-"+bt._id++),q.add(e,this._viewEvents);var a="none";if(F.setPrefixed(e.style,{userSelect:a,touchAction:a,touchCallout:a,contentZooming:a,userDrag:a,tapHighlightColor:"rgba(0,0,0,0)"}),i.hasAttribute(e,"resize")){var o=this;q.add(window,this._windowEvents={resize:function(){o.setViewSize(r())}})}if(this._setViewSize(s=r()),i.hasAttribute(e,"stats")&&"undefined"!=typeof Stats){this._stats=new Stats;var h=this._stats.domElement,u=h.style,c=F.getOffset(e);u.position="absolute",u.left=c.x+"px",u.top=c.y+"px",document.body.appendChild(h)}bt._views.push(this),bt._viewsById[this._id]=this,this._viewSize=s,(this._matrix=new g)._owner=this,this._zoom=1,bt._focused||(bt._focused=this),this._frameItems={},this._frameItemCount=0},remove:function(){return this._project?(V._focused===this&&(V._focused=null),V._views.splice(V._views.indexOf(this),1),delete V._viewsById[this._id],this._project._view===this&&(this._project._view=null),q.remove(this._element,this._viewEvents),q.remove(window,this._windowEvents),this._element=this._project=null,this.off("frame"),this._animate=!1,this._frameItems={},!0):!1},_events:e.each(["onResize","onMouseDown","onMouseUp","onMouseMove"],function(t){this[t]={install:function(t){this._installEvent(t)},uninstall:function(t){this._uninstallEvent(t)}}},{onFrame:{install:function(){this.play()},uninstall:function(){this.pause()}}}),_animate:!1,_time:0,_count:0,_requestFrame:function(){var t=this;q.requestAnimationFrame(function(){t._requested=!1,t._animate&&(t._requestFrame(),t._handleFrame())},this._element),this._requested=!0},_handleFrame:function(){paper=this._scope;var t=Date.now()/1e3,n=this._before?t-this._before:0;this._before=t,this._handlingFrame=!0,this.emit("frame",new e({delta:n,time:this._time+=n,count:this._count++})),this._stats&&this._stats.update(),this._handlingFrame=!1,this.update()},_animateItem:function(t,e){var n=this._frameItems;e?(n[t._id]={item:t,time:0,count:0},1===++this._frameItemCount&&this.on("frame",this._handleFrameItems)):(delete n[t._id],0===--this._frameItemCount&&this.off("frame",this._handleFrameItems))},_handleFrameItems:function(t){for(var n in this._frameItems){var i=this._frameItems[n];i.item.emit("frame",new e(t,{time:i.time+=t.delta,count:i.count++}))}},_update:function(){this._project._needsUpdate=!0,this._handlingFrame||(this._animate?this._handleFrame():this.update())},_changed:function(t){1&t&&(this._project._needsUpdate=!0)},_transform:function(t){this._matrix.concatenate(t),this._bounds=null,this._update()},getElement:function(){return this._element},getPixelRatio:function(){return this._pixelRatio},getResolution:function(){return 72*this._pixelRatio},getViewSize:function(){var t=this._viewSize;return new c(t.width,t.height,this,"setViewSize")},setViewSize:function(){var t=l.read(arguments),e=t.subtract(this._viewSize);e.isZero()||(this._viewSize.set(t.width,t.height),this._setViewSize(t),this._bounds=null,this.emit("resize",{size:t,delta:e}),this._update())},_setViewSize:function(t){var e=this._element;e.width=t.width,e.height=t.height},getBounds:function(){return this._bounds||(this._bounds=this._matrix.inverted()._transformBounds(new d(new h,this._viewSize))),this._bounds},getSize:function(){return this.getBounds().getSize()},getCenter:function(){return this.getBounds().getCenter()},setCenter:function(){var t=h.read(arguments);this.scrollBy(t.subtract(this.getCenter()))},getZoom:function(){return this._zoom},setZoom:function(t){this._transform((new g).scale(t/this._zoom,this.getCenter())),this._zoom=t},isVisible:function(){return F.isInView(this._element)},scrollBy:function(){
-this._transform((new g).translate(h.read(arguments).negate()))},play:function(){this._animate=!0,this._requested||this._requestFrame()},pause:function(){this._animate=!1},draw:function(){this.update()},projectToView:function(){return this._matrix._transformPoint(h.read(arguments))},viewToProject:function(){return this._matrix._inverseTransform(h.read(arguments))}},{statics:{_views:[],_viewsById:{},_id:0,create:function(t,e){return"string"==typeof e&&(e=document.getElementById(e)),new H(t,e)}}},new function(){function t(t){var e=q.getTarget(t);return e.getAttribute&&V._viewsById[e.getAttribute("id")]}function e(t,e){return t.viewToProject(q.getOffset(e,t._element))}function n(){if(!V._focused||!V._focused.isVisible())for(var t=0,e=V._views.length;e>t;t++){var n=V._views[t];if(n&&n.isVisible()){V._focused=a=n;break}}}function i(t,e,n){t._handleEvent("mousemove",e,n);var i=t._scope.tool;return i&&i._handleEvent(l&&i.responds("mousedrag")?"mousedrag":"mousemove",e,n),t.update(),i}var r,s,a,o,h,u,l=!1,c=window.navigator;c.pointerEnabled||c.msPointerEnabled?(o="pointerdown MSPointerDown",h="pointermove MSPointerMove",u="pointerup pointercancel MSPointerUp MSPointerCancel"):(o="touchstart",h="touchmove",u="touchend touchcancel","ontouchstart"in window&&c.userAgent.match(/mobile|tablet|ip(ad|hone|od)|android|silk/i)||(o+=" mousedown",h+=" mousemove",u+=" mouseup"));var d={"selectstart dragstart":function(t){l&&t.preventDefault()}},f={mouseout:function(t){var n=V._focused,r=q.getRelatedTarget(t);!n||r&&"HTML"!==r.nodeName||i(n,e(n,t),t)},scroll:n};d[o]=function(n){var i=V._focused=t(n),s=e(i,n);l=!0,i._handleEvent("mousedown",s,n),(r=i._scope.tool)&&r._handleEvent("mousedown",s,n),i.update()},f[h]=function(o){var h=V._focused;if(!l){var u=t(o);u?(h!==u&&i(h,e(h,o),o),s=h,h=V._focused=a=u):a&&a===h&&(h=V._focused=s,n())}if(h){var c=e(h,o);(l||h.getBounds().contains(c))&&(r=i(h,c,o))}},f[u]=function(t){var n=V._focused;if(n&&l){var i=e(n,t);l=!1,n._handleEvent("mouseup",i,t),r&&r._handleEvent("mouseup",i,t),n.update()}},q.add(document,f),q.add(window,{load:n});var g={mousedown:{mousedown:1,mousedrag:1,click:1,doubleclick:1},mouseup:{mouseup:1,mousedrag:1,click:1,doubleclick:1},mousemove:{mousedrag:1,mousemove:1,mouseenter:1,mouseleave:1}};return{_viewEvents:d,_handleEvent:function(){},_installEvent:function(t){var e=this._eventCounters;if(e)for(var n in g)e[n]=(e[n]||0)+(g[n][t]||0)},_uninstallEvent:function(t){var e=this._eventCounters;if(e)for(var n in g)e[n]-=g[n][t]||0},statics:{updateFocus:n}}}),H=V.extend({_class:"CanvasView",initialize:function(t,e){if(!(e instanceof HTMLCanvasElement)){var n=l.read(arguments,1);if(n.isZero())throw Error("Cannot create CanvasView with the provided argument: "+[].slice.call(arguments,1));e=Y.getCanvas(n)}if(this._context=e.getContext("2d"),this._eventCounters={},this._pixelRatio=1,!/^off|false$/.test(i.getAttribute(e,"hidpi"))){var r=window.devicePixelRatio||1,s=F.getPrefixed(this._context,"backingStorePixelRatio")||1;this._pixelRatio=r/s}V.call(this,t,e)},_setViewSize:function(t){var e=this._element,n=this._pixelRatio,r=t.width,s=t.height;if(e.width=r*n,e.height=s*n,1!==n){if(!i.hasAttribute(e,"resize")){var a=e.style;a.width=r+"px",a.height=s+"px"}this._context.scale(n,n)}},getPixelSize:function(t){var e,n=paper.browser;if(n&&n.firefox){var i=this._element.parentNode,r=document.createElement("div");r.style.fontSize=t,i.appendChild(r),e=parseFloat(F.getStyles(r).fontSize),i.removeChild(r)}else{var s=this._context,a=s.font;s.font=t+" serif",e=parseFloat(s.font),s.font=a}return e},getTextWidth:function(t,e){var n=this._context,i=n.font,r=0;n.font=t;for(var s=0,a=e.length;a>s;s++)r=Math.max(r,n.measureText(e[s]).width);return n.font=i,r},update:function(t){var e=this._project;if(!e||!t&&!e._needsUpdate)return!1;var n=this._context,i=this._viewSize;return n.clearRect(0,0,i.width+1,i.height+1),e.draw(n,this._matrix,this._pixelRatio),e._needsUpdate=!1,!0}},new function(){function e(e,n,i,r,s,a){function o(e){return e.responds(n)&&(h||(h=new G(n,i,r,s,a?r.subtract(a):null)),e.emit(n,h)&&h.isStopped)?(i.preventDefault(),!0):t}for(var h,u=s;u;){if(o(u))return!0;u=u.getParent()}return o(e)?!0:!1}var n,i,r,s,a,o,h,u,l;return{_handleEvent:function(t,c,d){if(this._eventCounters[t]){var f=this._project,g=f.hitTest(c,{tolerance:0,fill:!0,stroke:!0}),_=g&&g.item,v=!1;switch(t){case"mousedown":for(v=e(this,t,d,c,_),u=a==_&&Date.now()-l<300,s=a=_,n=i=r=c,h=!v&&_;h&&!h.responds("mousedrag");)h=h._parent;break;case"mouseup":v=e(this,t,d,c,_,n),h&&(i&&!i.equals(c)&&e(this,"mousedrag",d,c,h,i),_!==h&&(r=c,e(this,"mousemove",d,c,_,r))),!v&&_&&_===s&&(l=Date.now(),e(this,u&&s.responds("doubleclick")?"doubleclick":"click",d,n,_),u=!1),s=h=null;break;case"mousemove":h&&(v=e(this,"mousedrag",d,c,h,i)),v||(_!==o&&(r=c),v=e(this,t,d,c,_,r)),i=r=c,_!==o&&(e(this,"mouseleave",d,c,o),o=_,e(this,"mouseenter",d,c,_))}return v}}}}),Z=e.extend({_class:"Event",initialize:function(t){this.event=t},isPrevented:!1,isStopped:!1,preventDefault:function(){this.isPrevented=!0,this.event.preventDefault()},stopPropagation:function(){this.isStopped=!0,this.event.stopPropagation()},stop:function(){this.stopPropagation(),this.preventDefault()},getModifiers:function(){return W.modifiers}}),U=Z.extend({_class:"KeyEvent",initialize:function(t,e,n,i){Z.call(this,i),this.type=t?"keydown":"keyup",this.key=e,this.character=n},toString:function(){return"{ type: '"+this.type+"', key: '"+this.key+"', character: '"+this.character+"', modifiers: "+this.getModifiers()+" }"}}),W=new function(){function t(i,s,u,l){var c,d=u?String.fromCharCode(u):"",f=r[s],g=f||d.toLowerCase(),_=i?"keydown":"keyup",v=V._focused,p=v&&v.isVisible()&&v._scope,m=p&&p.tool;if(h[g]=i,i?o[s]=u:delete o[s],f&&(c=e.camelize(f))in a){a[c]=i;var y=paper.browser;if("command"===c&&y&&y.mac)if(i)n={};else{for(var w in n)w in o&&t(!1,w,n[w],l);n=null}}else i&&n&&(n[s]=u);m&&m.responds(_)&&(paper=p,m.emit(_,new U(i,g,d,l)),v&&v.update())}var n,i,r={8:"backspace",9:"tab",13:"enter",16:"shift",17:"control",18:"option",19:"pause",20:"caps-lock",27:"escape",32:"space",35:"end",36:"home",37:"left",38:"up",39:"right",40:"down",46:"delete",91:"command",93:"command",224:"command"},s={9:!0,13:!0,32:!0},a=new e({shift:!1,control:!1,option:!1,command:!1,capsLock:!1,space:!1}),o={},h={};return q.add(document,{keydown:function(e){var n=e.which||e.keyCode;n in r||a.command?t(!0,n,n in s||a.command?n:0,e):i=n},keypress:function(e){null!=i&&(t(!0,i,e.which||e.keyCode,e),i=null)},keyup:function(e){var n=e.which||e.keyCode;n in o&&t(!1,n,o[n],e)}}),q.add(window,{blur:function(e){for(var n in o)t(!1,n,o[n],e)}}),{modifiers:a,isDown:function(t){return!!h[t]}}},G=Z.extend({_class:"MouseEvent",initialize:function(t,e,n,i,r){Z.call(this,e),this.type=t,this.point=n,this.target=i,this.delta=r},toString:function(){return"{ type: '"+this.type+"', point: "+this.point+", target: "+this.target+(this.delta?", delta: "+this.delta:"")+", modifiers: "+this.getModifiers()+" }"}}),$=Z.extend({_class:"ToolEvent",_item:null,initialize:function(t,e,n){this.tool=t,this.type=e,this.event=n},_choosePoint:function(t,e){return t?t:e?e.clone():null},getPoint:function(){return this._choosePoint(this._point,this.tool._point)},setPoint:function(t){this._point=t},getLastPoint:function(){return this._choosePoint(this._lastPoint,this.tool._lastPoint)},setLastPoint:function(t){this._lastPoint=t},getDownPoint:function(){return this._choosePoint(this._downPoint,this.tool._downPoint)},setDownPoint:function(t){this._downPoint=t},getMiddlePoint:function(){return!this._middlePoint&&this.tool._lastPoint?this.tool._point.add(this.tool._lastPoint).divide(2):this._middlePoint},setMiddlePoint:function(t){this._middlePoint=t},getDelta:function(){return!this._delta&&this.tool._lastPoint?this.tool._point.subtract(this.tool._lastPoint):this._delta},setDelta:function(t){this._delta=t},getCount:function(){return/^mouse(down|up)$/.test(this.type)?this.tool._downCount:this.tool._count},setCount:function(t){this.tool[/^mouse(down|up)$/.test(this.type)?"downCount":"count"]=t},getItem:function(){if(!this._item){var t=this.tool._scope.project.hitTest(this.getPoint());if(t){for(var e=t.item,n=e._parent;/^(Group|CompoundPath)$/.test(n._class);)e=n,n=n._parent;this._item=e}}return this._item},setItem:function(t){this._item=t},toString:function(){return"{ type: "+this.type+", point: "+this.getPoint()+", count: "+this.getCount()+", modifiers: "+this.getModifiers()+" }"}}),X=r.extend({_class:"Tool",_list:"tools",_reference:"tool",_events:["onActivate","onDeactivate","onEditOptions","onMouseDown","onMouseUp","onMouseDrag","onMouseMove","onKeyDown","onKeyUp"],initialize:function(t){r.call(this),this._firstMove=!0,this._count=0,this._downCount=0,this._set(t)},getMinDistance:function(){return this._minDistance},setMinDistance:function(t){this._minDistance=t,null!=t&&null!=this._maxDistance&&t>this._maxDistance&&(this._maxDistance=t)},getMaxDistance:function(){return this._maxDistance},setMaxDistance:function(t){this._maxDistance=t,null!=this._minDistance&&null!=t&&t<this._minDistance&&(this._minDistance=t)},getFixedDistance:function(){return this._minDistance==this._maxDistance?this._minDistance:null},setFixedDistance:function(t){this._minDistance=this._maxDistance=t},_updateEvent:function(t,e,n,i,r,s,a){if(!r){if(null!=n||null!=i){var o=null!=n?n:0,h=e.subtract(this._point),u=h.getLength();if(o>u)return!1;if(null!=i&&0!=i)if(u>i)e=this._point.add(h.normalize(i));else if(a)return!1}if(s&&e.equals(this._point))return!1}switch(this._lastPoint=r&&"mousemove"==t?e:this._point,this._point=e,t){case"mousedown":this._lastPoint=this._downPoint,this._downPoint=this._point,this._downCount++;break;case"mouseup":this._lastPoint=this._downPoint}return this._count=r?0:this._count+1,!0},_fireEvent:function(t,e){var n=paper.project._removeSets;if(n){"mouseup"===t&&(n.mousedrag=null);var i=n[t];if(i){for(var r in i){var s=i[r];for(var a in n){var o=n[a];o&&o!=i&&delete o[s._id]}s.remove()}n[t]=null}}return this.responds(t)&&this.emit(t,new $(this,t,e))},_handleEvent:function(t,e,n){paper=this._scope;var i=!1;switch(t){case"mousedown":this._updateEvent(t,e,null,null,!0,!1,!1),i=this._fireEvent(t,n);break;case"mousedrag":for(var r=!1,s=!1;this._updateEvent(t,e,this.minDistance,this.maxDistance,!1,r,s);)i=this._fireEvent(t,n)||i,r=!0,s=!0;break;case"mouseup":!e.equals(this._point)&&this._updateEvent("mousedrag",e,this.minDistance,this.maxDistance,!1,!1,!1)&&(i=this._fireEvent("mousedrag",n)),this._updateEvent(t,e,null,this.maxDistance,!1,!1,!1),i=this._fireEvent(t,n)||i,this._updateEvent(t,e,null,null,!0,!1,!1),this._firstMove=!0;break;case"mousemove":for(;this._updateEvent(t,e,this.minDistance,this.maxDistance,this._firstMove,!0,!1);)i=this._fireEvent(t,n)||i,this._firstMove=!1}return i&&n.preventDefault(),i}}),J={request:function(e,n,i,r){r=r===t?!0:r;var s=new(window.ActiveXObject||XMLHttpRequest)("Microsoft.XMLHTTP");return s.open(e.toUpperCase(),n,r),"overrideMimeType"in s&&s.overrideMimeType("text/plain"),s.onreadystatechange=function(){if(4===s.readyState){var t=s.status;if(0!==t&&200!==t)throw Error("Could not load "+n+" (Error "+t+")");i.call(s,s.responseText)}},s.send(null)}},Y={canvases:[],getCanvas:function(t,e){var n,i=!0;"object"==typeof t&&(e=t.height,t=t.width),n=this.canvases.length?this.canvases.pop():document.createElement("canvas");var r=n.getContext("2d");return n.width===t&&n.height===e?i&&r.clearRect(0,0,t+1,e+1):(n.width=t,n.height=e),r.save(),n},getContext:function(t,e){return this.getCanvas(t,e).getContext("2d")},release:function(t){var e=t.canvas?t.canvas:t;e.getContext("2d").restore(),this.canvases.push(e)}},K=new function(){function t(t,e,n){return.2989*t+.587*e+.114*n}function n(e,n,i,r){var s=r-t(e,n,i);f=e+s,g=n+s,_=i+s;var r=t(f,g,_),a=v(f,g,_),o=p(f,g,_);if(0>a){var h=r-a;f=r+(f-r)*r/h,g=r+(g-r)*r/h,_=r+(_-r)*r/h}if(o>255){var u=255-r,l=o-r;f=r+(f-r)*u/l,g=r+(g-r)*u/l,_=r+(_-r)*u/l}}function i(t,e,n){return p(t,e,n)-v(t,e,n)}function r(t,e,n,i){var r,s=[t,e,n],a=p(t,e,n),o=v(t,e,n);o=o===t?0:o===e?1:2,a=a===t?0:a===e?1:2,r=0===v(o,a)?1===p(o,a)?2:1:0,s[a]>s[o]?(s[r]=(s[r]-s[o])*i/(s[a]-s[o]),s[a]=i):s[r]=s[a]=0,s[o]=0,f=s[0],g=s[1],_=s[2]}var s,a,o,h,u,l,c,d,f,g,_,v=Math.min,p=Math.max,m=Math.abs,y={multiply:function(){f=u*s/255,g=l*a/255,_=c*o/255},screen:function(){f=u+s-u*s/255,g=l+a-l*a/255,_=c+o-c*o/255},overlay:function(){f=128>u?2*u*s/255:255-2*(255-u)*(255-s)/255,g=128>l?2*l*a/255:255-2*(255-l)*(255-a)/255,_=128>c?2*c*o/255:255-2*(255-c)*(255-o)/255},"soft-light":function(){var t=s*u/255;f=t+u*(255-(255-u)*(255-s)/255-t)/255,t=a*l/255,g=t+l*(255-(255-l)*(255-a)/255-t)/255,t=o*c/255,_=t+c*(255-(255-c)*(255-o)/255-t)/255},"hard-light":function(){f=128>s?2*s*u/255:255-2*(255-s)*(255-u)/255,g=128>a?2*a*l/255:255-2*(255-a)*(255-l)/255,_=128>o?2*o*c/255:255-2*(255-o)*(255-c)/255},"color-dodge":function(){f=0===u?0:255===s?255:v(255,255*u/(255-s)),g=0===l?0:255===a?255:v(255,255*l/(255-a)),_=0===c?0:255===o?255:v(255,255*c/(255-o))},"color-burn":function(){f=255===u?255:0===s?0:p(0,255-255*(255-u)/s),g=255===l?255:0===a?0:p(0,255-255*(255-l)/a),_=255===c?255:0===o?0:p(0,255-255*(255-c)/o)},darken:function(){f=s>u?u:s,g=a>l?l:a,_=o>c?c:o},lighten:function(){f=u>s?u:s,g=l>a?l:a,_=c>o?c:o},difference:function(){f=u-s,0>f&&(f=-f),g=l-a,0>g&&(g=-g),_=c-o,0>_&&(_=-_)},exclusion:function(){f=u+s*(255-u-u)/255,g=l+a*(255-l-l)/255,_=c+o*(255-c-c)/255},hue:function(){r(s,a,o,i(u,l,c)),n(f,g,_,t(u,l,c))},saturation:function(){r(u,l,c,i(s,a,o)),n(f,g,_,t(u,l,c))},luminosity:function(){n(u,l,c,t(s,a,o))},color:function(){n(s,a,o,t(u,l,c))},add:function(){f=v(u+s,255),g=v(l+a,255),_=v(c+o,255)},subtract:function(){f=p(u-s,0),g=p(l-a,0),_=p(c-o,0)},average:function(){f=(u+s)/2,g=(l+a)/2,_=(c+o)/2},negation:function(){f=255-m(255-s-u),g=255-m(255-a-l),_=255-m(255-o-c)}},w=this.nativeModes=e.each(["source-over","source-in","source-out","source-atop","destination-over","destination-in","destination-out","destination-atop","lighter","darker","copy","xor"],function(t){this[t]=!0},{}),x=Y.getContext(1,1);e.each(y,function(t,e){var n="darken"===e,i=!1;x.save();try{x.fillStyle=n?"#300":"#a00",x.fillRect(0,0,1,1),x.globalCompositeOperation=e,x.globalCompositeOperation===e&&(x.fillStyle=n?"#a00":"#300",x.fillRect(0,0,1,1),i=x.getImageData(0,0,1,1).data[0]!==n?170:51)}catch(r){}x.restore(),w[e]=i}),Y.release(x),this.process=function(t,e,n,i,r){var v=e.canvas,p="normal"===t;if(p||w[t])n.save(),n.setTransform(1,0,0,1,0,0),n.globalAlpha=i,p||(n.globalCompositeOperation=t),n.drawImage(v,r.x,r.y),n.restore();else{var m=y[t];if(!m)return;for(var x=n.getImageData(r.x,r.y,v.width,v.height),b=x.data,C=e.getImageData(0,0,v.width,v.height).data,S=0,P=b.length;P>S;S+=4){s=C[S],u=b[S],a=C[S+1],l=b[S+1],o=C[S+2],c=b[S+2],h=C[S+3],d=b[S+3],m();var k=h*i/255,I=1-k;b[S]=k*f+I*u,b[S+1]=k*g+I*l,b[S+2]=k*_+I*c,b[S+3]=h*i+I*d}n.putImageData(x,r.x,r.y)}}},Q=e.each({fillColor:["fill","color"],strokeColor:["stroke","color"],strokeWidth:["stroke-width","number"],strokeCap:["stroke-linecap","string"],strokeJoin:["stroke-linejoin","string"],strokeScaling:["vector-effect","lookup",{"true":"none","false":"non-scaling-stroke"},function(t,e){return!e&&(t instanceof z||t instanceof x||t instanceof L)}],miterLimit:["stroke-miterlimit","number"],dashArray:["stroke-dasharray","array"],dashOffset:["stroke-dashoffset","number"],fontFamily:["font-family","string"],fontWeight:["font-weight","string"],fontSize:["font-size","number"],justification:["text-anchor","lookup",{left:"start",center:"middle",right:"end"}],opacity:["opacity","number"],blendMode:["mix-blend-mode","string"]},function(t,n){var i=e.capitalize(n),r=t[2];this[n]={type:t[1],property:n,attribute:t[0],toSVG:r,fromSVG:r&&e.each(r,function(t,e){this[t]=e},{}),exportFilter:t[3],get:"get"+i,set:"set"+i}},{}),tt={href:"http://www.w3.org/1999/xlink",xlink:"http://www.w3.org/2000/xmlns"};return new function(){function t(t,e){for(var n in e){var i=e[n],r=tt[n];"number"==typeof i&&(i=b.number(i)),r?t.setAttributeNS(r,n,i):t.setAttribute(n,i)}return t}function n(e,n){return t(document.createElementNS("http://www.w3.org/2000/svg",e),n)}function i(t,n,i){var r=new e,s=t.getTranslation();if(n){t=t.shiftless();var o=t._inverseTransform(s);r[i?"cx":"x"]=o.x,r[i?"cy":"y"]=o.y,s=null}if(!t.isIdentity()){var h=t.decompose();if(h&&!h.shearing){var u=[],l=h.rotation,c=h.scaling;s&&!s.isZero()&&u.push("translate("+b.point(s)+")"),a.isZero(c.x-1)&&a.isZero(c.y-1)||u.push("scale("+b.point(c)+")"),l&&u.push("rotate("+b.number(l)+")"),r.transform=u.join(" ")}else r.transform="matrix("+t.getValues().join(",")+")"}return r}function r(e,r){for(var s=i(e._matrix),a=e._children,o=n("g",s),h=0,u=a.length;u>h;h++){var l=a[h],c=w(l,r);if(c)if(l.isClipMask()){var d=n("clipPath");d.appendChild(c),p(l,d,"clip"),t(o,{"clip-path":"url(#"+d.id+")"})}else o.appendChild(c)}return o}function o(t,e){var r=i(t._matrix,!0),s=t.getSize(),a=t.getImage();return r.x-=s.width/2,r.y-=s.height/2,r.width=s.width,r.height=s.height,r.href=e.embedImages===!1&&a&&a.src||t.toDataURL(),n("image",r)}function h(t,e){var r=e.matchShapes;if(r){var s=t.toShape(!1);if(s)return u(s,e)}var a,o=t._segments,h=i(t._matrix);if(0===o.length)return null;if(r&&!t.hasHandles())if(o.length>=3){a=t._closed?"polygon":"polyline";for(var l=[],c=0,d=o.length;d>c;c++)l.push(b.point(o[c]._point));h.points=l.join(" ")}else{a="line";var f=o[0]._point,g=o[o.length-1]._point;h.set({x1:f.x,y1:f.y,x2:g.x,y2:g.y})}else a="path",h.d=t.getPathData(null,e.precision);return n(a,h)}function u(t){var e=t._type,r=t._radius,s=i(t._matrix,!0,"rectangle"!==e);if("rectangle"===e){e="rect";var a=t._size,o=a.width,h=a.height;s.x-=o/2,s.y-=h/2,s.width=o,s.height=h,r.isZero()&&(r=null)}return r&&("circle"===e?s.r=r:(s.rx=r.width,s.ry=r.height)),n(e,s)}function l(t,e){var r=i(t._matrix),s=t.getPathData(null,e.precision);return s&&(r.d=s),n("path",r)}function c(t,e){var r=i(t._matrix,!0),s=t.getSymbol(),a=_(s,"symbol"),o=s.getDefinition(),h=o.getBounds();return a||(a=n("symbol",{viewBox:b.rectangle(h)}),a.appendChild(w(o,e)),p(s,a,"symbol")),r.href="#"+a.id,r.x+=h.x,r.y+=h.y,r.width=b.number(h.width),r.height=b.number(h.height),r.overflow="visible",n("use",r)}function d(t){var e=_(t,"color");if(!e){var i,r=t.getGradient(),s=r._radial,a=t.getOrigin().transform(),o=t.getDestination().transform();if(s){i={cx:a.x,cy:a.y,r:a.getDistance(o)};var h=t.getHighlight();h&&(h=h.transform(),i.fx=h.x,i.fy=h.y)}else i={x1:a.x,y1:a.y,x2:o.x,y2:o.y};i.gradientUnits="userSpaceOnUse",e=n((s?"radial":"linear")+"Gradient",i);for(var u=r._stops,l=0,c=u.length;c>l;l++){var d=u[l],f=d._color,g=f.getAlpha();i={offset:d._rampPoint,"stop-color":f.toCSS(!0)},1>g&&(i["stop-opacity"]=g),e.appendChild(n("stop",i))}p(t,e,"color")}return"url(#"+e.id+")"}function f(t){var e=n("text",i(t._matrix,!0));return e.textContent=t._content,e}function g(n,i,r){var s={},a=!r&&n.getParent();return null!=n._name&&(s.id=n._name),e.each(Q,function(t){var i=t.get,r=t.type,o=n[i]();if(t.exportFilter?t.exportFilter(n,o):!a||!e.equals(a[i](),o)){if("color"===r&&null!=o){var h=o.getAlpha();1>h&&(s[t.attribute+"-opacity"]=h)}s[t.attribute]=null==o?"none":"number"===r?b.number(o):"color"===r?o.gradient?d(o,n):o.toCSS(!0):"array"===r?o.join(","):"lookup"===r?t.toSVG[o]:o}}),1===s.opacity&&delete s.opacity,n._visible||(s.visibility="hidden"),t(i,s)}function _(t,e){return C||(C={ids:{},svgs:{}}),t&&C.svgs[e+"-"+t._id]}function p(t,e,n){C||_();var i=C.ids[n]=(C.ids[n]||0)+1;e.id=n+"-"+i,C.svgs[n+"-"+t._id]=e}function y(t,e){var i=t,r=null;if(C){i="svg"===t.nodeName.toLowerCase()&&t;for(var s in C.svgs)r||(i||(i=n("svg"),i.appendChild(t)),r=i.insertBefore(n("defs"),i.firstChild)),r.appendChild(C.svgs[s]);C=null}return e.asString?(new XMLSerializer).serializeToString(i):i}function w(t,e,n){var i=S[t._class],r=i&&i(t,e);if(r){var s=e.onExport;s&&(r=s(t,r,e)||r);var a=JSON.stringify(t._data);a&&"{}"!==a&&"null"!==a&&r.setAttribute("data-paper-data",a)}return r&&g(t,r,n)}function x(t){return t||(t={}),b=new s(t.precision),t}var b,C,S={Group:r,Layer:r,Raster:o,Path:h,Shape:u,CompoundPath:l,PlacedSymbol:c,PointText:f};m.inject({exportSVG:function(t){return t=x(t),y(w(this,t,!0),t)}}),v.inject({exportSVG:function(t){t=x(t);var e=this.layers,r=this.getView(),s=r.getViewSize(),a=n("svg",{x:0,y:0,width:s.width,height:s.height,version:"1.1",xmlns:"http://www.w3.org/2000/svg","xmlns:xlink":"http://www.w3.org/1999/xlink"}),o=a,h=r._matrix;h.isIdentity()||(o=a.appendChild(n("g",i(h))));for(var u=0,l=e.length;l>u;u++)o.appendChild(w(e[u],t,!0));return y(a,t)}})},new function(){function n(t,e,n,i){var r=tt[e],s=r?t.getAttributeNS(r,e):t.getAttribute(e);return"null"===s&&(s=null),null==s?i?null:n?"":0:n?s:parseFloat(s)}function i(t,e,i,r){return e=n(t,e,!1,r),i=n(t,i,!1,r),!r||null!=e&&null!=i?new h(e,i):null}function r(t,e,i,r){return e=n(t,e,!1,r),i=n(t,i,!1,r),!r||null!=e&&null!=i?new l(e,i):null}function s(t,e,n){return"none"===t?null:"number"===e?parseFloat(t):"array"===e?t?t.split(/[\s,]+/g).map(parseFloat):[]:"color"===e?S(t)||t:"lookup"===e?n[t]:t}function a(t,e,n,i){var r=t.childNodes,s="clippath"===e,a=new y,o=a._project,h=o._currentStyle,u=[];if(s||(a=C(a,t,i),o._currentStyle=a._style.clone()),i)for(var l=t.querySelectorAll("defs"),c=0,d=l.length;d>c;c++)P(l[c],n,!1);for(var c=0,d=r.length;d>c;c++){var f,g=r[c];1!==g.nodeType||"defs"===g.nodeName.toLowerCase()||!(f=P(g,n,!1))||f instanceof p||u.push(f)}return a.addChildren(u),s&&(a=C(a.reduce(),t,i)),o._currentStyle=h,(s||"defs"===e)&&(a.remove(),a=null),a}function o(t,e){for(var n=t.getAttribute("points").match(/[+-]?(?:\d*\.\d+|\d+\.?)(?:[eE][+-]?\d+)?/g),i=[],r=0,s=n.length;s>r;r+=2)i.push(new h(parseFloat(n[r]),parseFloat(n[r+1])));var a=new A(i);return"polygon"===e&&a.closePath(),a}function u(t){var e=t.getAttribute("d"),n={pathData:e};return(e.match(/m/gi)||[]).length>1||/z\S+/i.test(e)?new O(n):new A(n)}function c(t,e){var r,s=(n(t,"href",!0)||"").substring(1),a="radialgradient"===e;if(s)r=M[s].getGradient();else{for(var o=t.childNodes,h=[],u=0,l=o.length;l>u;u++){var c=o[u];1===c.nodeType&&h.push(C(new R,c))}r=new B(h,a)}var d,f,g;return a?(d=i(t,"cx","cy"),f=d.add(n(t,"r"),0),g=i(t,"fx","fy",!0)):(d=i(t,"x1","y1"),f=i(t,"x2","y2")),C(new j(r,d,f,g),t),null}function f(t,e,n,i){for(var r=(i.getAttribute(n)||"").split(/\)\s*/g),s=new g,a=0,o=r.length;o>a;a++){var h=r[a];if(!h)break;for(var u=h.split(/\(\s*/),l=u[0],c=u[1].split(/[\s,]+/g),d=0,f=c.length;f>d;d++)c[d]=parseFloat(c[d]);switch(l){case"matrix":s.concatenate(new g(c[0],c[1],c[2],c[3],c[4],c[5]));break;case"rotate":s.rotate(c[0],c[1],c[2]);break;case"translate":s.translate(c[0],c[1]);break;case"scale":s.scale(c);break;case"skewX":s.skew(c[0],0);break;case"skewY":s.skew(0,c[0])}}t.transform(s)}function _(t,e,n){var i=t["fill-opacity"===n?"getFillColor":"getStrokeColor"]();i&&i.setAlpha(parseFloat(e))}function w(n,i,r){var s=n.attributes[i],a=s&&s.value;if(!a){var o=e.camelize(i);a=n.style[o],a||r.node[o]===r.parent[o]||(a=r.node[o])}return a?"none"===a?null:a:t}function C(n,i,r){var s={node:F.getStyles(i)||{},parent:!r&&F.getStyles(i.parentNode)||{}};return e.each(I,function(r,a){var o=w(i,a,s);o!==t&&(n=e.pick(r(n,o,a,i,s),n))}),n}function S(t){var e=t&&t.match(/\((?:#|)([^)']+)/);return e&&M[e[1]]}function P(t,n,i){function r(t){paper=a;var e=P(t,n,i),r=n.onLoad,s=a.project&&a.getView();r&&r.call(this,e),s.update()}if(!t)return null;n?"function"==typeof n&&(n={onLoad:n}):n={};var s=t,a=paper;if(i)if("string"!=typeof t||/^.*</.test(t)){if("undefined"!=typeof File&&t instanceof File){var o=new FileReader;return o.onload=function(){r(o.result)},o.readAsText(t)}}else{if(s=document.getElementById(t),!s)return J.request("get",t,r);t=null}if("string"==typeof t&&(s=(new DOMParser).parseFromString(t,"image/svg+xml")),!s.nodeName)throw Error("Unsupported SVG source: "+t);var h,u=s.nodeName.toLowerCase(),l=k[u],c=s.getAttribute&&s.getAttribute("data-paper-data"),d=a.settings,f=d.applyMatrix;if(d.applyMatrix=!1,h=l&&l(s,u,n,i)||null,d.applyMatrix=f,h){"#document"===u||h instanceof y||(h=C(h,s,i));var g=n.onImport;g&&(h=g(s,h,n)||h),n.expandShapes&&h instanceof x&&(h.remove(),h=h.toPath()),c&&(h._data=JSON.parse(c))}return i&&(M={},h&&e.pick(n.applyMatrix,f)&&h.matrix.apply(!0,!0)),h}var k={"#document":function(t,e,n,i){for(var r=t.childNodes,s=0,a=r.length;a>s;s++){var o=r[s];if(1===o.nodeType){var h=o.nextSibling;document.body.appendChild(o);var u=P(o,n,i);return h?t.insertBefore(o,h):t.appendChild(o),u}}},g:a,svg:a,clippath:a,polygon:o,polyline:o,path:u,lineargradient:c,radialgradient:c,image:function(t){var e=new b(n(t,"href",!0));return e.on("load",function(){var e=r(t,"width","height");this.setSize(e);var n=this._matrix._transformPoint(i(t,"x","y").add(e.divide(2)));this.translate(n)}),e},symbol:function(t,e,n,i){return new p(a(t,e,n,i),!0)},defs:a,use:function(t){var e=(n(t,"href",!0)||"").substring(1),r=M[e],s=i(t,"x","y");return r?r instanceof p?r.place(s):r.clone().translate(s):null},circle:function(t){return new x.Circle(i(t,"cx","cy"),n(t,"r"))},ellipse:function(t){return new x.Ellipse({center:i(t,"cx","cy"),radius:r(t,"rx","ry")})},rect:function(t){var e=i(t,"x","y"),n=r(t,"width","height"),s=r(t,"rx","ry");return new x.Rectangle(new d(e,n),s)},line:function(t){return new A.Line(i(t,"x1","y1"),i(t,"x2","y2"))},text:function(t){var e=new N(i(t,"x","y").add(i(t,"dx","dy")));return e.setContent(t.textContent.trim()||""),e}},I=e.set(e.each(Q,function(t){this[t.attribute]=function(e,n){if(e[t.set](s(n,t.type,t.fromSVG)),"color"===t.type&&e instanceof x){var i=e[t.get]();i&&i.transform((new g).translate(e.getPosition(!0).negate()))}}},{}),{id:function(t,e){M[e]=t,t.setName&&t.setName(e)},"clip-path":function(t,e){var n=S(e);if(n){if(n=n.clone(),n.setClipMask(!0),!(t instanceof y))return new y(n,t);t.insertChild(0,n)}},gradientTransform:f,transform:f,"fill-opacity":_,"stroke-opacity":_,visibility:function(t,e){t.setVisible("visible"===e)},display:function(t,e){t.setVisible(null!==e)},"stop-color":function(t,e){t.setColor&&t.setColor(e)},"stop-opacity":function(t,e){t._color&&t._color.setAlpha(parseFloat(e))},offset:function(t,e){var n=e.match(/(.*)%$/);t.setRampPoint(n?n[1]/100:parseFloat(e))},viewBox:function(t,e,n,i,a){var o=new d(s(e,"array")),h=r(i,"width","height",!0);if(t instanceof y){var u=h?o.getSize().divide(h):1,l=(new g).translate(o.getPoint()).scale(u);t.transform(l.inverted())}else if(t instanceof p){h&&o.setSize(h);var c="visible"!=w(i,"overflow",a),f=t._definition;c&&!o.contains(f.getBounds())&&(c=new x.Rectangle(o).transform(f._matrix),c.setClipMask(!0),f.addChild(c))}}}),M={};m.inject({importSVG:function(t,e){return this.addChild(P(t,e,!0))}}),v.inject({importSVG:function(t,e){return this.activate(),P(t,e,!0)}})},e.exports.PaperScript=function(){function t(t,e,n){var i=_[e];if(t&&t[i]){var r=t[i](n);return"!="===e?!r:r}switch(e){case"+":return t+n;case"-":return t-n;case"*":return t*n;case"/":return t/n;case"%":return t%n;case"==":return t==n;case"!=":return t!=n}}function n(t,e){var n=v[t];if(n&&e&&e[n])return e[n]();switch(t){case"+":return+e;case"-":return-e}}function r(t,e){return g.acorn.parse(t,e)}function s(t,e,n){function i(t){for(var e=0,n=u.length;n>e;e++){var i=u[e];if(i[0]>=t)break;t+=i[1]}return t}function s(e){return t.substring(i(e.range[0]),i(e.range[1]))}function a(e,n){return t.substring(i(e.range[1]),i(n.range[0]))}function o(e,n){for(var r=i(e.range[0]),s=i(e.range[1]),a=0,o=u.length-1;o>=0;o--)if(r>u[o][0]){a=o+1;break}u.splice(a,0,[r,n.length-s+r]),t=t.substring(0,r)+n+t.substring(s)}function h(t,e){if(t){for(var n in t)if("range"!==n&&"loc"!==n){var i=t[n];if(Array.isArray(i))for(var r=0,u=i.length;u>r;r++)h(i[r],t);else i&&"object"==typeof i&&h(i,t)}switch(t.type){case"UnaryExpression":if(t.operator in v&&"Literal"!==t.argument.type){var l=s(t.argument);o(t,'$__("'+t.operator+'", '+l+")")}break;case"BinaryExpression":if(t.operator in _&&"Literal"!==t.left.type){var c=s(t.left),d=s(t.right),f=a(t.left,t.right),g=t.operator;o(t,"__$__("+c+","+f.replace(RegExp("\\"+g),'"'+g+'"')+", "+d+")")}break;case"UpdateExpression":case"AssignmentExpression":var p=e&&e.type;if(!("ForStatement"===p||"BinaryExpression"===p&&/^[=!<>]/.test(e.operator)||"MemberExpression"===p&&e.computed))if("UpdateExpression"===t.type){var l=s(t.argument),m="__$__("+l+', "'+t.operator[0]+'", 1)',y=l+" = "+m;t.prefix||"AssignmentExpression"!==p&&"VariableDeclarator"!==p||(s(e.left||e.id)===l&&(y=m),y=l+"; "+y),o(t,y)}else if(/^.=$/.test(t.operator)&&"Literal"!==t.left.type){var c=s(t.left),d=s(t.right);o(t,c+" = __$__("+c+', "'+t.operator[0]+'", '+d+")")}}}}if(!t)return"";n=n||{},e=e||"";var u=[],l=null,c=paper.browser,d=c.versionNumber,f=/\r\n|\n|\r/gm;if(c.chrome&&d>=30||c.webkit&&d>=537.76||c.firefox&&d>=23){var g=0;if(0===window.location.href.indexOf(e)){var p=document.getElementsByTagName("html")[0].innerHTML;g=p.substr(0,p.indexOf(t)+1).match(f).length+1}var m=["AAAA"];m.length=(t.match(f)||[]).length+1+g,l={version:3,file:e,names:[],mappings:m.join(";AACA"),sourceRoot:"",sources:[e]};var y=n.source||!e&&t;y&&(l.sourcesContent=[y])}return h(r(t,{ranges:!0})),l&&(t=Array(g+1).join("\n")+t+"\n//# sourceMappingURL=data:application/json;base64,"+btoa(unescape(encodeURIComponent(JSON.stringify(l))))+"\n//# sourceURL="+(e||"paperscript")),t}function a(i,r,a,o){function u(t,e){for(var n in t)!e&&/^_/.test(n)||!RegExp("([\\b\\s\\W]|^)"+n.replace(/\$/g,"\\$")+"\\b").test(i)||(_.push(n),v.push(t[n]))}paper=r;var l,c=r.getView(),d=/\s+on(?:Key|Mouse)(?:Up|Down|Move|Drag)\b/.test(i)?new X:null,f=d?d._events:[],g=["onFrame","onResize"].concat(f),_=[],v=[];i=s(i,a,o),u({__$__:t,$__:n,paper:r,view:c,tool:d},!0),u(r),g=e.each(g,function(t){RegExp("\\s+"+t+"\\b").test(i)&&(_.push(t),this.push(t+": "+t))},[]).join(", "),g&&(i+="\nreturn { "+g+" };");var p=paper.browser;if(p.chrome||p.firefox){var m=document.createElement("script"),y=document.head||document.getElementsByTagName("head")[0];p.firefox&&(i="\n"+i),m.appendChild(document.createTextNode("paper._execute = function("+_+") {"+i+"\n}")),y.appendChild(m),l=paper._execute,delete paper._execute,y.removeChild(m)}else l=Function(_,i);var w=l.apply(r,v)||{};e.each(f,function(t){var e=w[t];e&&(d[t]=e)}),c&&(w.onResize&&c.setOnResize(w.onResize),c.emit("resize",{size:c.size,delta:new h}),w.onFrame&&c.setOnFrame(w.onFrame),c.update())}function o(t){if(/^text\/(?:x-|)paperscript$/.test(t.type)&&"true"!==i.getAttribute(t,"ignore")){var e=i.getAttribute(t,"canvas"),n=document.getElementById(e),r=t.src||t.getAttribute("data-src"),s=i.hasAttribute(t,"async"),o="data-paper-scope";if(!n)throw Error('Unable to find canvas with id "'+e+'"');var h=i.get(n.getAttribute(o))||(new i).setup(n);return n.setAttribute(o,h._id),r?J.request("get",r,function(t){a(t,h,r)},s):a(t.innerHTML,h,t.baseURI),t.setAttribute("data-paper-ignore","true"),h}}function u(){e.each(document.getElementsByTagName("script"),o)}function c(t){return t?o(t):u()}var d,f,g=this;!function(t,e){return"object"==typeof d&&"object"==typeof module?e(d):"function"==typeof f&&f.amd?f(["exports"],e):void e(t.acorn||(t.acorn={}))}(this,function(t){"use strict";function e(t){ct=t||{};for(var e in _t)Object.prototype.hasOwnProperty.call(ct,e)||(ct[e]=_t[e]);gt=ct.sourceFile||null}function n(t,e){var n=vt(dt,t);e+=" ("+n.line+":"+n.column+")";var i=new SyntaxError(e);throw i.pos=t,i.loc=n,i.raisedAt=pt,i}function i(t){function e(t){if(1==t.length)return n+="return str === "+JSON.stringify(t[0])+";";n+="switch(str){";for(var e=0;e<t.length;++e)n+="case "+JSON.stringify(t[e])+":";n+="return true}return false;"}t=t.split(" ");var n="",i=[];t:for(var r=0;r<t.length;++r){for(var s=0;s<i.length;++s)if(i[s][0].length==t[r].length){i[s].push(t[r]);continue t}i.push([t[r]])}if(i.length>3){i.sort(function(t,e){return e.length-t.length}),n+="switch(str.length){";for(var r=0;r<i.length;++r){var a=i[r];n+="case "+a[0].length+":",
-e(a)}n+="}"}else e(t);return Function("str",n)}function r(){this.line=Pt,this.column=pt-kt}function s(){Pt=1,pt=kt=0,St=!0,u()}function a(t,e){yt=pt,ct.locations&&(xt=new r),bt=t,u(),Ct=e,St=t.beforeExpr}function o(){var t=ct.onComment&&ct.locations&&new r,e=pt,i=dt.indexOf("*/",pt+=2);if(-1===i&&n(pt-2,"Unterminated comment"),pt=i+2,ct.locations){Je.lastIndex=e;for(var s;(s=Je.exec(dt))&&s.index<pt;)++Pt,kt=s.index+s[0].length}ct.onComment&&ct.onComment(!0,dt.slice(e+2,i),e,pt,t,ct.locations&&new r)}function h(){for(var t=pt,e=ct.onComment&&ct.locations&&new r,n=dt.charCodeAt(pt+=2);ft>pt&&10!==n&&13!==n&&8232!==n&&8233!==n;)++pt,n=dt.charCodeAt(pt);ct.onComment&&ct.onComment(!1,dt.slice(t+2,pt),t,pt,e,ct.locations&&new r)}function u(){for(;ft>pt;){var t=dt.charCodeAt(pt);if(32===t)++pt;else if(13===t){++pt;var e=dt.charCodeAt(pt);10===e&&++pt,ct.locations&&(++Pt,kt=pt)}else if(10===t||8232===t||8233===t)++pt,ct.locations&&(++Pt,kt=pt);else if(t>8&&14>t)++pt;else if(47===t){var e=dt.charCodeAt(pt+1);if(42===e)o();else{if(47!==e)break;h()}}else if(160===t)++pt;else{if(!(t>=5760&&Ze.test(String.fromCharCode(t))))break;++pt}}}function l(){var t=dt.charCodeAt(pt+1);return t>=48&&57>=t?S(!0):(++pt,a(we))}function c(){var t=dt.charCodeAt(pt+1);return St?(++pt,x()):61===t?w(Se,2):w(be,1)}function d(){var t=dt.charCodeAt(pt+1);return 61===t?w(Se,2):w(je,1)}function f(t){var e=dt.charCodeAt(pt+1);return e===t?w(124===t?Me:ze,2):61===e?w(Se,2):w(124===t?Ae:Te,1)}function g(){var t=dt.charCodeAt(pt+1);return 61===t?w(Se,2):w(Oe,1)}function _(t){var e=dt.charCodeAt(pt+1);return e===t?45==e&&62==dt.charCodeAt(pt+2)&&Xe.test(dt.slice(Mt,pt))?(pt+=3,h(),u(),y()):w(ke,2):61===e?w(Se,2):w(Pe,1)}function v(t){var e=dt.charCodeAt(pt+1),n=1;return e===t?(n=62===t&&62===dt.charCodeAt(pt+2)?3:2,61===dt.charCodeAt(pt+n)?w(Se,n+1):w(Ne,n)):33==e&&60==t&&45==dt.charCodeAt(pt+2)&&45==dt.charCodeAt(pt+3)?(pt+=4,h(),u(),y()):(61===e&&(n=61===dt.charCodeAt(pt+2)?3:2),w(Le,n))}function p(t){var e=dt.charCodeAt(pt+1);return 61===e?w(Ee,61===dt.charCodeAt(pt+2)?3:2):w(61===t?Ce:Ie,1)}function m(t){switch(t){case 46:return l();case 40:return++pt,a(_e);case 41:return++pt,a(ve);case 59:return++pt,a(me);case 44:return++pt,a(pe);case 91:return++pt,a(ce);case 93:return++pt,a(de);case 123:return++pt,a(fe);case 125:return++pt,a(ge);case 58:return++pt,a(ye);case 63:return++pt,a(xe);case 48:var e=dt.charCodeAt(pt+1);if(120===e||88===e)return C();case 49:case 50:case 51:case 52:case 53:case 54:case 55:case 56:case 57:return S(!1);case 34:case 39:return P(t);case 47:return c(t);case 37:case 42:return d();case 124:case 38:return f(t);case 94:return g();case 43:case 45:return _(t);case 60:case 62:return v(t);case 61:case 33:return p(t);case 126:return w(Ie,1)}return!1}function y(t){if(t?pt=mt+1:mt=pt,ct.locations&&(wt=new r),t)return x();if(pt>=ft)return a(Rt);var e=dt.charCodeAt(pt);if(Ye(e)||92===e)return M();var i=m(e);if(i===!1){var s=String.fromCharCode(e);if("\\"===s||Ge.test(s))return M();n(pt,"Unexpected character '"+s+"'")}return i}function w(t,e){var n=dt.slice(pt,pt+e);pt+=e,a(t,n)}function x(){for(var t,e,i="",r=pt;;){pt>=ft&&n(r,"Unterminated regular expression");var s=dt.charAt(pt);if(Xe.test(s)&&n(r,"Unterminated regular expression"),t)t=!1;else{if("["===s)e=!0;else if("]"===s&&e)e=!1;else if("/"===s&&!e)break;t="\\"===s}++pt}var i=dt.slice(r,pt);++pt;var o=I();return o&&!/^[gmsiy]*$/.test(o)&&n(r,"Invalid regexp flag"),a(Nt,RegExp(i,o))}function b(t,e){for(var n=pt,i=0,r=0,s=null==e?1/0:e;s>r;++r){var a,o=dt.charCodeAt(pt);if(a=o>=97?o-97+10:o>=65?o-65+10:o>=48&&57>=o?o-48:1/0,a>=t)break;++pt,i=i*t+a}return pt===n||null!=e&&pt-n!==e?null:i}function C(){pt+=2;var t=b(16);return null==t&&n(mt+2,"Expected hexadecimal number"),Ye(dt.charCodeAt(pt))&&n(pt,"Identifier directly after number"),a(Lt,t)}function S(t){var e=pt,i=!1,r=48===dt.charCodeAt(pt);t||null!==b(10)||n(e,"Invalid number"),46===dt.charCodeAt(pt)&&(++pt,b(10),i=!0);var s=dt.charCodeAt(pt);(69===s||101===s)&&(s=dt.charCodeAt(++pt),(43===s||45===s)&&++pt,null===b(10)&&n(e,"Invalid number"),i=!0),Ye(dt.charCodeAt(pt))&&n(pt,"Identifier directly after number");var o,h=dt.slice(e,pt);return i?o=parseFloat(h):r&&1!==h.length?/[89]/.test(h)||Tt?n(e,"Invalid number"):o=parseInt(h,8):o=parseInt(h,10),a(Lt,o)}function P(t){pt++;for(var e="";;){pt>=ft&&n(mt,"Unterminated string constant");var i=dt.charCodeAt(pt);if(i===t)return++pt,a(jt,e);if(92===i){i=dt.charCodeAt(++pt);var r=/^[0-7]+/.exec(dt.slice(pt,pt+3));for(r&&(r=r[0]);r&&parseInt(r,8)>255;)r=r.slice(0,r.length-1);if("0"===r&&(r=null),++pt,r)Tt&&n(pt-2,"Octal literal in strict mode"),e+=String.fromCharCode(parseInt(r,8)),pt+=r.length-1;else switch(i){case 110:e+="\n";break;case 114:e+="\r";break;case 120:e+=String.fromCharCode(k(2));break;case 117:e+=String.fromCharCode(k(4));break;case 85:e+=String.fromCharCode(k(8));break;case 116:e+="	";break;case 98:e+="\b";break;case 118:e+="";break;case 102:e+="\f";break;case 48:e+="\x00";break;case 13:10===dt.charCodeAt(pt)&&++pt;case 10:ct.locations&&(kt=pt,++Pt);break;default:e+=String.fromCharCode(i)}}else(13===i||10===i||8232===i||8233===i)&&n(mt,"Unterminated string constant"),e+=String.fromCharCode(i),++pt}}function k(t){var e=b(16,t);return null===e&&n(mt,"Bad character escape sequence"),e}function I(){Re=!1;for(var t,e=!0,i=pt;;){var r=dt.charCodeAt(pt);if(Ke(r))Re&&(t+=dt.charAt(pt)),++pt;else{if(92!==r)break;Re||(t=dt.slice(i,pt)),Re=!0,117!=dt.charCodeAt(++pt)&&n(pt,"Expecting Unicode escape sequence \\uXXXX"),++pt;var s=k(4),a=String.fromCharCode(s);a||n(pt-1,"Invalid Unicode escape"),(e?Ye(s):Ke(s))||n(pt-4,"Invalid Unicode escape"),t+=a}e=!1}return Re?t:dt.slice(i,pt)}function M(){var t=I(),e=Bt;return Re||(He(t)?e=le[t]:(ct.forbidReserved&&(3===ct.ecmaVersion?De:Fe)(t)||Tt&&qe(t))&&n(mt,"The keyword '"+t+"' is reserved")),a(e,t)}function z(){It=mt,Mt=yt,zt=xt,y()}function A(t){if(Tt=t,pt=Mt,ct.locations)for(;kt>pt;)kt=dt.lastIndexOf("\n",kt-2)+1,--Pt;u(),y()}function O(){this.type=null,this.start=mt,this.end=null}function T(){this.start=wt,this.end=null,null!==gt&&(this.source=gt)}function E(){var t=new O;return ct.locations&&(t.loc=new T),ct.ranges&&(t.range=[mt,0]),t}function L(t){var e=new O;return e.start=t.start,ct.locations&&(e.loc=new T,e.loc.start=t.loc.start),ct.ranges&&(e.range=[t.range[0],0]),e}function N(t,e){return t.type=e,t.end=Mt,ct.locations&&(t.loc.end=zt),ct.ranges&&(t.range[1]=Mt),t}function j(t){return ct.ecmaVersion>=5&&"ExpressionStatement"===t.type&&"Literal"===t.expression.type&&"use strict"===t.expression.value}function B(t){return bt===t?(z(),!0):void 0}function R(){return!ct.strictSemicolons&&(bt===Rt||bt===ge||Xe.test(dt.slice(Mt,mt)))}function D(){B(me)||R()||q()}function F(t){bt===t?z():q()}function q(){n(mt,"Unexpected token")}function V(t){"Identifier"!==t.type&&"MemberExpression"!==t.type&&n(t.start,"Assigning to rvalue"),Tt&&"Identifier"===t.type&&Ve(t.name)&&n(t.start,"Assigning to "+t.name+" in strict mode")}function H(t){It=Mt=pt,ct.locations&&(zt=new r),At=Tt=null,Ot=[],y();var e=t||E(),n=!0;for(t||(e.body=[]);bt!==Rt;){var i=Z();e.body.push(i),n&&j(i)&&A(!0),n=!1}return N(e,"Program")}function Z(){(bt===be||bt===Se&&"/="==Ct)&&y(!0);var t=bt,e=E();switch(t){case Dt:case Vt:z();var i=t===Dt;B(me)||R()?e.label=null:bt!==Bt?q():(e.label=lt(),D());for(var r=0;r<Ot.length;++r){var s=Ot[r];if(null==e.label||s.name===e.label.name){if(null!=s.kind&&(i||"loop"===s.kind))break;if(e.label&&i)break}}return r===Ot.length&&n(e.start,"Unsyntactic "+t.keyword),N(e,i?"BreakStatement":"ContinueStatement");case Ht:return z(),D(),N(e,"DebuggerStatement");case Ut:return z(),Ot.push(Qe),e.body=Z(),Ot.pop(),F(ne),e.test=U(),D(),N(e,"DoWhileStatement");case $t:if(z(),Ot.push(Qe),F(_e),bt===me)return G(e,null);if(bt===ee){var a=E();return z(),X(a,!0),N(a,"VariableDeclaration"),1===a.declarations.length&&B(ue)?$(e,a):G(e,a)}var a=J(!1,!0);return B(ue)?(V(a),$(e,a)):G(e,a);case Xt:return z(),ht(e,!0);case Jt:return z(),e.test=U(),e.consequent=Z(),e.alternate=B(Wt)?Z():null,N(e,"IfStatement");case Yt:return At||n(mt,"'return' outside of function"),z(),B(me)||R()?e.argument=null:(e.argument=J(),D()),N(e,"ReturnStatement");case Kt:z(),e.discriminant=U(),e.cases=[],F(fe),Ot.push(tn);for(var o,h;bt!=ge;)if(bt===Ft||bt===Zt){var u=bt===Ft;o&&N(o,"SwitchCase"),e.cases.push(o=E()),o.consequent=[],z(),u?o.test=J():(h&&n(It,"Multiple default clauses"),h=!0,o.test=null),F(ye)}else o||q(),o.consequent.push(Z());return o&&N(o,"SwitchCase"),z(),Ot.pop(),N(e,"SwitchStatement");case Qt:return z(),Xe.test(dt.slice(Mt,mt))&&n(Mt,"Illegal newline after throw"),e.argument=J(),D(),N(e,"ThrowStatement");case te:if(z(),e.block=W(),e.handler=null,bt===qt){var l=E();z(),F(_e),l.param=lt(),Tt&&Ve(l.param.name)&&n(l.param.start,"Binding "+l.param.name+" in strict mode"),F(ve),l.guard=null,l.body=W(),e.handler=N(l,"CatchClause")}return e.guardedHandlers=Et,e.finalizer=B(Gt)?W():null,e.handler||e.finalizer||n(e.start,"Missing catch or finally clause"),N(e,"TryStatement");case ee:return z(),X(e),D(),N(e,"VariableDeclaration");case ne:return z(),e.test=U(),Ot.push(Qe),e.body=Z(),Ot.pop(),N(e,"WhileStatement");case ie:return Tt&&n(mt,"'with' in strict mode"),z(),e.object=U(),e.body=Z(),N(e,"WithStatement");case fe:return W();case me:return z(),N(e,"EmptyStatement");default:var c=Ct,d=J();if(t===Bt&&"Identifier"===d.type&&B(ye)){for(var r=0;r<Ot.length;++r)Ot[r].name===c&&n(d.start,"Label '"+c+"' is already declared");var f=bt.isLoop?"loop":bt===Kt?"switch":null;return Ot.push({name:c,kind:f}),e.body=Z(),Ot.pop(),e.label=d,N(e,"LabeledStatement")}return e.expression=d,D(),N(e,"ExpressionStatement")}}function U(){F(_e);var t=J();return F(ve),t}function W(t){var e,n=E(),i=!0,r=!1;for(n.body=[],F(fe);!B(ge);){var s=Z();n.body.push(s),i&&t&&j(s)&&(e=r,A(r=!0)),i=!1}return r&&!e&&A(!1),N(n,"BlockStatement")}function G(t,e){return t.init=e,F(me),t.test=bt===me?null:J(),F(me),t.update=bt===ve?null:J(),F(ve),t.body=Z(),Ot.pop(),N(t,"ForStatement")}function $(t,e){return t.left=e,t.right=J(),F(ve),t.body=Z(),Ot.pop(),N(t,"ForInStatement")}function X(t,e){for(t.declarations=[],t.kind="var";;){var i=E();if(i.id=lt(),Tt&&Ve(i.id.name)&&n(i.id.start,"Binding "+i.id.name+" in strict mode"),i.init=B(Ce)?J(!0,e):null,t.declarations.push(N(i,"VariableDeclarator")),!B(pe))break}return t}function J(t,e){var n=Y(e);if(!t&&bt===pe){var i=L(n);for(i.expressions=[n];B(pe);)i.expressions.push(Y(e));return N(i,"SequenceExpression")}return n}function Y(t){var e=K(t);if(bt.isAssign){var n=L(e);return n.operator=Ct,n.left=e,z(),n.right=Y(t),V(e),N(n,"AssignmentExpression")}return e}function K(t){var e=Q(t);if(B(xe)){var n=L(e);return n.test=e,n.consequent=J(!0),F(ye),n.alternate=J(!0,t),N(n,"ConditionalExpression")}return e}function Q(t){return tt(et(),-1,t)}function tt(t,e,n){var i=bt.binop;if(null!=i&&(!n||bt!==ue)&&i>e){var r=L(t);r.left=t,r.operator=Ct,z(),r.right=tt(et(),i,n);var s=N(r,/&&|\|\|/.test(r.operator)?"LogicalExpression":"BinaryExpression");return tt(s,e,n)}return t}function et(){if(bt.prefix){var t=E(),e=bt.isUpdate;return t.operator=Ct,t.prefix=!0,St=!0,z(),t.argument=et(),e?V(t.argument):Tt&&"delete"===t.operator&&"Identifier"===t.argument.type&&n(t.start,"Deleting local variable in strict mode"),N(t,e?"UpdateExpression":"UnaryExpression")}for(var i=nt();bt.postfix&&!R();){var t=L(i);t.operator=Ct,t.prefix=!1,t.argument=i,V(i),z(),i=N(t,"UpdateExpression")}return i}function nt(){return it(rt())}function it(t,e){if(B(we)){var n=L(t);return n.object=t,n.property=lt(!0),n.computed=!1,it(N(n,"MemberExpression"),e)}if(B(ce)){var n=L(t);return n.object=t,n.property=J(),n.computed=!0,F(de),it(N(n,"MemberExpression"),e)}if(!e&&B(_e)){var n=L(t);return n.callee=t,n.arguments=ut(ve,!1),it(N(n,"CallExpression"),e)}return t}function rt(){switch(bt){case se:var t=E();return z(),N(t,"ThisExpression");case Bt:return lt();case Lt:case jt:case Nt:var t=E();return t.value=Ct,t.raw=dt.slice(mt,yt),z(),N(t,"Literal");case ae:case oe:case he:var t=E();return t.value=bt.atomValue,t.raw=bt.keyword,z(),N(t,"Literal");case _e:var e=wt,n=mt;z();var i=J();return i.start=n,i.end=yt,ct.locations&&(i.loc.start=e,i.loc.end=xt),ct.ranges&&(i.range=[n,yt]),F(ve),i;case ce:var t=E();return z(),t.elements=ut(de,!0,!0),N(t,"ArrayExpression");case fe:return at();case Xt:var t=E();return z(),ht(t,!1);case re:return st();default:q()}}function st(){var t=E();return z(),t.callee=it(rt(),!0),t.arguments=B(_e)?ut(ve,!1):Et,N(t,"NewExpression")}function at(){var t=E(),e=!0,i=!1;for(t.properties=[],z();!B(ge);){if(e)e=!1;else if(F(pe),ct.allowTrailingCommas&&B(ge))break;var r,s={key:ot()},a=!1;if(B(ye)?(s.value=J(!0),r=s.kind="init"):ct.ecmaVersion>=5&&"Identifier"===s.key.type&&("get"===s.key.name||"set"===s.key.name)?(a=i=!0,r=s.kind=s.key.name,s.key=ot(),bt!==_e&&q(),s.value=ht(E(),!1)):q(),"Identifier"===s.key.type&&(Tt||i))for(var o=0;o<t.properties.length;++o){var h=t.properties[o];if(h.key.name===s.key.name){var u=r==h.kind||a&&"init"===h.kind||"init"===r&&("get"===h.kind||"set"===h.kind);u&&!Tt&&"init"===r&&"init"===h.kind&&(u=!1),u&&n(s.key.start,"Redefinition of property")}}t.properties.push(s)}return N(t,"ObjectExpression")}function ot(){return bt===Lt||bt===jt?rt():lt(!0)}function ht(t,e){bt===Bt?t.id=lt():e?q():t.id=null,t.params=[];var i=!0;for(F(_e);!B(ve);)i?i=!1:F(pe),t.params.push(lt());var r=At,s=Ot;if(At=!0,Ot=[],t.body=W(!0),At=r,Ot=s,Tt||t.body.body.length&&j(t.body.body[0]))for(var a=t.id?-1:0;a<t.params.length;++a){var o=0>a?t.id:t.params[a];if((qe(o.name)||Ve(o.name))&&n(o.start,"Defining '"+o.name+"' in strict mode"),a>=0)for(var h=0;a>h;++h)o.name===t.params[h].name&&n(o.start,"Argument name clash in strict mode")}return N(t,e?"FunctionDeclaration":"FunctionExpression")}function ut(t,e,n){for(var i=[],r=!0;!B(t);){if(r)r=!1;else if(F(pe),e&&ct.allowTrailingCommas&&B(t))break;n&&bt===pe?i.push(null):i.push(J(!0))}return i}function lt(t){var e=E();return e.name=bt===Bt?Ct:t&&!ct.forbidReserved&&bt.keyword||q(),St=!1,z(),N(e,"Identifier")}t.version="0.4.0";var ct,dt,ft,gt;t.parse=function(t,n){return dt=t+"",ft=dt.length,e(n),s(),H(ct.program)};var _t=t.defaultOptions={ecmaVersion:5,strictSemicolons:!1,allowTrailingCommas:!0,forbidReserved:!1,locations:!1,onComment:null,ranges:!1,program:null,sourceFile:null},vt=t.getLineInfo=function(t,e){for(var n=1,i=0;;){Je.lastIndex=i;var r=Je.exec(t);if(!(r&&r.index<e))break;++n,i=r.index+r[0].length}return{line:n,column:e-i}};t.tokenize=function(t,n){function i(t){return y(t),r.start=mt,r.end=yt,r.startLoc=wt,r.endLoc=xt,r.type=bt,r.value=Ct,r}dt=t+"",ft=dt.length,e(n),s();var r={};return i.jumpTo=function(t,e){if(pt=t,ct.locations){Pt=1,kt=Je.lastIndex=0;for(var n;(n=Je.exec(dt))&&n.index<t;)++Pt,kt=n.index+n[0].length}St=e,u()},i};var pt,mt,yt,wt,xt,bt,Ct,St,Pt,kt,It,Mt,zt,At,Ot,Tt,Et=[],Lt={type:"num"},Nt={type:"regexp"},jt={type:"string"},Bt={type:"name"},Rt={type:"eof"},Dt={keyword:"break"},Ft={keyword:"case",beforeExpr:!0},qt={keyword:"catch"},Vt={keyword:"continue"},Ht={keyword:"debugger"},Zt={keyword:"default"},Ut={keyword:"do",isLoop:!0},Wt={keyword:"else",beforeExpr:!0},Gt={keyword:"finally"},$t={keyword:"for",isLoop:!0},Xt={keyword:"function"},Jt={keyword:"if"},Yt={keyword:"return",beforeExpr:!0},Kt={keyword:"switch"},Qt={keyword:"throw",beforeExpr:!0},te={keyword:"try"},ee={keyword:"var"},ne={keyword:"while",isLoop:!0},ie={keyword:"with"},re={keyword:"new",beforeExpr:!0},se={keyword:"this"},ae={keyword:"null",atomValue:null},oe={keyword:"true",atomValue:!0},he={keyword:"false",atomValue:!1},ue={keyword:"in",binop:7,beforeExpr:!0},le={"break":Dt,"case":Ft,"catch":qt,"continue":Vt,"debugger":Ht,"default":Zt,"do":Ut,"else":Wt,"finally":Gt,"for":$t,"function":Xt,"if":Jt,"return":Yt,"switch":Kt,"throw":Qt,"try":te,"var":ee,"while":ne,"with":ie,"null":ae,"true":oe,"false":he,"new":re,"in":ue,"instanceof":{keyword:"instanceof",binop:7,beforeExpr:!0},"this":se,"typeof":{keyword:"typeof",prefix:!0,beforeExpr:!0},"void":{keyword:"void",prefix:!0,beforeExpr:!0},"delete":{keyword:"delete",prefix:!0,beforeExpr:!0}},ce={type:"[",beforeExpr:!0},de={type:"]"},fe={type:"{",beforeExpr:!0},ge={type:"}"},_e={type:"(",beforeExpr:!0},ve={type:")"},pe={type:",",beforeExpr:!0},me={type:";",beforeExpr:!0},ye={type:":",beforeExpr:!0},we={type:"."},xe={type:"?",beforeExpr:!0},be={binop:10,beforeExpr:!0},Ce={isAssign:!0,beforeExpr:!0},Se={isAssign:!0,beforeExpr:!0},Pe={binop:9,prefix:!0,beforeExpr:!0},ke={postfix:!0,prefix:!0,isUpdate:!0},Ie={prefix:!0,beforeExpr:!0},Me={binop:1,beforeExpr:!0},ze={binop:2,beforeExpr:!0},Ae={binop:3,beforeExpr:!0},Oe={binop:4,beforeExpr:!0},Te={binop:5,beforeExpr:!0},Ee={binop:6,beforeExpr:!0},Le={binop:7,beforeExpr:!0},Ne={binop:8,beforeExpr:!0},je={binop:10,beforeExpr:!0};t.tokTypes={bracketL:ce,bracketR:de,braceL:fe,braceR:ge,parenL:_e,parenR:ve,comma:pe,semi:me,colon:ye,dot:we,question:xe,slash:be,eq:Ce,name:Bt,eof:Rt,num:Lt,regexp:Nt,string:jt};for(var Be in le)t.tokTypes["_"+Be]=le[Be];var Re,De=i("abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile"),Fe=i("class enum extends super const export import"),qe=i("implements interface let package private protected public static yield"),Ve=i("eval arguments"),He=i("break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this"),Ze=/[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]/,Ue="\xaa\xb5\xba\xc0-\xd6\xd8-\xf6\xf8-\u02c1\u02c6-\u02d1\u02e0-\u02e4\u02ec\u02ee\u0370-\u0374\u0376\u0377\u037a-\u037d\u0386\u0388-\u038a\u038c\u038e-\u03a1\u03a3-\u03f5\u03f7-\u0481\u048a-\u0527\u0531-\u0556\u0559\u0561-\u0587\u05d0-\u05ea\u05f0-\u05f2\u0620-\u064a\u066e\u066f\u0671-\u06d3\u06d5\u06e5\u06e6\u06ee\u06ef\u06fa-\u06fc\u06ff\u0710\u0712-\u072f\u074d-\u07a5\u07b1\u07ca-\u07ea\u07f4\u07f5\u07fa\u0800-\u0815\u081a\u0824\u0828\u0840-\u0858\u08a0\u08a2-\u08ac\u0904-\u0939\u093d\u0950\u0958-\u0961\u0971-\u0977\u0979-\u097f\u0985-\u098c\u098f\u0990\u0993-\u09a8\u09aa-\u09b0\u09b2\u09b6-\u09b9\u09bd\u09ce\u09dc\u09dd\u09df-\u09e1\u09f0\u09f1\u0a05-\u0a0a\u0a0f\u0a10\u0a13-\u0a28\u0a2a-\u0a30\u0a32\u0a33\u0a35\u0a36\u0a38\u0a39\u0a59-\u0a5c\u0a5e\u0a72-\u0a74\u0a85-\u0a8d\u0a8f-\u0a91\u0a93-\u0aa8\u0aaa-\u0ab0\u0ab2\u0ab3\u0ab5-\u0ab9\u0abd\u0ad0\u0ae0\u0ae1\u0b05-\u0b0c\u0b0f\u0b10\u0b13-\u0b28\u0b2a-\u0b30\u0b32\u0b33\u0b35-\u0b39\u0b3d\u0b5c\u0b5d\u0b5f-\u0b61\u0b71\u0b83\u0b85-\u0b8a\u0b8e-\u0b90\u0b92-\u0b95\u0b99\u0b9a\u0b9c\u0b9e\u0b9f\u0ba3\u0ba4\u0ba8-\u0baa\u0bae-\u0bb9\u0bd0\u0c05-\u0c0c\u0c0e-\u0c10\u0c12-\u0c28\u0c2a-\u0c33\u0c35-\u0c39\u0c3d\u0c58\u0c59\u0c60\u0c61\u0c85-\u0c8c\u0c8e-\u0c90\u0c92-\u0ca8\u0caa-\u0cb3\u0cb5-\u0cb9\u0cbd\u0cde\u0ce0\u0ce1\u0cf1\u0cf2\u0d05-\u0d0c\u0d0e-\u0d10\u0d12-\u0d3a\u0d3d\u0d4e\u0d60\u0d61\u0d7a-\u0d7f\u0d85-\u0d96\u0d9a-\u0db1\u0db3-\u0dbb\u0dbd\u0dc0-\u0dc6\u0e01-\u0e30\u0e32\u0e33\u0e40-\u0e46\u0e81\u0e82\u0e84\u0e87\u0e88\u0e8a\u0e8d\u0e94-\u0e97\u0e99-\u0e9f\u0ea1-\u0ea3\u0ea5\u0ea7\u0eaa\u0eab\u0ead-\u0eb0\u0eb2\u0eb3\u0ebd\u0ec0-\u0ec4\u0ec6\u0edc-\u0edf\u0f00\u0f40-\u0f47\u0f49-\u0f6c\u0f88-\u0f8c\u1000-\u102a\u103f\u1050-\u1055\u105a-\u105d\u1061\u1065\u1066\u106e-\u1070\u1075-\u1081\u108e\u10a0-\u10c5\u10c7\u10cd\u10d0-\u10fa\u10fc-\u1248\u124a-\u124d\u1250-\u1256\u1258\u125a-\u125d\u1260-\u1288\u128a-\u128d\u1290-\u12b0\u12b2-\u12b5\u12b8-\u12be\u12c0\u12c2-\u12c5\u12c8-\u12d6\u12d8-\u1310\u1312-\u1315\u1318-\u135a\u1380-\u138f\u13a0-\u13f4\u1401-\u166c\u166f-\u167f\u1681-\u169a\u16a0-\u16ea\u16ee-\u16f0\u1700-\u170c\u170e-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176c\u176e-\u1770\u1780-\u17b3\u17d7\u17dc\u1820-\u1877\u1880-\u18a8\u18aa\u18b0-\u18f5\u1900-\u191c\u1950-\u196d\u1970-\u1974\u1980-\u19ab\u19c1-\u19c7\u1a00-\u1a16\u1a20-\u1a54\u1aa7\u1b05-\u1b33\u1b45-\u1b4b\u1b83-\u1ba0\u1bae\u1baf\u1bba-\u1be5\u1c00-\u1c23\u1c4d-\u1c4f\u1c5a-\u1c7d\u1ce9-\u1cec\u1cee-\u1cf1\u1cf5\u1cf6\u1d00-\u1dbf\u1e00-\u1f15\u1f18-\u1f1d\u1f20-\u1f45\u1f48-\u1f4d\u1f50-\u1f57\u1f59\u1f5b\u1f5d\u1f5f-\u1f7d\u1f80-\u1fb4\u1fb6-\u1fbc\u1fbe\u1fc2-\u1fc4\u1fc6-\u1fcc\u1fd0-\u1fd3\u1fd6-\u1fdb\u1fe0-\u1fec\u1ff2-\u1ff4\u1ff6-\u1ffc\u2071\u207f\u2090-\u209c\u2102\u2107\u210a-\u2113\u2115\u2119-\u211d\u2124\u2126\u2128\u212a-\u212d\u212f-\u2139\u213c-\u213f\u2145-\u2149\u214e\u2160-\u2188\u2c00-\u2c2e\u2c30-\u2c5e\u2c60-\u2ce4\u2ceb-\u2cee\u2cf2\u2cf3\u2d00-\u2d25\u2d27\u2d2d\u2d30-\u2d67\u2d6f\u2d80-\u2d96\u2da0-\u2da6\u2da8-\u2dae\u2db0-\u2db6\u2db8-\u2dbe\u2dc0-\u2dc6\u2dc8-\u2dce\u2dd0-\u2dd6\u2dd8-\u2dde\u2e2f\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303c\u3041-\u3096\u309d-\u309f\u30a1-\u30fa\u30fc-\u30ff\u3105-\u312d\u3131-\u318e\u31a0-\u31ba\u31f0-\u31ff\u3400-\u4db5\u4e00-\u9fcc\ua000-\ua48c\ua4d0-\ua4fd\ua500-\ua60c\ua610-\ua61f\ua62a\ua62b\ua640-\ua66e\ua67f-\ua697\ua6a0-\ua6ef\ua717-\ua71f\ua722-\ua788\ua78b-\ua78e\ua790-\ua793\ua7a0-\ua7aa\ua7f8-\ua801\ua803-\ua805\ua807-\ua80a\ua80c-\ua822\ua840-\ua873\ua882-\ua8b3\ua8f2-\ua8f7\ua8fb\ua90a-\ua925\ua930-\ua946\ua960-\ua97c\ua984-\ua9b2\ua9cf\uaa00-\uaa28\uaa40-\uaa42\uaa44-\uaa4b\uaa60-\uaa76\uaa7a\uaa80-\uaaaf\uaab1\uaab5\uaab6\uaab9-\uaabd\uaac0\uaac2\uaadb-\uaadd\uaae0-\uaaea\uaaf2-\uaaf4\uab01-\uab06\uab09-\uab0e\uab11-\uab16\uab20-\uab26\uab28-\uab2e\uabc0-\uabe2\uac00-\ud7a3\ud7b0-\ud7c6\ud7cb-\ud7fb\uf900-\ufa6d\ufa70-\ufad9\ufb00-\ufb06\ufb13-\ufb17\ufb1d\ufb1f-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb3e\ufb40\ufb41\ufb43\ufb44\ufb46-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\uff21-\uff3a\uff41-\uff5a\uff66-\uffbe\uffc2-\uffc7\uffca-\uffcf\uffd2-\uffd7\uffda-\uffdc",We="\u0300-\u036f\u0483-\u0487\u0591-\u05bd\u05bf\u05c1\u05c2\u05c4\u05c5\u05c7\u0610-\u061a\u0620-\u0649\u0672-\u06d3\u06e7-\u06e8\u06fb-\u06fc\u0730-\u074a\u0800-\u0814\u081b-\u0823\u0825-\u0827\u0829-\u082d\u0840-\u0857\u08e4-\u08fe\u0900-\u0903\u093a-\u093c\u093e-\u094f\u0951-\u0957\u0962-\u0963\u0966-\u096f\u0981-\u0983\u09bc\u09be-\u09c4\u09c7\u09c8\u09d7\u09df-\u09e0\u0a01-\u0a03\u0a3c\u0a3e-\u0a42\u0a47\u0a48\u0a4b-\u0a4d\u0a51\u0a66-\u0a71\u0a75\u0a81-\u0a83\u0abc\u0abe-\u0ac5\u0ac7-\u0ac9\u0acb-\u0acd\u0ae2-\u0ae3\u0ae6-\u0aef\u0b01-\u0b03\u0b3c\u0b3e-\u0b44\u0b47\u0b48\u0b4b-\u0b4d\u0b56\u0b57\u0b5f-\u0b60\u0b66-\u0b6f\u0b82\u0bbe-\u0bc2\u0bc6-\u0bc8\u0bca-\u0bcd\u0bd7\u0be6-\u0bef\u0c01-\u0c03\u0c46-\u0c48\u0c4a-\u0c4d\u0c55\u0c56\u0c62-\u0c63\u0c66-\u0c6f\u0c82\u0c83\u0cbc\u0cbe-\u0cc4\u0cc6-\u0cc8\u0cca-\u0ccd\u0cd5\u0cd6\u0ce2-\u0ce3\u0ce6-\u0cef\u0d02\u0d03\u0d46-\u0d48\u0d57\u0d62-\u0d63\u0d66-\u0d6f\u0d82\u0d83\u0dca\u0dcf-\u0dd4\u0dd6\u0dd8-\u0ddf\u0df2\u0df3\u0e34-\u0e3a\u0e40-\u0e45\u0e50-\u0e59\u0eb4-\u0eb9\u0ec8-\u0ecd\u0ed0-\u0ed9\u0f18\u0f19\u0f20-\u0f29\u0f35\u0f37\u0f39\u0f41-\u0f47\u0f71-\u0f84\u0f86-\u0f87\u0f8d-\u0f97\u0f99-\u0fbc\u0fc6\u1000-\u1029\u1040-\u1049\u1067-\u106d\u1071-\u1074\u1082-\u108d\u108f-\u109d\u135d-\u135f\u170e-\u1710\u1720-\u1730\u1740-\u1750\u1772\u1773\u1780-\u17b2\u17dd\u17e0-\u17e9\u180b-\u180d\u1810-\u1819\u1920-\u192b\u1930-\u193b\u1951-\u196d\u19b0-\u19c0\u19c8-\u19c9\u19d0-\u19d9\u1a00-\u1a15\u1a20-\u1a53\u1a60-\u1a7c\u1a7f-\u1a89\u1a90-\u1a99\u1b46-\u1b4b\u1b50-\u1b59\u1b6b-\u1b73\u1bb0-\u1bb9\u1be6-\u1bf3\u1c00-\u1c22\u1c40-\u1c49\u1c5b-\u1c7d\u1cd0-\u1cd2\u1d00-\u1dbe\u1e01-\u1f15\u200c\u200d\u203f\u2040\u2054\u20d0-\u20dc\u20e1\u20e5-\u20f0\u2d81-\u2d96\u2de0-\u2dff\u3021-\u3028\u3099\u309a\ua640-\ua66d\ua674-\ua67d\ua69f\ua6f0-\ua6f1\ua7f8-\ua800\ua806\ua80b\ua823-\ua827\ua880-\ua881\ua8b4-\ua8c4\ua8d0-\ua8d9\ua8f3-\ua8f7\ua900-\ua909\ua926-\ua92d\ua930-\ua945\ua980-\ua983\ua9b3-\ua9c0\uaa00-\uaa27\uaa40-\uaa41\uaa4c-\uaa4d\uaa50-\uaa59\uaa7b\uaae0-\uaae9\uaaf2-\uaaf3\uabc0-\uabe1\uabec\uabed\uabf0-\uabf9\ufb20-\ufb28\ufe00-\ufe0f\ufe20-\ufe26\ufe33\ufe34\ufe4d-\ufe4f\uff10-\uff19\uff3f",Ge=RegExp("["+Ue+"]"),$e=RegExp("["+Ue+We+"]"),Xe=/[\n\r\u2028\u2029]/,Je=/\r\n|[\n\r\u2028\u2029]/g,Ye=t.isIdentifierStart=function(t){return 65>t?36===t:91>t?!0:97>t?95===t:123>t?!0:t>=170&&Ge.test(String.fromCharCode(t))},Ke=t.isIdentifierChar=function(t){return 48>t?36===t:58>t?!0:65>t?!1:91>t?!0:97>t?95===t:123>t?!0:t>=170&&$e.test(String.fromCharCode(t))},Qe={kind:"loop"},tn={kind:"switch"}});var _={"+":"__add","-":"__subtract","*":"__multiply","/":"__divide","%":"__modulo","==":"equals","!=":"equals"},v={"-":"__negate","+":null},p=e.each(["add","subtract","multiply","divide","modulo","negate"],function(t){this["__"+t]="#"+t},{});return h.inject(p),l.inject(p),j.inject(p),"complete"===document.readyState?setTimeout(u):q.add(window,{load:u}),{compile:s,execute:a,load:c,parse:r}}.call(this),paper=new(i.inject(e.exports,{enumerable:!0,Base:e,Numerical:a,Key:W})),"function"==typeof define&&define.amd?define("paper",paper):"object"==typeof module&&module&&(module.exports=paper),paper};
+
+var paper = new function(undefined) {
+
+var Base = new function() {
+	var hidden = /^(statics|enumerable|beans|preserve)$/,
+
+		forEach = [].forEach || function(iter, bind) {
+			for (var i = 0, l = this.length; i < l; i++)
+				iter.call(bind, this[i], i, this);
+		},
+
+		forIn = function(iter, bind) {
+			for (var i in this)
+				if (this.hasOwnProperty(i))
+					iter.call(bind, this[i], i, this);
+		},
+
+		create = Object.create || function(proto) {
+			return { __proto__: proto };
+		},
+
+		describe = Object.getOwnPropertyDescriptor || function(obj, name) {
+			var get = obj.__lookupGetter__ && obj.__lookupGetter__(name);
+			return get
+					? { get: get, set: obj.__lookupSetter__(name),
+						enumerable: true, configurable: true }
+					: obj.hasOwnProperty(name)
+						? { value: obj[name], enumerable: true,
+							configurable: true, writable: true }
+						: null;
+		},
+
+		_define = Object.defineProperty || function(obj, name, desc) {
+			if ((desc.get || desc.set) && obj.__defineGetter__) {
+				if (desc.get)
+					obj.__defineGetter__(name, desc.get);
+				if (desc.set)
+					obj.__defineSetter__(name, desc.set);
+			} else {
+				obj[name] = desc.value;
+			}
+			return obj;
+		},
+
+		define = function(obj, name, desc) {
+			delete obj[name];
+			return _define(obj, name, desc);
+		};
+
+	function inject(dest, src, enumerable, beans, preserve) {
+		var beansNames = {};
+
+		function field(name, val) {
+			val = val || (val = describe(src, name))
+					&& (val.get ? val : val.value);
+			if (typeof val === 'string' && val[0] === '#')
+				val = dest[val.substring(1)] || val;
+			var isFunc = typeof val === 'function',
+				res = val,
+				prev = preserve || isFunc && !val.base
+						? (val && val.get ? name in dest : dest[name])
+						: null,
+				bean;
+			if (!preserve || !prev) {
+				if (isFunc && prev)
+					val.base = prev;
+				if (isFunc && beans !== false
+						&& (bean = name.match(/^([gs]et|is)(([A-Z])(.*))$/)))
+					beansNames[bean[3].toLowerCase() + bean[4]] = bean[2];
+				if (!res || isFunc || !res.get || typeof res.get !== 'function'
+						|| !Base.isPlainObject(res))
+					res = { value: res, writable: true };
+				if ((describe(dest, name)
+						|| { configurable: true }).configurable) {
+					res.configurable = true;
+					res.enumerable = enumerable;
+				}
+				define(dest, name, res);
+			}
+		}
+		if (src) {
+			for (var name in src) {
+				if (src.hasOwnProperty(name) && !hidden.test(name))
+					field(name);
+			}
+			for (var name in beansNames) {
+				var part = beansNames[name],
+					set = dest['set' + part],
+					get = dest['get' + part] || set && dest['is' + part];
+				if (get && (beans === true || get.length === 0))
+					field(name, { get: get, set: set });
+			}
+		}
+		return dest;
+	}
+
+	function each(obj, iter, bind) {
+		if (obj)
+			('length' in obj && !obj.getLength
+					&& typeof obj.length === 'number'
+				? forEach
+				: forIn).call(obj, iter, bind = bind || obj);
+		return bind;
+	}
+
+	function set(obj, props, exclude) {
+		for (var key in props)
+			if (props.hasOwnProperty(key) && !(exclude && exclude[key]))
+				obj[key] = props[key];
+		return obj;
+	}
+
+	return inject(function Base() {
+		for (var i = 0, l = arguments.length; i < l; i++)
+			set(this, arguments[i]);
+	}, {
+		inject: function(src) {
+			if (src) {
+				var statics = src.statics === true ? src : src.statics,
+					beans = src.beans,
+					preserve = src.preserve;
+				if (statics !== src)
+					inject(this.prototype, src, src.enumerable, beans, preserve);
+				inject(this, statics, true, beans, preserve);
+			}
+			for (var i = 1, l = arguments.length; i < l; i++)
+				this.inject(arguments[i]);
+			return this;
+		},
+
+		extend: function() {
+			var base = this,
+				ctor,
+				proto;
+			for (var i = 0, l = arguments.length; i < l; i++)
+				if (ctor = arguments[i].initialize)
+					break;
+			ctor = ctor || function() {
+				base.apply(this, arguments);
+			};
+			proto = ctor.prototype = create(this.prototype);
+			define(proto, 'constructor',
+					{ value: ctor, writable: true, configurable: true });
+			inject(ctor, this, true);
+			if (arguments.length)
+				this.inject.apply(ctor, arguments);
+			ctor.base = base;
+			return ctor;
+		}
+	}, true).inject({
+		inject: function() {
+			for (var i = 0, l = arguments.length; i < l; i++) {
+				var src = arguments[i];
+				if (src)
+					inject(this, src, src.enumerable, src.beans, src.preserve);
+			}
+			return this;
+		},
+
+		extend: function() {
+			var res = create(this);
+			return res.inject.apply(res, arguments);
+		},
+
+		each: function(iter, bind) {
+			return each(this, iter, bind);
+		},
+
+		set: function(props) {
+			return set(this, props);
+		},
+
+		clone: function() {
+			return new this.constructor(this);
+		},
+
+		statics: {
+			each: each,
+			create: create,
+			define: define,
+			describe: describe,
+			set: set,
+
+			clone: function(obj) {
+				return set(new obj.constructor(), obj);
+			},
+
+			isPlainObject: function(obj) {
+				var ctor = obj != null && obj.constructor;
+				return ctor && (ctor === Object || ctor === Base
+						|| ctor.name === 'Object');
+			},
+
+			pick: function(a, b) {
+				return a !== undefined ? a : b;
+			}
+		}
+	});
+};
+
+if (typeof module !== 'undefined')
+	module.exports = Base;
+
+Base.inject({
+	toString: function() {
+		return this._id != null
+			?  (this._class || 'Object') + (this._name
+				? " '" + this._name + "'"
+				: ' @' + this._id)
+			: '{ ' + Base.each(this, function(value, key) {
+				if (!/^_/.test(key)) {
+					var type = typeof value;
+					this.push(key + ': ' + (type === 'number'
+							? Formatter.instance.number(value)
+							: type === 'string' ? "'" + value + "'" : value));
+				}
+			}, []).join(', ') + ' }';
+	},
+
+	getClassName: function() {
+		return this._class || '';
+	},
+
+	exportJSON: function(options) {
+		return Base.exportJSON(this, options);
+	},
+
+	toJSON: function() {
+		return Base.serialize(this);
+	},
+
+	_set: function(props, exclude, dontCheck) {
+		if (props && (dontCheck || Base.isPlainObject(props))) {
+			var keys = Object.keys(props._filtering || props);
+			for (var i = 0, l = keys.length; i < l; i++) {
+				var key = keys[i];
+				if (!(exclude && exclude[key])) {
+					var value = props[key];
+					if (value !== undefined)
+						this[key] = value;
+				}
+			}
+			return true;
+		}
+	},
+
+	statics: {
+
+		exports: {
+			enumerable: true
+		},
+
+		extend: function extend() {
+			var res = extend.base.apply(this, arguments),
+				name = res.prototype._class;
+			if (name && !Base.exports[name])
+				Base.exports[name] = res;
+			return res;
+		},
+
+		equals: function(obj1, obj2) {
+			if (obj1 === obj2)
+				return true;
+			if (obj1 && obj1.equals)
+				return obj1.equals(obj2);
+			if (obj2 && obj2.equals)
+				return obj2.equals(obj1);
+			if (obj1 && obj2
+					&& typeof obj1 === 'object' && typeof obj2 === 'object') {
+				if (Array.isArray(obj1) && Array.isArray(obj2)) {
+					var length = obj1.length;
+					if (length !== obj2.length)
+						return false;
+					while (length--) {
+						if (!Base.equals(obj1[length], obj2[length]))
+							return false;
+					}
+				} else {
+					var keys = Object.keys(obj1),
+						length = keys.length;
+					if (length !== Object.keys(obj2).length)
+						return false;
+					while (length--) {
+						var key = keys[length];
+						if (!(obj2.hasOwnProperty(key)
+								&& Base.equals(obj1[key], obj2[key])))
+							return false;
+					}
+				}
+				return true;
+			}
+			return false;
+		},
+
+		read: function(list, start, options, length) {
+			if (this === Base) {
+				var value = this.peek(list, start);
+				list.__index++;
+				return value;
+			}
+			var proto = this.prototype,
+				readIndex = proto._readIndex,
+				index = start || readIndex && list.__index || 0;
+			if (!length)
+				length = list.length - index;
+			var obj = list[index];
+			if (obj instanceof this
+				|| options && options.readNull && obj == null && length <= 1) {
+				if (readIndex)
+					list.__index = index + 1;
+				return obj && options && options.clone ? obj.clone() : obj;
+			}
+			obj = Base.create(this.prototype);
+			if (readIndex)
+				obj.__read = true;
+			obj = obj.initialize.apply(obj, index > 0 || length < list.length
+				? Array.prototype.slice.call(list, index, index + length)
+				: list) || obj;
+			if (readIndex) {
+				list.__index = index + obj.__read;
+				obj.__read = undefined;
+			}
+			return obj;
+		},
+
+		peek: function(list, start) {
+			return list[list.__index = start || list.__index || 0];
+		},
+
+		remain: function(list) {
+			return list.length - (list.__index || 0);
+		},
+
+		readAll: function(list, start, options) {
+			var res = [],
+				entry;
+			for (var i = start || 0, l = list.length; i < l; i++) {
+				res.push(Array.isArray(entry = list[i])
+						? this.read(entry, 0, options)
+						: this.read(list, i, options, 1));
+			}
+			return res;
+		},
+
+		readNamed: function(list, name, start, options, length) {
+			var value = this.getNamed(list, name),
+				hasObject = value !== undefined;
+			if (hasObject) {
+				var filtered = list._filtered;
+				if (!filtered) {
+					filtered = list._filtered = Base.create(list[0]);
+					filtered._filtering = list[0];
+				}
+				filtered[name] = undefined;
+			}
+			return this.read(hasObject ? [value] : list, start, options, length);
+		},
+
+		getNamed: function(list, name) {
+			var arg = list[0];
+			if (list._hasObject === undefined)
+				list._hasObject = list.length === 1 && Base.isPlainObject(arg);
+			if (list._hasObject)
+				return name ? arg[name] : list._filtered || arg;
+		},
+
+		hasNamed: function(list, name) {
+			return !!this.getNamed(list, name);
+		},
+
+		isPlainValue: function(obj, asString) {
+			return this.isPlainObject(obj) || Array.isArray(obj)
+					|| asString && typeof obj === 'string';
+		},
+
+		serialize: function(obj, options, compact, dictionary) {
+			options = options || {};
+
+			var root = !dictionary,
+				res;
+			if (root) {
+				options.formatter = new Formatter(options.precision);
+				dictionary = {
+					length: 0,
+					definitions: {},
+					references: {},
+					add: function(item, create) {
+						var id = '#' + item._id,
+							ref = this.references[id];
+						if (!ref) {
+							this.length++;
+							var res = create.call(item),
+								name = item._class;
+							if (name && res[0] !== name)
+								res.unshift(name);
+							this.definitions[id] = res;
+							ref = this.references[id] = [id];
+						}
+						return ref;
+					}
+				};
+			}
+			if (obj && obj._serialize) {
+				res = obj._serialize(options, dictionary);
+				var name = obj._class;
+				if (name && !compact && !res._compact && res[0] !== name)
+					res.unshift(name);
+			} else if (Array.isArray(obj)) {
+				res = [];
+				for (var i = 0, l = obj.length; i < l; i++)
+					res[i] = Base.serialize(obj[i], options, compact,
+							dictionary);
+				if (compact)
+					res._compact = true;
+			} else if (Base.isPlainObject(obj)) {
+				res = {};
+				var keys = Object.keys(obj);
+				for (var i = 0, l = keys.length; i < l; i++) {
+					var key = keys[i];
+					res[key] = Base.serialize(obj[key], options, compact,
+							dictionary);
+				}
+			} else if (typeof obj === 'number') {
+				res = options.formatter.number(obj, options.precision);
+			} else {
+				res = obj;
+			}
+			return root && dictionary.length > 0
+					? [['dictionary', dictionary.definitions], res]
+					: res;
+		},
+
+		deserialize: function(json, create, _data, _isDictionary) {
+			var res = json,
+				isRoot = !_data;
+			_data = _data || {};
+			if (Array.isArray(json)) {
+				var type = json[0],
+					isDictionary = type === 'dictionary';
+				if (json.length == 1 && /^#/.test(type))
+					return _data.dictionary[type];
+				type = Base.exports[type];
+				res = [];
+				if (_isDictionary)
+					_data.dictionary = res;
+				for (var i = type ? 1 : 0, l = json.length; i < l; i++)
+					res.push(Base.deserialize(json[i], create, _data,
+							isDictionary));
+				if (type) {
+					var args = res;
+					if (create) {
+						res = create(type, args);
+					} else {
+						res = Base.create(type.prototype);
+						type.apply(res, args);
+					}
+				}
+			} else if (Base.isPlainObject(json)) {
+				res = {};
+				if (_isDictionary)
+					_data.dictionary = res;
+				for (var key in json)
+					res[key] = Base.deserialize(json[key], create, _data);
+			}
+			return isRoot && json && json.length && json[0][0] === 'dictionary'
+					? res[1]
+					: res;
+		},
+
+		exportJSON: function(obj, options) {
+			var json = Base.serialize(obj, options);
+			return options && options.asString === false
+					? json
+					: JSON.stringify(json);
+		},
+
+		importJSON: function(json, target) {
+			return Base.deserialize(
+					typeof json === 'string' ? JSON.parse(json) : json,
+					function(ctor, args) {
+						var useTarget = target && target.constructor === ctor,
+							obj = useTarget ? target
+								: Base.create(ctor.prototype),
+							init = useTarget ? obj._initialize || obj._set
+								: ctor;
+						if (args.length === 1 && obj instanceof Item
+								&& (useTarget || !(obj instanceof Layer))) {
+							var arg = args[0];
+							if (Base.isPlainObject(arg))
+								arg.insert = false;
+						}
+						init.apply(obj, args);
+						if (useTarget)
+							target = null;
+						return obj;
+					});
+		},
+
+		splice: function(list, items, index, remove) {
+			var amount = items && items.length,
+				append = index === undefined;
+			index = append ? list.length : index;
+			if (index > list.length)
+				index = list.length;
+			for (var i = 0; i < amount; i++)
+				items[i]._index = index + i;
+			if (append) {
+				list.push.apply(list, items);
+				return [];
+			} else {
+				var args = [index, remove];
+				if (items)
+					args.push.apply(args, items);
+				var removed = list.splice.apply(list, args);
+				for (var i = 0, l = removed.length; i < l; i++)
+					removed[i]._index = undefined;
+				for (var i = index + amount, l = list.length; i < l; i++)
+					list[i]._index = i;
+				return removed;
+			}
+		},
+
+		capitalize: function(str) {
+			return str.replace(/\b[a-z]/g, function(match) {
+				return match.toUpperCase();
+			});
+		},
+
+		camelize: function(str) {
+			return str.replace(/-(.)/g, function(all, chr) {
+				return chr.toUpperCase();
+			});
+		},
+
+		hyphenate: function(str) {
+			return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+		}
+	}
+});
+
+var Emitter = {
+	on: function(type, func) {
+		if (typeof type !== 'string') {
+			Base.each(type, function(value, key) {
+				this.on(key, value);
+			}, this);
+		} else {
+			var types = this._eventTypes,
+				entry = types && types[type],
+				handlers = this._callbacks = this._callbacks || {};
+			handlers = handlers[type] = handlers[type] || [];
+			if (handlers.indexOf(func) === -1) {
+				handlers.push(func);
+				if (entry && entry.install && handlers.length === 1)
+					entry.install.call(this, type);
+			}
+		}
+		return this;
+	},
+
+	off: function(type, func) {
+		if (typeof type !== 'string') {
+			Base.each(type, function(value, key) {
+				this.off(key, value);
+			}, this);
+			return;
+		}
+		var types = this._eventTypes,
+			entry = types && types[type],
+			handlers = this._callbacks && this._callbacks[type],
+			index;
+		if (handlers) {
+			if (!func || (index = handlers.indexOf(func)) !== -1
+					&& handlers.length === 1) {
+				if (entry && entry.uninstall)
+					entry.uninstall.call(this, type);
+				delete this._callbacks[type];
+			} else if (index !== -1) {
+				handlers.splice(index, 1);
+			}
+		}
+		return this;
+	},
+
+	once: function(type, func) {
+		return this.on(type, function() {
+			func.apply(this, arguments);
+			this.off(type, func);
+		});
+	},
+
+	emit: function(type, event) {
+		var handlers = this._callbacks && this._callbacks[type];
+		if (!handlers)
+			return false;
+		var args = [].slice.call(arguments, 1);
+		handlers = handlers.slice();
+		for (var i = 0, l = handlers.length; i < l; i++) {
+			if (handlers[i].apply(this, args) === false) {
+				if (event && event.stop)
+					event.stop();
+				break;
+		   }
+		}
+		return true;
+	},
+
+	responds: function(type) {
+		return !!(this._callbacks && this._callbacks[type]);
+	},
+
+	attach: '#on',
+	detach: '#off',
+	fire: '#emit',
+
+	_installEvents: function(install) {
+		var handlers = this._callbacks,
+			key = install ? 'install' : 'uninstall';
+		for (var type in handlers) {
+			if (handlers[type].length > 0) {
+				var types = this._eventTypes,
+					entry = types && types[type],
+					func = entry && entry[key];
+				if (func)
+					func.call(this, type);
+			}
+		}
+	},
+
+	statics: {
+		inject: function inject(src) {
+			var events = src._events;
+			if (events) {
+				var types = {};
+				Base.each(events, function(entry, key) {
+					var isString = typeof entry === 'string',
+						name = isString ? entry : key,
+						part = Base.capitalize(name),
+						type = name.substring(2).toLowerCase();
+					types[type] = isString ? {} : entry;
+					name = '_' + name;
+					src['get' + part] = function() {
+						return this[name];
+					};
+					src['set' + part] = function(func) {
+						var prev = this[name];
+						if (prev)
+							this.off(type, prev);
+						if (func)
+							this.on(type, func);
+						this[name] = func;
+					};
+				});
+				src._eventTypes = types;
+			}
+			return inject.base.apply(this, arguments);
+		}
+	}
+};
+
+var PaperScope = Base.extend({
+	_class: 'PaperScope',
+
+	initialize: function PaperScope() {
+		paper = this;
+		this.settings = new Base({
+			applyMatrix: true,
+			handleSize: 4,
+			hitTolerance: 0
+		});
+		this.project = null;
+		this.projects = [];
+		this.tools = [];
+		this.palettes = [];
+		this._id = PaperScope._id++;
+		PaperScope._scopes[this._id] = this;
+		var proto = PaperScope.prototype;
+		if (!this.support) {
+			var ctx = CanvasProvider.getContext(1, 1);
+			proto.support = {
+				nativeDash: 'setLineDash' in ctx || 'mozDash' in ctx,
+				nativeBlendModes: BlendMode.nativeModes
+			};
+			CanvasProvider.release(ctx);
+		}
+
+		if (!this.browser) {
+			var agent = navigator.userAgent.toLowerCase(),
+				platform = (/(win)/.exec(agent)
+						|| /(mac)/.exec(agent)
+						|| /(linux)/.exec(agent)
+						|| [])[0],
+				browser = proto.browser = { platform: platform };
+			if (platform)
+				browser[platform] = true;
+			agent.replace(
+				/(opera|chrome|safari|webkit|firefox|msie|trident|atom)\/?\s*([.\d]+)(?:.*version\/([.\d]+))?(?:.*rv\:([.\d]+))?/g,
+				function(all, n, v1, v2, rv) {
+					if (!browser.chrome) {
+						var v = n === 'opera' ? v2 : v1;
+						if (n === 'trident') {
+							v = rv;
+							n = 'msie';
+						}
+						browser.version = v;
+						browser.versionNumber = parseFloat(v);
+						browser.name = n;
+						browser[n] = true;
+					}
+				}
+			);
+			if (browser.chrome)
+				delete browser.webkit;
+			if (browser.atom)
+				delete browser.chrome;
+		}
+	},
+
+	version: "0.9.25",
+
+	getView: function() {
+		var project = this.project;
+		return project && project._view;
+	},
+
+	getPaper: function() {
+		return this;
+	},
+
+	execute: function(code, url, options) {
+		paper.PaperScript.execute(code, this, url, options);
+		View.updateFocus();
+	},
+
+	install: function(scope) {
+		var that = this;
+		Base.each(['project', 'view', 'tool'], function(key) {
+			Base.define(scope, key, {
+				configurable: true,
+				get: function() {
+					return that[key];
+				}
+			});
+		});
+		for (var key in this)
+			if (!/^_/.test(key) && this[key])
+				scope[key] = this[key];
+	},
+
+	setup: function(element) {
+		paper = this;
+		this.project = new Project(element);
+		return this;
+	},
+
+	activate: function() {
+		paper = this;
+	},
+
+	clear: function() {
+		var projects = this.projects,
+			tools = this.tools,
+			palettes = this.palettes;
+		for (var i = projects.length - 1; i >= 0; i--)
+			projects[i].remove();
+		for (var i = tools.length - 1; i >= 0; i--)
+			tools[i].remove();
+		for (var i = palettes.length - 1; i >= 0; i--)
+			palettes[i].remove();
+	},
+
+	remove: function() {
+		this.clear();
+		delete PaperScope._scopes[this._id];
+	},
+
+	statics: new function() {
+		function handleAttribute(name) {
+			name += 'Attribute';
+			return function(el, attr) {
+				return el[name](attr) || el[name]('data-paper-' + attr);
+			};
+		}
+
+		return {
+			_scopes: {},
+			_id: 0,
+
+			get: function(id) {
+				return this._scopes[id] || null;
+			},
+
+			getAttribute: handleAttribute('get'),
+			hasAttribute: handleAttribute('has')
+		};
+	}
+});
+
+var PaperScopeItem = Base.extend(Emitter, {
+
+	initialize: function(activate) {
+		this._scope = paper;
+		this._index = this._scope[this._list].push(this) - 1;
+		if (activate || !this._scope[this._reference])
+			this.activate();
+	},
+
+	activate: function() {
+		if (!this._scope)
+			return false;
+		var prev = this._scope[this._reference];
+		if (prev && prev !== this)
+			prev.emit('deactivate');
+		this._scope[this._reference] = this;
+		this.emit('activate', prev);
+		return true;
+	},
+
+	isActive: function() {
+		return this._scope[this._reference] === this;
+	},
+
+	remove: function() {
+		if (this._index == null)
+			return false;
+		Base.splice(this._scope[this._list], null, this._index, 1);
+		if (this._scope[this._reference] == this)
+			this._scope[this._reference] = null;
+		this._scope = null;
+		return true;
+	},
+
+	getView: function() {
+		return this._scope.getView();
+	}
+});
+
+var Formatter = Base.extend({
+	initialize: function(precision) {
+		this.precision = Base.pick(precision, 5);
+		this.multiplier = Math.pow(10, this.precision);
+	},
+
+	number: function(val) {
+		return this.precision < 16
+				? Math.round(val * this.multiplier) / this.multiplier : val;
+	},
+
+	pair: function(val1, val2, separator) {
+		return this.number(val1) + (separator || ',') + this.number(val2);
+	},
+
+	point: function(val, separator) {
+		return this.number(val.x) + (separator || ',') + this.number(val.y);
+	},
+
+	size: function(val, separator) {
+		return this.number(val.width) + (separator || ',')
+				+ this.number(val.height);
+	},
+
+	rectangle: function(val, separator) {
+		return this.point(val, separator) + (separator || ',')
+				+ this.size(val, separator);
+	}
+});
+
+Formatter.instance = new Formatter();
+
+var Numerical = new function() {
+
+	var abscissas = [
+		[  0.5773502691896257645091488],
+		[0,0.7745966692414833770358531],
+		[  0.3399810435848562648026658,0.8611363115940525752239465],
+		[0,0.5384693101056830910363144,0.9061798459386639927976269],
+		[  0.2386191860831969086305017,0.6612093864662645136613996,0.9324695142031520278123016],
+		[0,0.4058451513773971669066064,0.7415311855993944398638648,0.9491079123427585245261897],
+		[  0.1834346424956498049394761,0.5255324099163289858177390,0.7966664774136267395915539,0.9602898564975362316835609],
+		[0,0.3242534234038089290385380,0.6133714327005903973087020,0.8360311073266357942994298,0.9681602395076260898355762],
+		[  0.1488743389816312108848260,0.4333953941292471907992659,0.6794095682990244062343274,0.8650633666889845107320967,0.9739065285171717200779640],
+		[0,0.2695431559523449723315320,0.5190961292068118159257257,0.7301520055740493240934163,0.8870625997680952990751578,0.9782286581460569928039380],
+		[  0.1252334085114689154724414,0.3678314989981801937526915,0.5873179542866174472967024,0.7699026741943046870368938,0.9041172563704748566784659,0.9815606342467192506905491],
+		[0,0.2304583159551347940655281,0.4484927510364468528779129,0.6423493394403402206439846,0.8015780907333099127942065,0.9175983992229779652065478,0.9841830547185881494728294],
+		[  0.1080549487073436620662447,0.3191123689278897604356718,0.5152486363581540919652907,0.6872929048116854701480198,0.8272013150697649931897947,0.9284348836635735173363911,0.9862838086968123388415973],
+		[0,0.2011940939974345223006283,0.3941513470775633698972074,0.5709721726085388475372267,0.7244177313601700474161861,0.8482065834104272162006483,0.9372733924007059043077589,0.9879925180204854284895657],
+		[  0.0950125098376374401853193,0.2816035507792589132304605,0.4580167776572273863424194,0.6178762444026437484466718,0.7554044083550030338951012,0.8656312023878317438804679,0.9445750230732325760779884,0.9894009349916499325961542]
+	];
+
+	var weights = [
+		[1],
+		[0.8888888888888888888888889,0.5555555555555555555555556],
+		[0.6521451548625461426269361,0.3478548451374538573730639],
+		[0.5688888888888888888888889,0.4786286704993664680412915,0.2369268850561890875142640],
+		[0.4679139345726910473898703,0.3607615730481386075698335,0.1713244923791703450402961],
+		[0.4179591836734693877551020,0.3818300505051189449503698,0.2797053914892766679014678,0.1294849661688696932706114],
+		[0.3626837833783619829651504,0.3137066458778872873379622,0.2223810344533744705443560,0.1012285362903762591525314],
+		[0.3302393550012597631645251,0.3123470770400028400686304,0.2606106964029354623187429,0.1806481606948574040584720,0.0812743883615744119718922],
+		[0.2955242247147528701738930,0.2692667193099963550912269,0.2190863625159820439955349,0.1494513491505805931457763,0.0666713443086881375935688],
+		[0.2729250867779006307144835,0.2628045445102466621806889,0.2331937645919904799185237,0.1862902109277342514260976,0.1255803694649046246346943,0.0556685671161736664827537],
+		[0.2491470458134027850005624,0.2334925365383548087608499,0.2031674267230659217490645,0.1600783285433462263346525,0.1069393259953184309602547,0.0471753363865118271946160],
+		[0.2325515532308739101945895,0.2262831802628972384120902,0.2078160475368885023125232,0.1781459807619457382800467,0.1388735102197872384636018,0.0921214998377284479144218,0.0404840047653158795200216],
+		[0.2152638534631577901958764,0.2051984637212956039659241,0.1855383974779378137417166,0.1572031671581935345696019,0.1215185706879031846894148,0.0801580871597602098056333,0.0351194603317518630318329],
+		[0.2025782419255612728806202,0.1984314853271115764561183,0.1861610000155622110268006,0.1662692058169939335532009,0.1395706779261543144478048,0.1071592204671719350118695,0.0703660474881081247092674,0.0307532419961172683546284],
+		[0.1894506104550684962853967,0.1826034150449235888667637,0.1691565193950025381893121,0.1495959888165767320815017,0.1246289712555338720524763,0.0951585116824927848099251,0.0622535239386478928628438,0.0271524594117540948517806]
+	];
+
+	var abs = Math.abs,
+		sqrt = Math.sqrt,
+		pow = Math.pow,
+		EPSILON = 1e-12,
+		MACHINE_EPSILON = 1.12e-16;
+
+	function clamp(value, min, max) {
+		return value < min ? min : value > max ? max : value;
+	}
+
+	return {
+		TOLERANCE: 1e-6,
+		EPSILON: EPSILON,
+		MACHINE_EPSILON: MACHINE_EPSILON,
+		CURVETIME_EPSILON: 4e-7,
+		GEOMETRIC_EPSILON: 2e-7,
+		WINDING_EPSILON: 2e-7,
+		TRIGONOMETRIC_EPSILON: 1e-7,
+		CLIPPING_EPSILON: 1e-7,
+		KAPPA: 4 * (sqrt(2) - 1) / 3,
+
+		isZero: function(val) {
+			return val >= -EPSILON && val <= EPSILON;
+		},
+
+		clamp: clamp,
+
+		integrate: function(f, a, b, n) {
+			var x = abscissas[n - 2],
+				w = weights[n - 2],
+				A = (b - a) * 0.5,
+				B = A + a,
+				i = 0,
+				m = (n + 1) >> 1,
+				sum = n & 1 ? w[i++] * f(B) : 0;
+			while (i < m) {
+				var Ax = A * x[i];
+				sum += w[i++] * (f(B + Ax) + f(B - Ax));
+			}
+			return A * sum;
+		},
+
+		findRoot: function(f, df, x, a, b, n, tolerance) {
+			for (var i = 0; i < n; i++) {
+				var fx = f(x),
+					dx = fx / df(x),
+					nx = x - dx;
+				if (abs(dx) < tolerance)
+					return nx;
+				if (fx > 0) {
+					b = x;
+					x = nx <= a ? (a + b) * 0.5 : nx;
+				} else {
+					a = x;
+					x = nx >= b ? (a + b) * 0.5 : nx;
+				}
+			}
+			return x;
+		},
+
+		solveQuadratic: function(a, b, c, roots, min, max) {
+			var count = 0,
+				eMin = min - EPSILON,
+				eMax = max + EPSILON,
+				x1, x2 = Infinity,
+				B = b,
+				D;
+			b /= -2;
+			D = b * b - a * c;
+			if (D !== 0 && abs(D) < MACHINE_EPSILON) {
+				var gmC = pow(abs(a * b * c), 1 / 3);
+				if (gmC < 1e-8) {
+					var mult = pow(10,
+							abs(Math.floor(Math.log(gmC) * Math.LOG10E)));
+					if (!isFinite(mult))
+						mult = 0;
+					a *= mult;
+					b *= mult;
+					c *= mult;
+					D = b * b - a * c;
+				}
+			}
+			if (abs(a) < EPSILON) {
+				if (abs(B) < EPSILON)
+					return abs(c) < EPSILON ? -1 : 0;
+				x1 = -c / B;
+			} else if (D >= -MACHINE_EPSILON) {
+				var Q = D < 0 ? 0 : sqrt(D),
+					R = b + (b < 0 ? -Q : Q);
+				if (R === 0) {
+					x1 = c / a;
+					x2 = -x1;
+				} else {
+					x1 = R / a;
+					x2 = c / R;
+				}
+			}
+			if (isFinite(x1) && (min == null || x1 > eMin && x1 < eMax))
+				roots[count++] = min == null ? x1 : clamp(x1, min, max);
+			if (x2 !== x1
+					&& isFinite(x2) && (min == null || x2 > eMin && x2 < eMax))
+				roots[count++] = min == null ? x2 : clamp(x2, min, max);
+			return count;
+		},
+
+		solveCubic: function(a, b, c, d, roots, min, max) {
+			var count = 0,
+				x, b1, c2;
+			if (abs(a) < EPSILON) {
+				a = b;
+				b1 = c;
+				c2 = d;
+				x = Infinity;
+			} else if (abs(d) < EPSILON) {
+				b1 = b;
+				c2 = c;
+				x = 0;
+			} else {
+				var ec = 1 + MACHINE_EPSILON,
+					x0, q, qd, t, r, s, tmp;
+				x = -(b / a) / 3;
+				tmp = a * x;
+				b1 = tmp + b;
+				c2 = b1 * x + c;
+				qd = (tmp + b1) * x + c2;
+				q = c2 * x + d;
+				t = q / a;
+				r = pow(abs(t), 1/3);
+				s = t < 0 ? -1 : 1;
+				t = -qd / a;
+				r = t > 0 ? 1.3247179572 * Math.max(r, sqrt(t)) : r;
+				x0 = x - s * r;
+				if (x0 !== x) {
+					do {
+						x = x0;
+						tmp = a * x;
+						b1 = tmp + b;
+						c2 = b1 * x + c;
+						qd = (tmp + b1) * x + c2;
+						q = c2 * x + d;
+						x0 = qd === 0 ? x : x - q / qd / ec;
+					} while (s * x0 > s * x);
+					if (abs(a) * x * x > abs(d / x)) {
+						c2 = -d / x;
+						b1 = (c2 - c) / x;
+					}
+				}
+			}
+			var count = Numerical.solveQuadratic(a, b1, c2, roots, min, max);
+			if (isFinite(x) && (count === 0 || x !== roots[count - 1])
+					&& (min == null || x > min - EPSILON && x < max + EPSILON))
+				roots[count++] = min == null ? x : clamp(x, min, max);
+			return count;
+		}
+	};
+};
+
+var UID = {
+	_id: 1,
+	_pools: {},
+
+	get: function(ctor) {
+		if (ctor) {
+			var name = ctor._class,
+				pool = this._pools[name];
+			if (!pool)
+				pool = this._pools[name] = { _id: 1 };
+			return pool._id++;
+		} else {
+			return this._id++;
+		}
+	}
+};
+
+var Point = Base.extend({
+	_class: 'Point',
+	_readIndex: true,
+
+	initialize: function Point(arg0, arg1) {
+		var type = typeof arg0;
+		if (type === 'number') {
+			var hasY = typeof arg1 === 'number';
+			this.x = arg0;
+			this.y = hasY ? arg1 : arg0;
+			if (this.__read)
+				this.__read = hasY ? 2 : 1;
+		} else if (type === 'undefined' || arg0 === null) {
+			this.x = this.y = 0;
+			if (this.__read)
+				this.__read = arg0 === null ? 1 : 0;
+		} else {
+			if (Array.isArray(arg0)) {
+				this.x = arg0[0];
+				this.y = arg0.length > 1 ? arg0[1] : arg0[0];
+			} else if (arg0.x != null) {
+				this.x = arg0.x;
+				this.y = arg0.y;
+			} else if (arg0.width != null) {
+				this.x = arg0.width;
+				this.y = arg0.height;
+			} else if (arg0.angle != null) {
+				this.x = arg0.length;
+				this.y = 0;
+				this.setAngle(arg0.angle);
+			} else {
+				this.x = this.y = 0;
+				if (this.__read)
+					this.__read = 0;
+			}
+			if (this.__read)
+				this.__read = 1;
+		}
+	},
+
+	set: function(x, y) {
+		this.x = x;
+		this.y = y;
+		return this;
+	},
+
+	equals: function(point) {
+		return this === point || point
+				&& (this.x === point.x && this.y === point.y
+					|| Array.isArray(point)
+						&& this.x === point[0] && this.y === point[1])
+				|| false;
+	},
+
+	clone: function() {
+		return new Point(this.x, this.y);
+	},
+
+	toString: function() {
+		var f = Formatter.instance;
+		return '{ x: ' + f.number(this.x) + ', y: ' + f.number(this.y) + ' }';
+	},
+
+	_serialize: function(options) {
+		var f = options.formatter;
+		return [f.number(this.x), f.number(this.y)];
+	},
+
+	getLength: function() {
+		return Math.sqrt(this.x * this.x + this.y * this.y);
+	},
+
+	setLength: function(length) {
+		if (this.isZero()) {
+			var angle = this._angle || 0;
+			this.set(
+				Math.cos(angle) * length,
+				Math.sin(angle) * length
+			);
+		} else {
+			var scale = length / this.getLength();
+			if (Numerical.isZero(scale))
+				this.getAngle();
+			this.set(
+				this.x * scale,
+				this.y * scale
+			);
+		}
+	},
+	getAngle: function() {
+		return this.getAngleInRadians.apply(this, arguments) * 180 / Math.PI;
+	},
+
+	setAngle: function(angle) {
+		this.setAngleInRadians.call(this, angle * Math.PI / 180);
+	},
+
+	getAngleInDegrees: '#getAngle',
+	setAngleInDegrees: '#setAngle',
+
+	getAngleInRadians: function() {
+		if (!arguments.length) {
+			return this.isZero()
+					? this._angle || 0
+					: this._angle = Math.atan2(this.y, this.x);
+		} else {
+			var point = Point.read(arguments),
+				div = this.getLength() * point.getLength();
+			if (Numerical.isZero(div)) {
+				return NaN;
+			} else {
+				var a = this.dot(point) / div;
+				return Math.acos(a < -1 ? -1 : a > 1 ? 1 : a);
+			}
+		}
+	},
+
+	setAngleInRadians: function(angle) {
+		this._angle = angle;
+		if (!this.isZero()) {
+			var length = this.getLength();
+			this.set(
+				Math.cos(angle) * length,
+				Math.sin(angle) * length
+			);
+		}
+	},
+
+	getQuadrant: function() {
+		return this.x >= 0 ? this.y >= 0 ? 1 : 4 : this.y >= 0 ? 2 : 3;
+	}
+}, {
+	beans: false,
+
+	getDirectedAngle: function() {
+		var point = Point.read(arguments);
+		return Math.atan2(this.cross(point), this.dot(point)) * 180 / Math.PI;
+	},
+
+	getDistance: function() {
+		var point = Point.read(arguments),
+			x = point.x - this.x,
+			y = point.y - this.y,
+			d = x * x + y * y,
+			squared = Base.read(arguments);
+		return squared ? d : Math.sqrt(d);
+	},
+
+	normalize: function(length) {
+		if (length === undefined)
+			length = 1;
+		var current = this.getLength(),
+			scale = current !== 0 ? length / current : 0,
+			point = new Point(this.x * scale, this.y * scale);
+		if (scale >= 0)
+			point._angle = this._angle;
+		return point;
+	},
+
+	rotate: function(angle, center) {
+		if (angle === 0)
+			return this.clone();
+		angle = angle * Math.PI / 180;
+		var point = center ? this.subtract(center) : this,
+			sin = Math.sin(angle),
+			cos = Math.cos(angle);
+		point = new Point(
+			point.x * cos - point.y * sin,
+			point.x * sin + point.y * cos
+		);
+		return center ? point.add(center) : point;
+	},
+
+	transform: function(matrix) {
+		return matrix ? matrix._transformPoint(this) : this;
+	},
+
+	add: function() {
+		var point = Point.read(arguments);
+		return new Point(this.x + point.x, this.y + point.y);
+	},
+
+	subtract: function() {
+		var point = Point.read(arguments);
+		return new Point(this.x - point.x, this.y - point.y);
+	},
+
+	multiply: function() {
+		var point = Point.read(arguments);
+		return new Point(this.x * point.x, this.y * point.y);
+	},
+
+	divide: function() {
+		var point = Point.read(arguments);
+		return new Point(this.x / point.x, this.y / point.y);
+	},
+
+	modulo: function() {
+		var point = Point.read(arguments);
+		return new Point(this.x % point.x, this.y % point.y);
+	},
+
+	negate: function() {
+		return new Point(-this.x, -this.y);
+	},
+
+	isInside: function() {
+		return Rectangle.read(arguments).contains(this);
+	},
+
+	isClose: function() {
+		var point = Point.read(arguments),
+			tolerance = Base.read(arguments);
+		return this.getDistance(point) < tolerance;
+	},
+
+	isCollinear: function() {
+		var point = Point.read(arguments);
+		return Point.isCollinear(this.x, this.y, point.x, point.y);
+	},
+
+	isColinear: '#isCollinear',
+
+	isOrthogonal: function() {
+		var point = Point.read(arguments);
+		return Point.isOrthogonal(this.x, this.y, point.x, point.y);
+	},
+
+	isZero: function() {
+		return Numerical.isZero(this.x) && Numerical.isZero(this.y);
+	},
+
+	isNaN: function() {
+		return isNaN(this.x) || isNaN(this.y);
+	},
+
+	dot: function() {
+		var point = Point.read(arguments);
+		return this.x * point.x + this.y * point.y;
+	},
+
+	cross: function() {
+		var point = Point.read(arguments);
+		return this.x * point.y - this.y * point.x;
+	},
+
+	project: function() {
+		var point = Point.read(arguments),
+			scale = point.isZero() ? 0 : this.dot(point) / point.dot(point);
+		return new Point(
+			point.x * scale,
+			point.y * scale
+		);
+	},
+
+	statics: {
+		min: function() {
+			var point1 = Point.read(arguments),
+				point2 = Point.read(arguments);
+			return new Point(
+				Math.min(point1.x, point2.x),
+				Math.min(point1.y, point2.y)
+			);
+		},
+
+		max: function() {
+			var point1 = Point.read(arguments),
+				point2 = Point.read(arguments);
+			return new Point(
+				Math.max(point1.x, point2.x),
+				Math.max(point1.y, point2.y)
+			);
+		},
+
+		random: function() {
+			return new Point(Math.random(), Math.random());
+		},
+
+		isCollinear: function(x1, y1, x2, y2) {
+			return Math.abs(x1 * y2 - y1 * x2)
+					<= Math.sqrt((x1 * x1 + y1 * y1) * (x2 * x2 + y2 * y2))
+						* 1e-7;
+		},
+
+		isOrthogonal: function(x1, y1, x2, y2) {
+			return Math.abs(x1 * x2 + y1 * y2)
+					<= Math.sqrt((x1 * x1 + y1 * y1) * (x2 * x2 + y2 * y2))
+						* 1e-7;
+		}
+	}
+}, Base.each(['round', 'ceil', 'floor', 'abs'], function(key) {
+	var op = Math[key];
+	this[key] = function() {
+		return new Point(op(this.x), op(this.y));
+	};
+}, {}));
+
+var LinkedPoint = Point.extend({
+	initialize: function Point(x, y, owner, setter) {
+		this._x = x;
+		this._y = y;
+		this._owner = owner;
+		this._setter = setter;
+	},
+
+	set: function(x, y, _dontNotify) {
+		this._x = x;
+		this._y = y;
+		if (!_dontNotify)
+			this._owner[this._setter](this);
+		return this;
+	},
+
+	getX: function() {
+		return this._x;
+	},
+
+	setX: function(x) {
+		this._x = x;
+		this._owner[this._setter](this);
+	},
+
+	getY: function() {
+		return this._y;
+	},
+
+	setY: function(y) {
+		this._y = y;
+		this._owner[this._setter](this);
+	}
+});
+
+var Size = Base.extend({
+	_class: 'Size',
+	_readIndex: true,
+
+	initialize: function Size(arg0, arg1) {
+		var type = typeof arg0;
+		if (type === 'number') {
+			var hasHeight = typeof arg1 === 'number';
+			this.width = arg0;
+			this.height = hasHeight ? arg1 : arg0;
+			if (this.__read)
+				this.__read = hasHeight ? 2 : 1;
+		} else if (type === 'undefined' || arg0 === null) {
+			this.width = this.height = 0;
+			if (this.__read)
+				this.__read = arg0 === null ? 1 : 0;
+		} else {
+			if (Array.isArray(arg0)) {
+				this.width = arg0[0];
+				this.height = arg0.length > 1 ? arg0[1] : arg0[0];
+			} else if (arg0.width != null) {
+				this.width = arg0.width;
+				this.height = arg0.height;
+			} else if (arg0.x != null) {
+				this.width = arg0.x;
+				this.height = arg0.y;
+			} else {
+				this.width = this.height = 0;
+				if (this.__read)
+					this.__read = 0;
+			}
+			if (this.__read)
+				this.__read = 1;
+		}
+	},
+
+	set: function(width, height) {
+		this.width = width;
+		this.height = height;
+		return this;
+	},
+
+	equals: function(size) {
+		return size === this || size && (this.width === size.width
+				&& this.height === size.height
+				|| Array.isArray(size) && this.width === size[0]
+					&& this.height === size[1]) || false;
+	},
+
+	clone: function() {
+		return new Size(this.width, this.height);
+	},
+
+	toString: function() {
+		var f = Formatter.instance;
+		return '{ width: ' + f.number(this.width)
+				+ ', height: ' + f.number(this.height) + ' }';
+	},
+
+	_serialize: function(options) {
+		var f = options.formatter;
+		return [f.number(this.width),
+				f.number(this.height)];
+	},
+
+	add: function() {
+		var size = Size.read(arguments);
+		return new Size(this.width + size.width, this.height + size.height);
+	},
+
+	subtract: function() {
+		var size = Size.read(arguments);
+		return new Size(this.width - size.width, this.height - size.height);
+	},
+
+	multiply: function() {
+		var size = Size.read(arguments);
+		return new Size(this.width * size.width, this.height * size.height);
+	},
+
+	divide: function() {
+		var size = Size.read(arguments);
+		return new Size(this.width / size.width, this.height / size.height);
+	},
+
+	modulo: function() {
+		var size = Size.read(arguments);
+		return new Size(this.width % size.width, this.height % size.height);
+	},
+
+	negate: function() {
+		return new Size(-this.width, -this.height);
+	},
+
+	isZero: function() {
+		return Numerical.isZero(this.width) && Numerical.isZero(this.height);
+	},
+
+	isNaN: function() {
+		return isNaN(this.width) || isNaN(this.height);
+	},
+
+	statics: {
+		min: function(size1, size2) {
+			return new Size(
+				Math.min(size1.width, size2.width),
+				Math.min(size1.height, size2.height));
+		},
+
+		max: function(size1, size2) {
+			return new Size(
+				Math.max(size1.width, size2.width),
+				Math.max(size1.height, size2.height));
+		},
+
+		random: function() {
+			return new Size(Math.random(), Math.random());
+		}
+	}
+}, Base.each(['round', 'ceil', 'floor', 'abs'], function(key) {
+	var op = Math[key];
+	this[key] = function() {
+		return new Size(op(this.width), op(this.height));
+	};
+}, {}));
+
+var LinkedSize = Size.extend({
+	initialize: function Size(width, height, owner, setter) {
+		this._width = width;
+		this._height = height;
+		this._owner = owner;
+		this._setter = setter;
+	},
+
+	set: function(width, height, _dontNotify) {
+		this._width = width;
+		this._height = height;
+		if (!_dontNotify)
+			this._owner[this._setter](this);
+		return this;
+	},
+
+	getWidth: function() {
+		return this._width;
+	},
+
+	setWidth: function(width) {
+		this._width = width;
+		this._owner[this._setter](this);
+	},
+
+	getHeight: function() {
+		return this._height;
+	},
+
+	setHeight: function(height) {
+		this._height = height;
+		this._owner[this._setter](this);
+	}
+});
+
+var Rectangle = Base.extend({
+	_class: 'Rectangle',
+	_readIndex: true,
+	beans: true,
+
+	initialize: function Rectangle(arg0, arg1, arg2, arg3) {
+		var type = typeof arg0,
+			read = 0;
+		if (type === 'number') {
+			this.x = arg0;
+			this.y = arg1;
+			this.width = arg2;
+			this.height = arg3;
+			read = 4;
+		} else if (type === 'undefined' || arg0 === null) {
+			this.x = this.y = this.width = this.height = 0;
+			read = arg0 === null ? 1 : 0;
+		} else if (arguments.length === 1) {
+			if (Array.isArray(arg0)) {
+				this.x = arg0[0];
+				this.y = arg0[1];
+				this.width = arg0[2];
+				this.height = arg0[3];
+				read = 1;
+			} else if (arg0.x !== undefined || arg0.width !== undefined) {
+				this.x = arg0.x || 0;
+				this.y = arg0.y || 0;
+				this.width = arg0.width || 0;
+				this.height = arg0.height || 0;
+				read = 1;
+			} else if (arg0.from === undefined && arg0.to === undefined) {
+				this.x = this.y = this.width = this.height = 0;
+				this._set(arg0);
+				read = 1;
+			}
+		}
+		if (!read) {
+			var point = Point.readNamed(arguments, 'from'),
+				next = Base.peek(arguments);
+			this.x = point.x;
+			this.y = point.y;
+			if (next && next.x !== undefined || Base.hasNamed(arguments, 'to')) {
+				var to = Point.readNamed(arguments, 'to');
+				this.width = to.x - point.x;
+				this.height = to.y - point.y;
+				if (this.width < 0) {
+					this.x = to.x;
+					this.width = -this.width;
+				}
+				if (this.height < 0) {
+					this.y = to.y;
+					this.height = -this.height;
+				}
+			} else {
+				var size = Size.read(arguments);
+				this.width = size.width;
+				this.height = size.height;
+			}
+			read = arguments.__index;
+		}
+		if (this.__read)
+			this.__read = read;
+	},
+
+	set: function(x, y, width, height) {
+		this.x = x;
+		this.y = y;
+		this.width = width;
+		this.height = height;
+		return this;
+	},
+
+	clone: function() {
+		return new Rectangle(this.x, this.y, this.width, this.height);
+	},
+
+	equals: function(rect) {
+		var rt = Base.isPlainValue(rect)
+				? Rectangle.read(arguments)
+				: rect;
+		return rt === this
+				|| rt && this.x === rt.x && this.y === rt.y
+					&& this.width === rt.width && this.height === rt.height
+				|| false;
+	},
+
+	toString: function() {
+		var f = Formatter.instance;
+		return '{ x: ' + f.number(this.x)
+				+ ', y: ' + f.number(this.y)
+				+ ', width: ' + f.number(this.width)
+				+ ', height: ' + f.number(this.height)
+				+ ' }';
+	},
+
+	_serialize: function(options) {
+		var f = options.formatter;
+		return [f.number(this.x),
+				f.number(this.y),
+				f.number(this.width),
+				f.number(this.height)];
+	},
+
+	getPoint: function(_dontLink) {
+		var ctor = _dontLink ? Point : LinkedPoint;
+		return new ctor(this.x, this.y, this, 'setPoint');
+	},
+
+	setPoint: function() {
+		var point = Point.read(arguments);
+		this.x = point.x;
+		this.y = point.y;
+	},
+
+	getSize: function(_dontLink) {
+		var ctor = _dontLink ? Size : LinkedSize;
+		return new ctor(this.width, this.height, this, 'setSize');
+	},
+
+	setSize: function() {
+		var size = Size.read(arguments);
+		if (this._fixX)
+			this.x += (this.width - size.width) * this._fixX;
+		if (this._fixY)
+			this.y += (this.height - size.height) * this._fixY;
+		this.width = size.width;
+		this.height = size.height;
+		this._fixW = 1;
+		this._fixH = 1;
+	},
+
+	getLeft: function() {
+		return this.x;
+	},
+
+	setLeft: function(left) {
+		if (!this._fixW)
+			this.width -= left - this.x;
+		this.x = left;
+		this._fixX = 0;
+	},
+
+	getTop: function() {
+		return this.y;
+	},
+
+	setTop: function(top) {
+		if (!this._fixH)
+			this.height -= top - this.y;
+		this.y = top;
+		this._fixY = 0;
+	},
+
+	getRight: function() {
+		return this.x + this.width;
+	},
+
+	setRight: function(right) {
+		if (this._fixX !== undefined && this._fixX !== 1)
+			this._fixW = 0;
+		if (this._fixW)
+			this.x = right - this.width;
+		else
+			this.width = right - this.x;
+		this._fixX = 1;
+	},
+
+	getBottom: function() {
+		return this.y + this.height;
+	},
+
+	setBottom: function(bottom) {
+		if (this._fixY !== undefined && this._fixY !== 1)
+			this._fixH = 0;
+		if (this._fixH)
+			this.y = bottom - this.height;
+		else
+			this.height = bottom - this.y;
+		this._fixY = 1;
+	},
+
+	getCenterX: function() {
+		return this.x + this.width * 0.5;
+	},
+
+	setCenterX: function(x) {
+		this.x = x - this.width * 0.5;
+		this._fixX = 0.5;
+	},
+
+	getCenterY: function() {
+		return this.y + this.height * 0.5;
+	},
+
+	setCenterY: function(y) {
+		this.y = y - this.height * 0.5;
+		this._fixY = 0.5;
+	},
+
+	getCenter: function(_dontLink) {
+		var ctor = _dontLink ? Point : LinkedPoint;
+		return new ctor(this.getCenterX(), this.getCenterY(), this, 'setCenter');
+	},
+
+	setCenter: function() {
+		var point = Point.read(arguments);
+		this.setCenterX(point.x);
+		this.setCenterY(point.y);
+		return this;
+	},
+
+	getArea: function() {
+		return this.width * this.height;
+	},
+
+	isEmpty: function() {
+		return this.width === 0 || this.height === 0;
+	},
+
+	contains: function(arg) {
+		return arg && arg.width !== undefined
+				|| (Array.isArray(arg) ? arg : arguments).length === 4
+				? this._containsRectangle(Rectangle.read(arguments))
+				: this._containsPoint(Point.read(arguments));
+	},
+
+	_containsPoint: function(point) {
+		var x = point.x,
+			y = point.y;
+		return x >= this.x && y >= this.y
+				&& x <= this.x + this.width
+				&& y <= this.y + this.height;
+	},
+
+	_containsRectangle: function(rect) {
+		var x = rect.x,
+			y = rect.y;
+		return x >= this.x && y >= this.y
+				&& x + rect.width <= this.x + this.width
+				&& y + rect.height <= this.y + this.height;
+	},
+
+	intersects: function() {
+		var rect = Rectangle.read(arguments);
+		return rect.x + rect.width > this.x
+				&& rect.y + rect.height > this.y
+				&& rect.x < this.x + this.width
+				&& rect.y < this.y + this.height;
+	},
+
+	touches: function() {
+		var rect = Rectangle.read(arguments);
+		return rect.x + rect.width >= this.x
+				&& rect.y + rect.height >= this.y
+				&& rect.x <= this.x + this.width
+				&& rect.y <= this.y + this.height;
+	},
+
+	intersect: function() {
+		var rect = Rectangle.read(arguments),
+			x1 = Math.max(this.x, rect.x),
+			y1 = Math.max(this.y, rect.y),
+			x2 = Math.min(this.x + this.width, rect.x + rect.width),
+			y2 = Math.min(this.y + this.height, rect.y + rect.height);
+		return new Rectangle(x1, y1, x2 - x1, y2 - y1);
+	},
+
+	unite: function() {
+		var rect = Rectangle.read(arguments),
+			x1 = Math.min(this.x, rect.x),
+			y1 = Math.min(this.y, rect.y),
+			x2 = Math.max(this.x + this.width, rect.x + rect.width),
+			y2 = Math.max(this.y + this.height, rect.y + rect.height);
+		return new Rectangle(x1, y1, x2 - x1, y2 - y1);
+	},
+
+	include: function() {
+		var point = Point.read(arguments);
+		var x1 = Math.min(this.x, point.x),
+			y1 = Math.min(this.y, point.y),
+			x2 = Math.max(this.x + this.width, point.x),
+			y2 = Math.max(this.y + this.height, point.y);
+		return new Rectangle(x1, y1, x2 - x1, y2 - y1);
+	},
+
+	expand: function() {
+		var amount = Size.read(arguments),
+			hor = amount.width,
+			ver = amount.height;
+		return new Rectangle(this.x - hor / 2, this.y - ver / 2,
+				this.width + hor, this.height + ver);
+	},
+
+	scale: function(hor, ver) {
+		return this.expand(this.width * hor - this.width,
+				this.height * (ver === undefined ? hor : ver) - this.height);
+	}
+}, Base.each([
+		['Top', 'Left'], ['Top', 'Right'],
+		['Bottom', 'Left'], ['Bottom', 'Right'],
+		['Left', 'Center'], ['Top', 'Center'],
+		['Right', 'Center'], ['Bottom', 'Center']
+	],
+	function(parts, index) {
+		var part = parts.join(''),
+			xFirst = /^[RL]/.test(part);
+		if (index >= 4)
+			parts[1] += xFirst ? 'Y' : 'X';
+		var x = parts[xFirst ? 0 : 1],
+			y = parts[xFirst ? 1 : 0],
+			getX = 'get' + x,
+			getY = 'get' + y,
+			setX = 'set' + x,
+			setY = 'set' + y,
+			get = 'get' + part,
+			set = 'set' + part;
+		this[get] = function(_dontLink) {
+			var ctor = _dontLink ? Point : LinkedPoint;
+			return new ctor(this[getX](), this[getY](), this, set);
+		};
+		this[set] = function() {
+			var point = Point.read(arguments);
+			this[setX](point.x);
+			this[setY](point.y);
+		};
+	}, {
+		beans: true
+	}
+));
+
+var LinkedRectangle = Rectangle.extend({
+	initialize: function Rectangle(x, y, width, height, owner, setter) {
+		this.set(x, y, width, height, true);
+		this._owner = owner;
+		this._setter = setter;
+	},
+
+	set: function(x, y, width, height, _dontNotify) {
+		this._x = x;
+		this._y = y;
+		this._width = width;
+		this._height = height;
+		if (!_dontNotify)
+			this._owner[this._setter](this);
+		return this;
+	}
+},
+new function() {
+	var proto = Rectangle.prototype;
+
+	return Base.each(['x', 'y', 'width', 'height'], function(key) {
+		var part = Base.capitalize(key),
+			internal = '_' + key;
+		this['get' + part] = function() {
+			return this[internal];
+		};
+
+		this['set' + part] = function(value) {
+			this[internal] = value;
+			if (!this._dontNotify)
+				this._owner[this._setter](this);
+		};
+	}, Base.each(['Point', 'Size', 'Center',
+			'Left', 'Top', 'Right', 'Bottom', 'CenterX', 'CenterY',
+			'TopLeft', 'TopRight', 'BottomLeft', 'BottomRight',
+			'LeftCenter', 'TopCenter', 'RightCenter', 'BottomCenter'],
+		function(key) {
+			var name = 'set' + key;
+			this[name] = function() {
+				this._dontNotify = true;
+				proto[name].apply(this, arguments);
+				this._dontNotify = false;
+				this._owner[this._setter](this);
+			};
+		}, {
+			isSelected: function() {
+				return this._owner._boundsSelected;
+			},
+
+			setSelected: function(selected) {
+				var owner = this._owner;
+				if (owner.setSelected) {
+					owner._boundsSelected = selected;
+					owner.setSelected(selected || owner._selectedSegmentState > 0);
+				}
+			}
+		})
+	);
+});
+
+var Matrix = Base.extend({
+	_class: 'Matrix',
+
+	initialize: function Matrix(arg) {
+		var count = arguments.length,
+			ok = true;
+		if (count === 6) {
+			this.set.apply(this, arguments);
+		} else if (count === 1) {
+			if (arg instanceof Matrix) {
+				this.set(arg._a, arg._c, arg._b, arg._d, arg._tx, arg._ty);
+			} else if (Array.isArray(arg)) {
+				this.set.apply(this, arg);
+			} else {
+				ok = false;
+			}
+		} else if (count === 0) {
+			this.reset();
+		} else {
+			ok = false;
+		}
+		if (!ok)
+			throw new Error('Unsupported matrix parameters');
+	},
+
+	set: function(a, c, b, d, tx, ty, _dontNotify) {
+		this._a = a;
+		this._c = c;
+		this._b = b;
+		this._d = d;
+		this._tx = tx;
+		this._ty = ty;
+		if (!_dontNotify)
+			this._changed();
+		return this;
+	},
+
+	_serialize: function(options) {
+		return Base.serialize(this.getValues(), options);
+	},
+
+	_changed: function() {
+		var owner = this._owner;
+		if (owner) {
+			if (owner._applyMatrix) {
+				owner.transform(null, true);
+			} else {
+				owner._changed(9);
+			}
+		}
+	},
+
+	clone: function() {
+		return new Matrix(this._a, this._c, this._b, this._d,
+				this._tx, this._ty);
+	},
+
+	equals: function(mx) {
+		return mx === this || mx && this._a === mx._a && this._b === mx._b
+				&& this._c === mx._c && this._d === mx._d
+				&& this._tx === mx._tx && this._ty === mx._ty
+				|| false;
+	},
+
+	toString: function() {
+		var f = Formatter.instance;
+		return '[[' + [f.number(this._a), f.number(this._b),
+					f.number(this._tx)].join(', ') + '], ['
+				+ [f.number(this._c), f.number(this._d),
+					f.number(this._ty)].join(', ') + ']]';
+	},
+
+	reset: function(_dontNotify) {
+		this._a = this._d = 1;
+		this._c = this._b = this._tx = this._ty = 0;
+		if (!_dontNotify)
+			this._changed();
+		return this;
+	},
+
+	apply: function(recursively, _setApplyMatrix) {
+		var owner = this._owner;
+		if (owner) {
+			owner.transform(null, true, Base.pick(recursively, true),
+					_setApplyMatrix);
+			return this.isIdentity();
+		}
+		return false;
+	},
+
+	translate: function() {
+		var point = Point.read(arguments),
+			x = point.x,
+			y = point.y;
+		this._tx += x * this._a + y * this._b;
+		this._ty += x * this._c + y * this._d;
+		this._changed();
+		return this;
+	},
+
+	scale: function() {
+		var scale = Point.read(arguments),
+			center = Point.read(arguments, 0, { readNull: true });
+		if (center)
+			this.translate(center);
+		this._a *= scale.x;
+		this._c *= scale.x;
+		this._b *= scale.y;
+		this._d *= scale.y;
+		if (center)
+			this.translate(center.negate());
+		this._changed();
+		return this;
+	},
+
+	rotate: function(angle ) {
+		angle *= Math.PI / 180;
+		var center = Point.read(arguments, 1),
+			x = center.x,
+			y = center.y,
+			cos = Math.cos(angle),
+			sin = Math.sin(angle),
+			tx = x - x * cos + y * sin,
+			ty = y - x * sin - y * cos,
+			a = this._a,
+			b = this._b,
+			c = this._c,
+			d = this._d;
+		this._a = cos * a + sin * b;
+		this._b = -sin * a + cos * b;
+		this._c = cos * c + sin * d;
+		this._d = -sin * c + cos * d;
+		this._tx += tx * a + ty * b;
+		this._ty += tx * c + ty * d;
+		this._changed();
+		return this;
+	},
+
+	shear: function() {
+		var shear = Point.read(arguments),
+			center = Point.read(arguments, 0, { readNull: true });
+		if (center)
+			this.translate(center);
+		var a = this._a,
+			c = this._c;
+		this._a += shear.y * this._b;
+		this._c += shear.y * this._d;
+		this._b += shear.x * a;
+		this._d += shear.x * c;
+		if (center)
+			this.translate(center.negate());
+		this._changed();
+		return this;
+	},
+
+	skew: function() {
+		var skew = Point.read(arguments),
+			center = Point.read(arguments, 0, { readNull: true }),
+			toRadians = Math.PI / 180,
+			shear = new Point(Math.tan(skew.x * toRadians),
+				Math.tan(skew.y * toRadians));
+		return this.shear(shear, center);
+	},
+
+	concatenate: function(mx) {
+		var a1 = this._a,
+			b1 = this._b,
+			c1 = this._c,
+			d1 = this._d,
+			a2 = mx._a,
+			b2 = mx._b,
+			c2 = mx._c,
+			d2 = mx._d,
+			tx2 = mx._tx,
+			ty2 = mx._ty;
+		this._a = a2 * a1 + c2 * b1;
+		this._b = b2 * a1 + d2 * b1;
+		this._c = a2 * c1 + c2 * d1;
+		this._d = b2 * c1 + d2 * d1;
+		this._tx += tx2 * a1 + ty2 * b1;
+		this._ty += tx2 * c1 + ty2 * d1;
+		this._changed();
+		return this;
+	},
+
+	preConcatenate: function(mx) {
+		var a1 = this._a,
+			b1 = this._b,
+			c1 = this._c,
+			d1 = this._d,
+			tx1 = this._tx,
+			ty1 = this._ty,
+			a2 = mx._a,
+			b2 = mx._b,
+			c2 = mx._c,
+			d2 = mx._d,
+			tx2 = mx._tx,
+			ty2 = mx._ty;
+		this._a = a2 * a1 + b2 * c1;
+		this._b = a2 * b1 + b2 * d1;
+		this._c = c2 * a1 + d2 * c1;
+		this._d = c2 * b1 + d2 * d1;
+		this._tx = a2 * tx1 + b2 * ty1 + tx2;
+		this._ty = c2 * tx1 + d2 * ty1 + ty2;
+		this._changed();
+		return this;
+	},
+
+	chain: function(mx) {
+		var a1 = this._a,
+			b1 = this._b,
+			c1 = this._c,
+			d1 = this._d,
+			tx1 = this._tx,
+			ty1 = this._ty,
+			a2 = mx._a,
+			b2 = mx._b,
+			c2 = mx._c,
+			d2 = mx._d,
+			tx2 = mx._tx,
+			ty2 = mx._ty;
+		return new Matrix(
+				a2 * a1 + c2 * b1,
+				a2 * c1 + c2 * d1,
+				b2 * a1 + d2 * b1,
+				b2 * c1 + d2 * d1,
+				tx1 + tx2 * a1 + ty2 * b1,
+				ty1 + tx2 * c1 + ty2 * d1);
+	},
+
+	isIdentity: function() {
+		return this._a === 1 && this._c === 0 && this._b === 0 && this._d === 1
+				&& this._tx === 0 && this._ty === 0;
+	},
+
+	orNullIfIdentity: function() {
+		return this.isIdentity() ? null : this;
+	},
+
+	isInvertible: function() {
+		return !!this._getDeterminant();
+	},
+
+	isSingular: function() {
+		return !this._getDeterminant();
+	},
+
+	transform: function( src, dst, count) {
+		return arguments.length < 3
+			? this._transformPoint(Point.read(arguments))
+			: this._transformCoordinates(src, dst, count);
+	},
+
+	_transformPoint: function(point, dest, _dontNotify) {
+		var x = point.x,
+			y = point.y;
+		if (!dest)
+			dest = new Point();
+		return dest.set(
+			x * this._a + y * this._b + this._tx,
+			x * this._c + y * this._d + this._ty,
+			_dontNotify
+		);
+	},
+
+	_transformCoordinates: function(src, dst, count) {
+		var i = 0,
+			j = 0,
+			max = 2 * count;
+		while (i < max) {
+			var x = src[i++],
+				y = src[i++];
+			dst[j++] = x * this._a + y * this._b + this._tx;
+			dst[j++] = x * this._c + y * this._d + this._ty;
+		}
+		return dst;
+	},
+
+	_transformCorners: function(rect) {
+		var x1 = rect.x,
+			y1 = rect.y,
+			x2 = x1 + rect.width,
+			y2 = y1 + rect.height,
+			coords = [ x1, y1, x2, y1, x2, y2, x1, y2 ];
+		return this._transformCoordinates(coords, coords, 4);
+	},
+
+	_transformBounds: function(bounds, dest, _dontNotify) {
+		var coords = this._transformCorners(bounds),
+			min = coords.slice(0, 2),
+			max = min.slice();
+		for (var i = 2; i < 8; i++) {
+			var val = coords[i],
+				j = i & 1;
+			if (val < min[j])
+				min[j] = val;
+			else if (val > max[j])
+				max[j] = val;
+		}
+		if (!dest)
+			dest = new Rectangle();
+		return dest.set(min[0], min[1], max[0] - min[0], max[1] - min[1],
+				_dontNotify);
+	},
+
+	inverseTransform: function() {
+		return this._inverseTransform(Point.read(arguments));
+	},
+
+	_getDeterminant: function() {
+		var det = this._a * this._d - this._b * this._c;
+		return isFinite(det) && !Numerical.isZero(det)
+				&& isFinite(this._tx) && isFinite(this._ty)
+				? det : null;
+	},
+
+	_inverseTransform: function(point, dest, _dontNotify) {
+		var det = this._getDeterminant();
+		if (!det)
+			return null;
+		var x = point.x - this._tx,
+			y = point.y - this._ty;
+		if (!dest)
+			dest = new Point();
+		return dest.set(
+			(x * this._d - y * this._b) / det,
+			(y * this._a - x * this._c) / det,
+			_dontNotify
+		);
+	},
+
+	decompose: function() {
+		var a = this._a, b = this._b, c = this._c, d = this._d;
+		if (Numerical.isZero(a * d - b * c))
+			return null;
+
+		var scaleX = Math.sqrt(a * a + b * b);
+		a /= scaleX;
+		b /= scaleX;
+
+		var shear = a * c + b * d;
+		c -= a * shear;
+		d -= b * shear;
+
+		var scaleY = Math.sqrt(c * c + d * d);
+		c /= scaleY;
+		d /= scaleY;
+		shear /= scaleY;
+
+		if (a * d < b * c) {
+			a = -a;
+			b = -b;
+			shear = -shear;
+			scaleX = -scaleX;
+		}
+
+		return {
+			scaling: new Point(scaleX, scaleY),
+			rotation: -Math.atan2(b, a) * 180 / Math.PI,
+			shearing: shear
+		};
+	},
+
+	getValues: function() {
+		return [ this._a, this._c, this._b, this._d, this._tx, this._ty ];
+	},
+
+	getTranslation: function() {
+		return new Point(this._tx, this._ty);
+	},
+
+	getScaling: function() {
+		return (this.decompose() || {}).scaling;
+	},
+
+	getRotation: function() {
+		return (this.decompose() || {}).rotation;
+	},
+
+	inverted: function() {
+		var det = this._getDeterminant();
+		return det && new Matrix(
+				this._d / det,
+				-this._c / det,
+				-this._b / det,
+				this._a / det,
+				(this._b * this._ty - this._d * this._tx) / det,
+				(this._c * this._tx - this._a * this._ty) / det);
+	},
+
+	shiftless: function() {
+		return new Matrix(this._a, this._c, this._b, this._d, 0, 0);
+	},
+
+	applyToContext: function(ctx) {
+		if (!this.isIdentity()) {
+			ctx.transform(this._a, this._c, this._b, this._d,
+					this._tx, this._ty);
+		}
+	}
+}, Base.each(['a', 'c', 'b', 'd', 'tx', 'ty'], function(key) {
+	var part = Base.capitalize(key),
+		prop = '_' + key;
+	this['get' + part] = function() {
+		return this[prop];
+	};
+	this['set' + part] = function(value) {
+		this[prop] = value;
+		this._changed();
+	};
+}, {}));
+
+var Line = Base.extend({
+	_class: 'Line',
+
+	initialize: function Line(arg0, arg1, arg2, arg3, arg4) {
+		var asVector = false;
+		if (arguments.length >= 4) {
+			this._px = arg0;
+			this._py = arg1;
+			this._vx = arg2;
+			this._vy = arg3;
+			asVector = arg4;
+		} else {
+			this._px = arg0.x;
+			this._py = arg0.y;
+			this._vx = arg1.x;
+			this._vy = arg1.y;
+			asVector = arg2;
+		}
+		if (!asVector) {
+			this._vx -= this._px;
+			this._vy -= this._py;
+		}
+	},
+
+	getPoint: function() {
+		return new Point(this._px, this._py);
+	},
+
+	getVector: function() {
+		return new Point(this._vx, this._vy);
+	},
+
+	getLength: function() {
+		return this.getVector().getLength();
+	},
+
+	intersect: function(line, isInfinite) {
+		return Line.intersect(
+				this._px, this._py, this._vx, this._vy,
+				line._px, line._py, line._vx, line._vy,
+				true, isInfinite);
+	},
+
+	getSide: function(point, isInfinite) {
+		return Line.getSide(
+				this._px, this._py, this._vx, this._vy,
+				point.x, point.y, true, isInfinite);
+	},
+
+	getDistance: function(point) {
+		return Math.abs(Line.getSignedDistance(
+				this._px, this._py, this._vx, this._vy,
+				point.x, point.y, true));
+	},
+
+	isCollinear: function(line) {
+		return Point.isCollinear(this._vx, this._vy, line._vx, line._vy);
+	},
+
+	isOrthogonal: function(line) {
+		return Point.isOrthogonal(this._vx, this._vy, line._vx, line._vy);
+	},
+
+	statics: {
+		intersect: function(p1x, p1y, v1x, v1y, p2x, p2y, v2x, v2y, asVector,
+				isInfinite) {
+			if (!asVector) {
+				v1x -= p1x;
+				v1y -= p1y;
+				v2x -= p2x;
+				v2y -= p2y;
+			}
+			var cross = v1x * v2y - v1y * v2x;
+			if (!Numerical.isZero(cross)) {
+				var dx = p1x - p2x,
+					dy = p1y - p2y,
+					u1 = (v2x * dy - v2y * dx) / cross,
+					u2 = (v1x * dy - v1y * dx) / cross,
+					epsilon = 1e-12,
+					uMin = -epsilon,
+					uMax = 1 + epsilon;
+				if (isInfinite
+						|| uMin < u1 && u1 < uMax && uMin < u2 && u2 < uMax) {
+					if (!isInfinite) {
+						u1 = u1 <= 0 ? 0 : u1 >= 1 ? 1 : u1;
+					}
+					return new Point(
+							p1x + u1 * v1x,
+							p1y + u1 * v1y);
+				}
+			}
+		},
+
+		getSide: function(px, py, vx, vy, x, y, asVector, isInfinite) {
+			if (!asVector) {
+				vx -= px;
+				vy -= py;
+			}
+			var v2x = x - px,
+				v2y = y - py,
+				ccw = v2x * vy - v2y * vx;
+			if (ccw === 0 && !isInfinite) {
+				ccw = (v2x * vx + v2x * vx) / (vx * vx + vy * vy);
+				if (ccw >= 0 && ccw <= 1)
+					ccw = 0;
+			}
+			return ccw < 0 ? -1 : ccw > 0 ? 1 : 0;
+		},
+
+		getSignedDistance: function(px, py, vx, vy, x, y, asVector) {
+			if (!asVector) {
+				vx -= px;
+				vy -= py;
+			}
+			return vx === 0 ? vy > 0 ? x - px : px - x
+				 : vy === 0 ? vx < 0 ? y - py : py - y
+				 : ((x-px) * vy - (y-py) * vx) / Math.sqrt(vx * vx + vy * vy);
+		}
+	}
+});
+
+var Project = PaperScopeItem.extend({
+	_class: 'Project',
+	_list: 'projects',
+	_reference: 'project',
+
+	initialize: function Project(element) {
+		PaperScopeItem.call(this, true);
+		this._children = [];
+		this._namedChildren = {};
+		this._activeLayer = null;
+		this.symbols = [];
+		this._currentStyle = new Style(null, null, this);
+		this._view = View.create(this,
+				element || CanvasProvider.getCanvas(1, 1));
+		this._selectedItems = {};
+		this._selectedItemCount = 0;
+		this._updateVersion = 0;
+	},
+
+	_serialize: function(options, dictionary) {
+		return Base.serialize(this._children, options, true, dictionary);
+	},
+
+	_changed: function(flags, item) {
+		if (flags & 1) {
+			this._needsUpdate = true;
+		}
+		var changes = this._changes;
+		if (changes && item) {
+			var changesById = this._changesById,
+				id = item._id,
+				entry = changesById[id];
+			if (entry) {
+				entry.flags |= flags;
+			} else {
+				changes.push(changesById[id] = { item: item, flags: flags });
+			}
+		}
+	},
+
+	clear: function() {
+		var children = this._children;
+		for (var i = children.length - 1; i >= 0; i--)
+			children[i].remove();
+		this.symbols = [];
+	},
+
+	isEmpty: function() {
+		return this._children.length === 0;
+	},
+
+	remove: function remove() {
+		if (!remove.base.call(this))
+			return false;
+		if (this._view)
+			this._view.remove();
+		return true;
+	},
+
+	getView: function() {
+		return this._view;
+	},
+
+	getCurrentStyle: function() {
+		return this._currentStyle;
+	},
+
+	setCurrentStyle: function(style) {
+		this._currentStyle.initialize(style);
+	},
+
+	getIndex: function() {
+		return this._index;
+	},
+
+	getOptions: function() {
+		return this._scope.settings;
+	},
+
+	getLayers: function() {
+		return this._children;
+	},
+
+	getActiveLayer: function() {
+		return this._activeLayer || new Layer({ project: this });
+	},
+
+	getSelectedItems: function() {
+		var selectedItems = this._selectedItems,
+			items = [];
+		for (var id in selectedItems) {
+			var item = selectedItems[id];
+			if (item.isInserted()) {
+				items.push(item);
+			} else {
+				this._selectedItemCount--;
+				delete selectedItems[id];
+			}
+		}
+		return items;
+	},
+
+	_updateSelection: function(item) {
+		var id = item._id,
+			selectedItems = this._selectedItems;
+		if (item._selected) {
+			if (selectedItems[id] !== item) {
+				this._selectedItemCount++;
+				selectedItems[id] = item;
+			}
+		} else if (selectedItems[id] === item) {
+			this._selectedItemCount--;
+			delete selectedItems[id];
+		}
+	},
+
+	selectAll: function() {
+		var children = this._children;
+		for (var i = 0, l = children.length; i < l; i++)
+			children[i].setFullySelected(true);
+	},
+
+	deselectAll: function() {
+		var selectedItems = this._selectedItems;
+		for (var i in selectedItems)
+			selectedItems[i].setFullySelected(false);
+	},
+
+	hitTest: function() {
+		var point = Point.read(arguments),
+			options = HitResult.getOptions(Base.read(arguments)),
+			children = this._children;
+		for (var i = children.length - 1; i >= 0; i--) {
+			var res = children[i]._hitTest(point, options);
+			if (res) return res;
+		}
+		return null;
+	},
+
+	addLayer: function(layer) {
+		return this.insertLayer(undefined, layer);
+	},
+
+	insertLayer: function(index, layer) {
+		if (layer instanceof Layer) {
+			layer._remove(false, true);
+			Base.splice(this._children, [layer], index, 0);
+			layer._setProject(this, true);
+			if (this._changes)
+				layer._changed(5);
+			if (!this._activeLayer)
+				this._activeLayer = layer;
+		} else {
+			layer = null;
+		}
+		return layer;
+	},
+
+	_insertItem: function(index, item, _preserve, _created) {
+		item = this.insertLayer(index, item)
+				|| (this._activeLayer || this._insertItem(undefined,
+						new Layer(Item.NO_INSERT), true, true))
+						.insertChild(index, item, _preserve);
+		if (_created && item.activate)
+			item.activate();
+		return item;
+	},
+
+	getItems: function(match) {
+		return Item._getItems(this, match);
+	},
+
+	getItem: function(match) {
+		return Item._getItems(this, match, null, null, true)[0] || null;
+	},
+
+	importJSON: function(json) {
+		this.activate();
+		var layer = this._activeLayer;
+		return Base.importJSON(json, layer && layer.isEmpty() && layer);
+	},
+
+	removeOn: function(type) {
+		var sets = this._removeSets;
+		if (sets) {
+			if (type === 'mouseup')
+				sets.mousedrag = null;
+			var set = sets[type];
+			if (set) {
+				for (var id in set) {
+					var item = set[id];
+					for (var key in sets) {
+						var other = sets[key];
+						if (other && other != set)
+							delete other[item._id];
+					}
+					item.remove();
+				}
+				sets[type] = null;
+			}
+		}
+	},
+
+	draw: function(ctx, matrix, pixelRatio) {
+		this._updateVersion++;
+		ctx.save();
+		matrix.applyToContext(ctx);
+		var children = this._children,
+			param = new Base({
+				offset: new Point(0, 0),
+				pixelRatio: pixelRatio,
+				viewMatrix: matrix.isIdentity() ? null : matrix,
+				matrices: [new Matrix()],
+				updateMatrix: true
+			});
+		for (var i = 0, l = children.length; i < l; i++)
+			children[i].draw(ctx, param);
+		ctx.restore();
+
+		if (this._selectedItemCount > 0) {
+			ctx.save();
+			ctx.strokeWidth = 1;
+			var items = this._selectedItems,
+				size = this._scope.settings.handleSize,
+				version = this._updateVersion;
+			for (var id in items)
+				items[id]._drawSelection(ctx, matrix, size, items, version);
+			ctx.restore();
+		}
+	}
+});
+
+var Symbol = Base.extend({
+	_class: 'Symbol',
+
+	initialize: function Symbol(item, dontCenter) {
+		this._id = UID.get();
+		this.project = paper.project;
+		this.project.symbols.push(this);
+		if (item)
+			this.setDefinition(item, dontCenter);
+	},
+
+	_serialize: function(options, dictionary) {
+		return dictionary.add(this, function() {
+			return Base.serialize([this._class, this._definition],
+					options, false, dictionary);
+		});
+	},
+
+	_changed: function(flags) {
+		if (flags & 8)
+			Item._clearBoundsCache(this);
+		if (flags & 1)
+			this.project._changed(flags);
+	},
+
+	getDefinition: function() {
+		return this._definition;
+	},
+
+	setDefinition: function(item, _dontCenter) {
+		if (item._parentSymbol)
+			item = item.clone();
+		if (this._definition)
+			this._definition._parentSymbol = null;
+		this._definition = item;
+		item.remove();
+		item.setSelected(false);
+		if (!_dontCenter)
+			item.setPosition(new Point());
+		item._parentSymbol = this;
+		this._changed(9);
+	},
+
+	place: function(position) {
+		return new PlacedSymbol(this, position);
+	},
+
+	clone: function() {
+		return new Symbol(this._definition.clone(false));
+	},
+
+	equals: function(symbol) {
+		return symbol === this
+				|| symbol && this.definition.equals(symbol.definition)
+				|| false;
+	}
+});
+
+var Item = Base.extend(Emitter, {
+	statics: {
+		extend: function extend(src) {
+			if (src._serializeFields)
+				src._serializeFields = new Base(
+						this.prototype._serializeFields, src._serializeFields);
+			return extend.base.apply(this, arguments);
+		},
+
+		NO_INSERT: { insert: false }
+	},
+
+	_class: 'Item',
+	_applyMatrix: true,
+	_canApplyMatrix: true,
+	_canScaleStroke: false,
+	_boundsSelected: false,
+	_selectChildren: false,
+	_serializeFields: {
+		name: null,
+		applyMatrix: null,
+		matrix: new Matrix(),
+		pivot: null,
+		locked: false,
+		visible: true,
+		blendMode: 'normal',
+		opacity: 1,
+		guide: false,
+		selected: false,
+		clipMask: false,
+		data: {}
+	},
+
+	initialize: function Item() {
+	},
+
+	_initialize: function(props, point) {
+		var hasProps = props && Base.isPlainObject(props),
+			internal = hasProps && props.internal === true,
+			matrix = this._matrix = new Matrix(),
+			project = hasProps && props.project || paper.project;
+		this._id = internal ? null : UID.get();
+		this._parent = this._index = null;
+		this._applyMatrix = this._canApplyMatrix && paper.settings.applyMatrix;
+		if (point)
+			matrix.translate(point);
+		matrix._owner = this;
+		this._style = new Style(project._currentStyle, this, project);
+		if (internal || hasProps && props.insert === false) {
+			this._setProject(project);
+		} else {
+			(hasProps && props.parent || project)
+					._insertItem(undefined, this, true, true);
+		}
+		if (hasProps && props !== Item.NO_INSERT) {
+			this._set(props,
+				{ internal: true, insert: true, project: true, parent: true },
+				true);
+		}
+		return hasProps;
+	},
+
+	_events: Base.each(['onMouseDown', 'onMouseUp', 'onMouseDrag', 'onClick',
+			'onDoubleClick', 'onMouseMove', 'onMouseEnter', 'onMouseLeave'],
+		function(name) {
+			this[name] = {
+				install: function(type) {
+					this.getView()._countItemEvent(type, 1);
+				},
+
+				uninstall: function(type) {
+					this.getView()._countItemEvent(type, -1);
+				}
+			};
+		}, {
+			onFrame: {
+				install: function() {
+					this.getView()._animateItem(this, true);
+				},
+
+				uninstall: function() {
+					this.getView()._animateItem(this, false);
+				}
+			},
+
+			onLoad: {}
+		}
+	),
+
+	_serialize: function(options, dictionary) {
+		var props = {},
+			that = this;
+
+		function serialize(fields) {
+			for (var key in fields) {
+				var value = that[key];
+				if (!Base.equals(value, key === 'leading'
+						? fields.fontSize * 1.2 : fields[key])) {
+					props[key] = Base.serialize(value, options,
+							key !== 'data', dictionary);
+				}
+			}
+		}
+
+		serialize(this._serializeFields);
+		if (!(this instanceof Group))
+			serialize(this._style._defaults);
+		return [ this._class, props ];
+	},
+
+	_changed: function(flags) {
+		var symbol = this._parentSymbol,
+			cacheParent = this._parent || symbol,
+			project = this._project;
+		if (flags & 8) {
+			this._bounds = this._position = this._decomposed =
+					this._globalMatrix = undefined;
+		}
+		if (cacheParent
+				&& (flags & 40)) {
+			Item._clearBoundsCache(cacheParent);
+		}
+		if (flags & 2) {
+			Item._clearBoundsCache(this);
+		}
+		if (project)
+			project._changed(flags, this);
+		if (symbol)
+			symbol._changed(flags);
+	},
+
+	set: function(props) {
+		if (props)
+			this._set(props);
+		return this;
+	},
+
+	getId: function() {
+		return this._id;
+	},
+
+	getName: function() {
+		return this._name;
+	},
+
+	setName: function(name) {
+
+		if (this._name)
+			this._removeNamed();
+		if (name === (+name) + '')
+			throw new Error(
+					'Names consisting only of numbers are not supported.');
+		var owner = this._getOwner();
+		if (name && owner) {
+			var children = owner._children,
+				namedChildren = owner._namedChildren;
+			(namedChildren[name] = namedChildren[name] || []).push(this);
+			if (!(name in children))
+				children[name] = this;
+		}
+		this._name = name || undefined;
+		this._changed(128);
+	},
+
+	getStyle: function() {
+		return this._style;
+	},
+
+	setStyle: function(style) {
+		this.getStyle().set(style);
+	}
+}, Base.each(['locked', 'visible', 'blendMode', 'opacity', 'guide'],
+	function(name) {
+		var part = Base.capitalize(name),
+			name = '_' + name;
+		this['get' + part] = function() {
+			return this[name];
+		};
+		this['set' + part] = function(value) {
+			if (value != this[name]) {
+				this[name] = value;
+				this._changed(name === '_locked'
+						? 128 : 129);
+			}
+		};
+	},
+{}), {
+	beans: true,
+
+	_locked: false,
+
+	_visible: true,
+
+	_blendMode: 'normal',
+
+	_opacity: 1,
+
+	_guide: false,
+
+	isSelected: function() {
+		if (this._selectChildren) {
+			var children = this._children;
+			for (var i = 0, l = children.length; i < l; i++)
+				if (children[i].isSelected())
+					return true;
+		}
+		return this._selected;
+	},
+
+	setSelected: function(selected, noChildren) {
+		if (!noChildren && this._selectChildren) {
+			var children = this._children;
+			for (var i = 0, l = children.length; i < l; i++)
+				children[i].setSelected(selected);
+		}
+		if ((selected = !!selected) ^ this._selected) {
+			this._selected = selected;
+			var project = this._project;
+			if (project) {
+				project._updateSelection(this);
+				this._changed(129);
+			}
+		}
+	},
+
+	_selected: false,
+
+	isFullySelected: function() {
+		var children = this._children;
+		if (children && this._selected) {
+			for (var i = 0, l = children.length; i < l; i++)
+				if (!children[i].isFullySelected())
+					return false;
+			return true;
+		}
+		return this._selected;
+	},
+
+	setFullySelected: function(selected) {
+		var children = this._children;
+		if (children) {
+			for (var i = 0, l = children.length; i < l; i++)
+				children[i].setFullySelected(selected);
+		}
+		this.setSelected(selected, true);
+	},
+
+	isClipMask: function() {
+		return this._clipMask;
+	},
+
+	setClipMask: function(clipMask) {
+		if (this._clipMask != (clipMask = !!clipMask)) {
+			this._clipMask = clipMask;
+			if (clipMask) {
+				this.setFillColor(null);
+				this.setStrokeColor(null);
+			}
+			this._changed(129);
+			if (this._parent)
+				this._parent._changed(1024);
+		}
+	},
+
+	_clipMask: false,
+
+	getData: function() {
+		if (!this._data)
+			this._data = {};
+		return this._data;
+	},
+
+	setData: function(data) {
+		this._data = data;
+	},
+
+	getPosition: function(_dontLink) {
+		var position = this._position,
+			ctor = _dontLink ? Point : LinkedPoint;
+		if (!position) {
+			var pivot = this._pivot;
+			position = this._position = pivot
+					? this._matrix._transformPoint(pivot)
+					: this.getBounds().getCenter(true);
+		}
+		return new ctor(position.x, position.y, this, 'setPosition');
+	},
+
+	setPosition: function() {
+		this.translate(Point.read(arguments).subtract(this.getPosition(true)));
+	},
+
+	getPivot: function(_dontLink) {
+		var pivot = this._pivot;
+		if (pivot) {
+			var ctor = _dontLink ? Point : LinkedPoint;
+			pivot = new ctor(pivot.x, pivot.y, this, 'setPivot');
+		}
+		return pivot;
+	},
+
+	setPivot: function() {
+		this._pivot = Point.read(arguments, 0, { clone: true, readNull: true });
+		this._position = undefined;
+	},
+
+	_pivot: null,
+}, Base.each(['bounds', 'strokeBounds', 'handleBounds', 'roughBounds',
+		'internalBounds', 'internalHandleBounds', 'internalRoughBounds'],
+	function(key) {
+		var getter = 'get' + Base.capitalize(key),
+			match = key.match(/^internal(.*)$/),
+			internalGetter = match ? 'get' + match[1] : null;
+		this[getter] = function(_matrix) {
+			var boundsGetter = this._boundsGetter,
+				name = !internalGetter && (typeof boundsGetter === 'string'
+						? boundsGetter : boundsGetter && boundsGetter[getter])
+						|| getter,
+				bounds = this._getCachedBounds(name, _matrix, this,
+						internalGetter);
+			return key === 'bounds'
+					? new LinkedRectangle(bounds.x, bounds.y, bounds.width,
+							bounds.height, this, 'setBounds')
+					: bounds;
+		};
+	},
+{
+	beans: true,
+
+	_getBounds: function(getter, matrix, cacheItem) {
+		var children = this._children;
+		if (!children || children.length === 0)
+			return new Rectangle();
+		Item._updateBoundsCache(this, cacheItem);
+		var x1 = Infinity,
+			x2 = -x1,
+			y1 = x1,
+			y2 = x2;
+		for (var i = 0, l = children.length; i < l; i++) {
+			var child = children[i];
+			if (child._visible && !child.isEmpty()) {
+				var rect = child._getCachedBounds(getter,
+						matrix && matrix.chain(child._matrix), cacheItem);
+				x1 = Math.min(rect.x, x1);
+				y1 = Math.min(rect.y, y1);
+				x2 = Math.max(rect.x + rect.width, x2);
+				y2 = Math.max(rect.y + rect.height, y2);
+			}
+		}
+		return isFinite(x1)
+				? new Rectangle(x1, y1, x2 - x1, y2 - y1)
+				: new Rectangle();
+	},
+
+	setBounds: function() {
+		var rect = Rectangle.read(arguments),
+			bounds = this.getBounds(),
+			matrix = new Matrix(),
+			center = rect.getCenter();
+		matrix.translate(center);
+		if (rect.width != bounds.width || rect.height != bounds.height) {
+			matrix.scale(
+					bounds.width !== 0 ? rect.width / bounds.width : 1,
+					bounds.height !== 0 ? rect.height / bounds.height : 1);
+		}
+		center = bounds.getCenter();
+		matrix.translate(-center.x, -center.y);
+		this.transform(matrix);
+	},
+
+	_getCachedBounds: function(getter, matrix, cacheItem, internalGetter) {
+		matrix = matrix && matrix.orNullIfIdentity();
+		var _matrix = internalGetter ? null : this._matrix.orNullIfIdentity(),
+			cache = (!matrix || matrix.equals(_matrix)) && getter;
+		Item._updateBoundsCache(this._parent || this._parentSymbol, cacheItem);
+		if (cache && this._bounds && this._bounds[cache])
+			return this._bounds[cache].clone();
+		var bounds = this._getBounds(internalGetter || getter,
+				matrix || _matrix, cacheItem);
+		if (cache) {
+			if (!this._bounds)
+				this._bounds = {};
+			var cached = this._bounds[cache] = bounds.clone();
+			cached._internal = !!internalGetter;
+		}
+		return bounds;
+	},
+
+	statics: {
+		_updateBoundsCache: function(parent, item) {
+			if (parent) {
+				var id = item._id,
+					ref = parent._boundsCache = parent._boundsCache || {
+						ids: {},
+						list: []
+					};
+				if (!ref.ids[id]) {
+					ref.list.push(item);
+					ref.ids[id] = item;
+				}
+			}
+		},
+
+		_clearBoundsCache: function(item) {
+			var cache = item._boundsCache;
+			if (cache) {
+				item._bounds = item._position = item._boundsCache = undefined;
+				for (var i = 0, list = cache.list, l = list.length; i < l; i++){
+					var other = list[i];
+					if (other !== item) {
+						other._bounds = other._position = undefined;
+						if (other._boundsCache)
+							Item._clearBoundsCache(other);
+					}
+				}
+			}
+		}
+	}
+
+}), {
+	beans: true,
+
+	_decompose: function() {
+		return this._decomposed = this._matrix.decompose();
+	},
+
+	getRotation: function() {
+		var decomposed = this._decomposed || this._decompose();
+		return decomposed && decomposed.rotation;
+	},
+
+	setRotation: function(rotation) {
+		var current = this.getRotation();
+		if (current != null && rotation != null) {
+			var decomposed = this._decomposed;
+			this.rotate(rotation - current);
+			decomposed.rotation = rotation;
+			this._decomposed = decomposed;
+		}
+	},
+
+	getScaling: function(_dontLink) {
+		var decomposed = this._decomposed || this._decompose(),
+			scaling = decomposed && decomposed.scaling,
+			ctor = _dontLink ? Point : LinkedPoint;
+		return scaling && new ctor(scaling.x, scaling.y, this, 'setScaling');
+	},
+
+	setScaling: function() {
+		var current = this.getScaling();
+		if (current) {
+			var scaling = Point.read(arguments, 0, { clone: true }),
+				decomposed = this._decomposed;
+			this.scale(scaling.x / current.x, scaling.y / current.y);
+			decomposed.scaling = scaling;
+			this._decomposed = decomposed;
+		}
+	},
+
+	getMatrix: function() {
+		return this._matrix;
+	},
+
+	setMatrix: function() {
+		var matrix = this._matrix;
+		matrix.initialize.apply(matrix, arguments);
+	},
+
+	getGlobalMatrix: function(_dontClone) {
+		var matrix = this._globalMatrix,
+			updateVersion = this._project._updateVersion;
+		if (matrix && matrix._updateVersion !== updateVersion)
+			matrix = null;
+		if (!matrix) {
+			matrix = this._globalMatrix = this._matrix.clone();
+			var parent = this._parent;
+			if (parent)
+				matrix.preConcatenate(parent.getGlobalMatrix(true));
+			matrix._updateVersion = updateVersion;
+		}
+		return _dontClone ? matrix : matrix.clone();
+	},
+
+	getApplyMatrix: function() {
+		return this._applyMatrix;
+	},
+
+	setApplyMatrix: function(apply) {
+		if (this._applyMatrix = this._canApplyMatrix && !!apply)
+			this.transform(null, true);
+	},
+
+	getTransformContent: '#getApplyMatrix',
+	setTransformContent: '#setApplyMatrix',
+}, {
+	getProject: function() {
+		return this._project;
+	},
+
+	_setProject: function(project, installEvents) {
+		if (this._project !== project) {
+			if (this._project)
+				this._installEvents(false);
+			this._project = project;
+			var children = this._children;
+			for (var i = 0, l = children && children.length; i < l; i++)
+				children[i]._setProject(project);
+			installEvents = true;
+		}
+		if (installEvents)
+			this._installEvents(true);
+	},
+
+	getView: function() {
+		return this._project._view;
+	},
+
+	_installEvents: function _installEvents(install) {
+		_installEvents.base.call(this, install);
+		var children = this._children;
+		for (var i = 0, l = children && children.length; i < l; i++)
+			children[i]._installEvents(install);
+	},
+
+	getLayer: function() {
+		var parent = this;
+		while (parent = parent._parent) {
+			if (parent instanceof Layer)
+				return parent;
+		}
+		return null;
+	},
+
+	getParent: function() {
+		return this._parent;
+	},
+
+	setParent: function(item) {
+		return item.addChild(this);
+	},
+
+	_getOwner: '#getParent',
+
+	getChildren: function() {
+		return this._children;
+	},
+
+	setChildren: function(items, _preserve) {
+		this.removeChildren();
+		this.addChildren(items, _preserve);
+	},
+
+	getFirstChild: function() {
+		return this._children && this._children[0] || null;
+	},
+
+	getLastChild: function() {
+		return this._children && this._children[this._children.length - 1]
+				|| null;
+	},
+
+	getNextSibling: function() {
+		var owner = this._getOwner();
+		return owner && owner._children[this._index + 1] || null;
+	},
+
+	getPreviousSibling: function() {
+		var owner = this._getOwner();
+		return owner && owner._children[this._index - 1] || null;
+	},
+
+	getIndex: function() {
+		return this._index;
+	},
+
+	equals: function(item) {
+		return item === this || item && this._class === item._class
+				&& this._style.equals(item._style)
+				&& this._matrix.equals(item._matrix)
+				&& this._locked === item._locked
+				&& this._visible === item._visible
+				&& this._blendMode === item._blendMode
+				&& this._opacity === item._opacity
+				&& this._clipMask === item._clipMask
+				&& this._guide === item._guide
+				&& this._equals(item)
+				|| false;
+	},
+
+	_equals: function(item) {
+		return Base.equals(this._children, item._children);
+	},
+
+	clone: function(insert) {
+		var copy = new this.constructor(Item.NO_INSERT),
+			children = this._children;
+		if (children)
+			copy.copyAttributes(this);
+		copy.copyContent(this);
+		if (!children)
+			copy.copyAttributes(this);
+		if (insert === undefined || insert)
+			copy.insertAbove(this);
+		var name = this._name,
+			parent = this._parent;
+		if (name && parent) {
+			var children = parent._children,
+				orig = name,
+				i = 1;
+			while (children[name])
+				name = orig + ' ' + (i++);
+			if (name !== orig)
+				copy.setName(name);
+		}
+		return copy;
+	},
+
+	copyContent: function(source) {
+		var children = source._children;
+		for (var i = 0, l = children && children.length; i < l; i++) {
+			this.addChild(children[i].clone(false), true);
+		}
+	},
+
+	copyAttributes: function(source, excludeMatrix) {
+		this.setStyle(source._style);
+		var keys = ['_locked', '_visible', '_blendMode', '_opacity',
+				'_clipMask', '_guide'];
+		for (var i = 0, l = keys.length; i < l; i++) {
+			var key = keys[i];
+			if (source.hasOwnProperty(key))
+				this[key] = source[key];
+		}
+		if (!excludeMatrix)
+			this._matrix.initialize(source._matrix);
+		this.setApplyMatrix(source._applyMatrix);
+		this.setPivot(source._pivot);
+		this.setSelected(source._selected);
+		var data = source._data,
+			name = source._name;
+		this._data = data ? Base.clone(data) : null;
+		if (name)
+			this.setName(name);
+	},
+
+	rasterize: function(resolution, insert) {
+		var bounds = this.getStrokeBounds(),
+			scale = (resolution || this.getView().getResolution()) / 72,
+			topLeft = bounds.getTopLeft().floor(),
+			bottomRight = bounds.getBottomRight().ceil(),
+			size = new Size(bottomRight.subtract(topLeft)),
+			raster = new Raster(Item.NO_INSERT);
+		if (!size.isZero()) {
+			var canvas = CanvasProvider.getCanvas(size.multiply(scale)),
+				ctx = canvas.getContext('2d'),
+				matrix = new Matrix().scale(scale).translate(topLeft.negate());
+			ctx.save();
+			matrix.applyToContext(ctx);
+			this.draw(ctx, new Base({ matrices: [matrix] }));
+			ctx.restore();
+			raster.setCanvas(canvas);
+		}
+		raster.transform(new Matrix().translate(topLeft.add(size.divide(2)))
+				.scale(1 / scale));
+		if (insert === undefined || insert)
+			raster.insertAbove(this);
+		return raster;
+	},
+
+	contains: function() {
+		return !!this._contains(
+				this._matrix._inverseTransform(Point.read(arguments)));
+	},
+
+	_contains: function(point) {
+		var children = this._children;
+		if (children) {
+			for (var i = children.length - 1; i >= 0; i--) {
+				if (children[i].contains(point))
+					return true;
+			}
+			return false;
+		}
+		return point.isInside(this.getInternalBounds());
+	},
+
+	isInside: function() {
+		return Rectangle.read(arguments).contains(this.getBounds());
+	},
+
+	_asPathItem: function() {
+		return new Path.Rectangle({
+			rectangle: this.getInternalBounds(),
+			matrix: this._matrix,
+			insert: false,
+		});
+	},
+
+	intersects: function(item, _matrix) {
+		if (!(item instanceof Item))
+			return false;
+		return this._asPathItem().getIntersections(item._asPathItem(), null,
+				_matrix, true).length > 0;
+	},
+
+	hitTest: function() {
+		return this._hitTest(
+				Point.read(arguments),
+				HitResult.getOptions(Base.read(arguments)));
+	},
+
+	_hitTest: function(point, options) {
+		if (this._locked || !this._visible || this._guide && !options.guides
+				|| this.isEmpty())
+			return null;
+
+		var matrix = this._matrix,
+			parentTotalMatrix = options._totalMatrix,
+			view = this.getView(),
+			totalMatrix = options._totalMatrix = parentTotalMatrix
+					? parentTotalMatrix.chain(matrix)
+					: this.getGlobalMatrix().preConcatenate(view._matrix),
+			tolerancePadding = options._tolerancePadding = new Size(
+						Path._getPenPadding(1, totalMatrix.inverted())
+					).multiply(
+						Math.max(options.tolerance, 1e-6)
+					);
+		point = matrix._inverseTransform(point);
+		if (!point || !this._children && !this.getInternalRoughBounds()
+				.expand(tolerancePadding.multiply(2))._containsPoint(point))
+			return null;
+		var checkSelf = !(options.guides && !this._guide
+				|| options.selected && !this._selected
+				|| options.type && options.type !== Base.hyphenate(this._class)
+				|| options.class && !(this instanceof options.class)),
+			that = this,
+			res;
+
+		function checkBounds(type, part) {
+			var pt = bounds['get' + part]();
+			if (point.subtract(pt).divide(tolerancePadding).length <= 1)
+				return new HitResult(type, that,
+						{ name: Base.hyphenate(part), point: pt });
+		}
+
+		if (checkSelf && (options.center || options.bounds) && this._parent) {
+			var bounds = this.getInternalBounds();
+			if (options.center)
+				res = checkBounds('center', 'Center');
+			if (!res && options.bounds) {
+				var points = [
+					'TopLeft', 'TopRight', 'BottomLeft', 'BottomRight',
+					'LeftCenter', 'TopCenter', 'RightCenter', 'BottomCenter'
+				];
+				for (var i = 0; i < 8 && !res; i++)
+					res = checkBounds('bounds', points[i]);
+			}
+		}
+
+		var children = !res && this._children;
+		if (children) {
+			var opts = this._getChildHitTestOptions(options);
+			for (var i = children.length - 1; i >= 0 && !res; i--)
+				res = children[i]._hitTest(point, opts);
+		}
+		if (!res && checkSelf)
+			res = this._hitTestSelf(point, options);
+		if (res && res.point)
+			res.point = matrix.transform(res.point);
+		options._totalMatrix = parentTotalMatrix;
+		return res;
+	},
+
+	_getChildHitTestOptions: function(options) {
+		return options;
+	},
+
+	_hitTestSelf: function(point, options) {
+		if (options.fill && this.hasFill() && this._contains(point))
+			return new HitResult('fill', this);
+	},
+
+	matches: function(name, compare) {
+		function matchObject(obj1, obj2) {
+			for (var i in obj1) {
+				if (obj1.hasOwnProperty(i)) {
+					var val1 = obj1[i],
+						val2 = obj2[i];
+					if (Base.isPlainObject(val1) && Base.isPlainObject(val2)) {
+						if (!matchObject(val1, val2))
+							return false;
+					} else if (!Base.equals(val1, val2)) {
+						return false;
+					}
+				}
+			}
+			return true;
+		}
+		var type = typeof name;
+		if (type === 'object') {
+			for (var key in name) {
+				if (name.hasOwnProperty(key) && !this.matches(key, name[key]))
+					return false;
+			}
+			return true;
+		} else if (type === 'function') {
+			return name(this);
+		} else if (name === 'match') {
+			return compare(this);
+		} else {
+			var value = /^(empty|editable)$/.test(name)
+					? this['is' + Base.capitalize(name)]()
+					: name === 'type'
+						? Base.hyphenate(this._class)
+						: this[name];
+			if (name === 'class') {
+				if (typeof compare === 'function')
+					return this instanceof compare;
+				value = this._class;
+			}
+			if (compare instanceof RegExp) {
+				return compare.test(value);
+			} else if (typeof compare === 'function') {
+				return !!compare(value);
+			} else if (Base.isPlainObject(compare)) {
+				return matchObject(compare, value);
+			}
+			return Base.equals(value, compare);
+		}
+	},
+
+	getItems: function(match) {
+		return Item._getItems(this, match, this._matrix);
+	},
+
+	getItem: function(match) {
+		return Item._getItems(this, match, this._matrix, null, true)[0] || null;
+	},
+
+	statics: {
+		_getItems: function _getItems(item, match, matrix, param, firstOnly) {
+			if (!param) {
+				var obj = typeof match === 'object' && match,
+					overlapping = obj && obj.overlapping,
+					inside = obj && obj.inside,
+					bounds = overlapping || inside,
+					rect = bounds && Rectangle.read([bounds]);
+				param = {
+					items: [],
+					recursive: obj && obj.recursive !== false,
+					inside: !!inside,
+					overlapping: !!overlapping,
+					rect: rect,
+					path: overlapping && new Path.Rectangle({
+						rectangle: rect,
+						insert: false
+					})
+				};
+				if (obj) {
+					match = Base.set({}, match, {
+						recursive: true, inside: true, overlapping: true
+					});
+				}
+			}
+			var children = item._children,
+				items = param.items,
+				rect = param.rect;
+			matrix = rect && (matrix || new Matrix());
+			for (var i = 0, l = children && children.length; i < l; i++) {
+				var child = children[i],
+					childMatrix = matrix && matrix.chain(child._matrix),
+					add = true;
+				if (rect) {
+					var bounds = child.getBounds(childMatrix);
+					if (!rect.intersects(bounds))
+						continue;
+					if (!(rect.contains(bounds)
+							|| param.overlapping && (bounds.contains(rect)
+								|| param.path.intersects(child, childMatrix))))
+						add = false;
+				}
+				if (add && child.matches(match)) {
+					items.push(child);
+					if (firstOnly)
+						break;
+				}
+				if (param.recursive !== false) {
+					_getItems(child, match, childMatrix, param, firstOnly);
+				}
+				if (firstOnly && items.length > 0)
+					break;
+			}
+			return items;
+		}
+	}
+}, {
+
+	importJSON: function(json) {
+		var res = Base.importJSON(json, this);
+		return res !== this ? this.addChild(res) : res;
+	},
+
+	addChild: function(item, _preserve) {
+		return this.insertChild(undefined, item, _preserve);
+	},
+
+	insertChild: function(index, item, _preserve) {
+		var res = item ? this.insertChildren(index, [item], _preserve) : null;
+		return res && res[0];
+	},
+
+	addChildren: function(items, _preserve) {
+		return this.insertChildren(this._children.length, items, _preserve);
+	},
+
+	insertChildren: function(index, items, _preserve, _proto) {
+		var children = this._children;
+		if (children && items && items.length > 0) {
+			items = Array.prototype.slice.apply(items);
+			for (var i = items.length - 1; i >= 0; i--) {
+				var item = items[i];
+				if (_proto && !(item instanceof _proto)) {
+					items.splice(i, 1);
+				} else {
+					var shift = item._parent === this && item._index < index;
+					if (item._remove(false, true) && shift)
+						index--;
+				}
+			}
+			Base.splice(children, items, index, 0);
+			var project = this._project,
+				notifySelf = project && project._changes;
+			for (var i = 0, l = items.length; i < l; i++) {
+				var item = items[i];
+				item._parent = this;
+				item._setProject(this._project, true);
+				if (item._name)
+					item.setName(item._name);
+				if (notifySelf)
+					this._changed(5);
+			}
+			this._changed(11);
+		} else {
+			items = null;
+		}
+		return items;
+	},
+
+	_insertItem: '#insertChild',
+
+	insertAbove: function(item, _preserve) {
+		var owner = item && item._getOwner();
+		return owner ? owner._insertItem(item._index + 1, this, _preserve)
+				: null;
+	},
+
+	insertBelow: function(item, _preserve) {
+		var owner = item && item._getOwner();
+		return owner ? owner._insertItem(item._index, this, _preserve) : null;
+	},
+
+	sendToBack: function() {
+		var owner = this._getOwner();
+		return owner ? owner._insertItem(0, this) : null;
+	},
+
+	bringToFront: function() {
+		var owner = this._getOwner();
+		return owner ? owner._insertItem(undefined, this) : null;
+	},
+
+	appendTop: '#addChild',
+
+	appendBottom: function(item) {
+		return this.insertChild(0, item);
+	},
+
+	moveAbove: '#insertAbove',
+
+	moveBelow: '#insertBelow',
+
+	copyTo: function(owner) {
+		return owner._insertItem(undefined, this.clone(false));
+	},
+
+	reduce: function(options) {
+		var children = this._children;
+		if (children && children.length === 1) {
+			var child = children[0].reduce(options);
+			if (this._parent) {
+				child.insertAbove(this);
+				this.remove();
+			} else {
+				child.remove();
+			}
+			child.copyAttributes(this);
+			return child;
+		}
+		return this;
+	},
+
+	_removeNamed: function() {
+		var owner = this._getOwner();
+		if (owner) {
+			var children = owner._children,
+				namedChildren = owner._namedChildren,
+				name = this._name,
+				namedArray = namedChildren[name],
+				index = namedArray ? namedArray.indexOf(this) : -1;
+			if (index !== -1) {
+				if (children[name] == this)
+					delete children[name];
+				namedArray.splice(index, 1);
+				if (namedArray.length) {
+					children[name] = namedArray[0];
+				} else {
+					delete namedChildren[name];
+				}
+			}
+		}
+	},
+
+	_remove: function(notifySelf, notifyParent) {
+		var owner = this._getOwner(),
+			project = this._project,
+			index = this._index;
+		if (owner && index != null) {
+			if (project._activeLayer === this)
+				project._activeLayer = this.getNextSibling()
+						|| this.getPreviousSibling();
+			if (this._name)
+				this._removeNamed();
+			Base.splice(owner._children, null, index, 1);
+			this._installEvents(false);
+			if (notifySelf && project._changes)
+				this._changed(5);
+			if (notifyParent)
+				owner._changed(11, this);
+			this._parent = null;
+			return true;
+		}
+		return false;
+	},
+
+	remove: function() {
+		return this._remove(true, true);
+	},
+
+	replaceWith: function(item) {
+		var ok = item && item.insertBelow(this);
+		if (ok)
+			this.remove();
+		return ok;
+	},
+
+	removeChildren: function(start, end) {
+		if (!this._children)
+			return null;
+		start = start || 0;
+		end = Base.pick(end, this._children.length);
+		var removed = Base.splice(this._children, null, start, end - start);
+		for (var i = removed.length - 1; i >= 0; i--) {
+			removed[i]._remove(true, false);
+		}
+		if (removed.length > 0)
+			this._changed(11);
+		return removed;
+	},
+
+	clear: '#removeChildren',
+
+	reverseChildren: function() {
+		if (this._children) {
+			this._children.reverse();
+			for (var i = 0, l = this._children.length; i < l; i++)
+				this._children[i]._index = i;
+			this._changed(11);
+		}
+	},
+
+	isEmpty: function() {
+		return !this._children || this._children.length === 0;
+	},
+
+	isEditable: function() {
+		var item = this;
+		while (item) {
+			if (!item._visible || item._locked)
+				return false;
+			item = item._parent;
+		}
+		return true;
+	},
+
+	hasFill: function() {
+		return this.getStyle().hasFill();
+	},
+
+	hasStroke: function() {
+		return this.getStyle().hasStroke();
+	},
+
+	hasShadow: function() {
+		return this.getStyle().hasShadow();
+	},
+
+	_getOrder: function(item) {
+		function getList(item) {
+			var list = [];
+			do {
+				list.unshift(item);
+			} while (item = item._parent);
+			return list;
+		}
+		var list1 = getList(this),
+			list2 = getList(item);
+		for (var i = 0, l = Math.min(list1.length, list2.length); i < l; i++) {
+			if (list1[i] != list2[i]) {
+				return list1[i]._index < list2[i]._index ? 1 : -1;
+			}
+		}
+		return 0;
+	},
+
+	hasChildren: function() {
+		return this._children && this._children.length > 0;
+	},
+
+	isInserted: function() {
+		return this._parent ? this._parent.isInserted() : false;
+	},
+
+	isAbove: function(item) {
+		return this._getOrder(item) === -1;
+	},
+
+	isBelow: function(item) {
+		return this._getOrder(item) === 1;
+	},
+
+	isParent: function(item) {
+		return this._parent === item;
+	},
+
+	isChild: function(item) {
+		return item && item._parent === this;
+	},
+
+	isDescendant: function(item) {
+		var parent = this;
+		while (parent = parent._parent) {
+			if (parent === item)
+				return true;
+		}
+		return false;
+	},
+
+	isAncestor: function(item) {
+		return item ? item.isDescendant(this) : false;
+	},
+
+	isSibling: function(item) {
+		return this._parent === item._parent;
+	},
+
+	isGroupedWith: function(item) {
+		var parent = this._parent;
+		while (parent) {
+			if (parent._parent
+				&& /^(Group|Layer|CompoundPath)$/.test(parent._class)
+				&& item.isDescendant(parent))
+					return true;
+			parent = parent._parent;
+		}
+		return false;
+	},
+
+}, Base.each(['rotate', 'scale', 'shear', 'skew'], function(key) {
+	var rotate = key === 'rotate';
+	this[key] = function() {
+		var value = (rotate ? Base : Point).read(arguments),
+			center = Point.read(arguments, 0, { readNull: true });
+		return this.transform(new Matrix()[key](value,
+				center || this.getPosition(true)));
+	};
+}, {
+	translate: function() {
+		var mx = new Matrix();
+		return this.transform(mx.translate.apply(mx, arguments));
+	},
+
+	transform: function(matrix, _applyMatrix, _applyRecursively,
+			_setApplyMatrix) {
+		if (matrix && matrix.isIdentity())
+			matrix = null;
+		var _matrix = this._matrix,
+			applyMatrix = (_applyMatrix || this._applyMatrix)
+					&& ((!_matrix.isIdentity() || matrix)
+						|| _applyMatrix && _applyRecursively && this._children);
+		if (!matrix && !applyMatrix)
+			return this;
+		if (matrix)
+			_matrix.preConcatenate(matrix);
+		if (applyMatrix = applyMatrix && this._transformContent(_matrix,
+					_applyRecursively, _setApplyMatrix)) {
+			var pivot = this._pivot,
+				style = this._style,
+				fillColor = style.getFillColor(true),
+				strokeColor = style.getStrokeColor(true);
+			if (pivot)
+				_matrix._transformPoint(pivot, pivot, true);
+			if (fillColor)
+				fillColor.transform(_matrix);
+			if (strokeColor)
+				strokeColor.transform(_matrix);
+			_matrix.reset(true);
+			if (_setApplyMatrix && this._canApplyMatrix)
+				this._applyMatrix = true;
+		}
+		var bounds = this._bounds,
+			position = this._position;
+		this._changed(9);
+		var decomp = bounds && matrix && matrix.decompose();
+		if (decomp && !decomp.shearing && decomp.rotation % 90 === 0) {
+			for (var key in bounds) {
+				var rect = bounds[key];
+				if (applyMatrix || !rect._internal)
+					matrix._transformBounds(rect, rect);
+			}
+			var getter = this._boundsGetter,
+				rect = bounds[getter && getter.getBounds || getter || 'getBounds'];
+			if (rect)
+				this._position = rect.getCenter(true);
+			this._bounds = bounds;
+		} else if (matrix && position) {
+			this._position = matrix._transformPoint(position, position);
+		}
+		return this;
+	},
+
+	_transformContent: function(matrix, applyRecursively, setApplyMatrix) {
+		var children = this._children;
+		if (children) {
+			for (var i = 0, l = children.length; i < l; i++)
+				children[i].transform(matrix, true, applyRecursively,
+						setApplyMatrix);
+			return true;
+		}
+	},
+
+	globalToLocal: function() {
+		return this.getGlobalMatrix(true)._inverseTransform(
+				Point.read(arguments));
+	},
+
+	localToGlobal: function() {
+		return this.getGlobalMatrix(true)._transformPoint(
+				Point.read(arguments));
+	},
+
+	parentToLocal: function() {
+		return this._matrix._inverseTransform(Point.read(arguments));
+	},
+
+	localToParent: function() {
+		return this._matrix._transformPoint(Point.read(arguments));
+	},
+
+	fitBounds: function(rectangle, fill) {
+		rectangle = Rectangle.read(arguments);
+		var bounds = this.getBounds(),
+			itemRatio = bounds.height / bounds.width,
+			rectRatio = rectangle.height / rectangle.width,
+			scale = (fill ? itemRatio > rectRatio : itemRatio < rectRatio)
+					? rectangle.width / bounds.width
+					: rectangle.height / bounds.height,
+			newBounds = new Rectangle(new Point(),
+					new Size(bounds.width * scale, bounds.height * scale));
+		newBounds.setCenter(rectangle.getCenter());
+		this.setBounds(newBounds);
+	}
+}), {
+
+	_setStyles: function(ctx) {
+		var style = this._style,
+			fillColor = style.getFillColor(),
+			strokeColor = style.getStrokeColor(),
+			shadowColor = style.getShadowColor();
+		if (fillColor)
+			ctx.fillStyle = fillColor.toCanvasStyle(ctx);
+		if (strokeColor) {
+			var strokeWidth = style.getStrokeWidth();
+			if (strokeWidth > 0) {
+				ctx.strokeStyle = strokeColor.toCanvasStyle(ctx);
+				ctx.lineWidth = strokeWidth;
+				var strokeJoin = style.getStrokeJoin(),
+					strokeCap = style.getStrokeCap(),
+					miterLimit = style.getMiterLimit();
+				if (strokeJoin)
+					ctx.lineJoin = strokeJoin;
+				if (strokeCap)
+					ctx.lineCap = strokeCap;
+				if (miterLimit)
+					ctx.miterLimit = miterLimit;
+				if (paper.support.nativeDash) {
+					var dashArray = style.getDashArray(),
+						dashOffset = style.getDashOffset();
+					if (dashArray && dashArray.length) {
+						if ('setLineDash' in ctx) {
+							ctx.setLineDash(dashArray);
+							ctx.lineDashOffset = dashOffset;
+						} else {
+							ctx.mozDash = dashArray;
+							ctx.mozDashOffset = dashOffset;
+						}
+					}
+				}
+			}
+		}
+		if (shadowColor) {
+			var shadowBlur = style.getShadowBlur();
+			if (shadowBlur > 0) {
+				ctx.shadowColor = shadowColor.toCanvasStyle(ctx);
+				ctx.shadowBlur = shadowBlur;
+				var offset = this.getShadowOffset();
+				ctx.shadowOffsetX = offset.x;
+				ctx.shadowOffsetY = offset.y;
+			}
+		}
+	},
+
+	draw: function(ctx, param, parentStrokeMatrix) {
+		var updateVersion = this._updateVersion = this._project._updateVersion;
+		if (!this._visible || this._opacity === 0)
+			return;
+		var matrices = param.matrices,
+			viewMatrix = param.viewMatrix,
+			matrix = this._matrix,
+			globalMatrix = matrices[matrices.length - 1].chain(matrix);
+		if (!globalMatrix.isInvertible())
+			return;
+
+		function getViewMatrix(matrix) {
+			return viewMatrix ? viewMatrix.chain(matrix) : matrix;
+		}
+
+		matrices.push(globalMatrix);
+		if (param.updateMatrix) {
+			globalMatrix._updateVersion = updateVersion;
+			this._globalMatrix = globalMatrix;
+		}
+
+		var blendMode = this._blendMode,
+			opacity = this._opacity,
+			normalBlend = blendMode === 'normal',
+			nativeBlend = BlendMode.nativeModes[blendMode],
+			direct = normalBlend && opacity === 1
+					|| param.dontStart
+					|| param.clip
+					|| (nativeBlend || normalBlend && opacity < 1)
+						&& this._canComposite(),
+			pixelRatio = param.pixelRatio || 1,
+			mainCtx, itemOffset, prevOffset;
+		if (!direct) {
+			var bounds = this.getStrokeBounds(getViewMatrix(globalMatrix));
+			if (!bounds.width || !bounds.height)
+				return;
+			prevOffset = param.offset;
+			itemOffset = param.offset = bounds.getTopLeft().floor();
+			mainCtx = ctx;
+			ctx = CanvasProvider.getContext(bounds.getSize().ceil().add(1)
+					.multiply(pixelRatio));
+			if (pixelRatio !== 1)
+				ctx.scale(pixelRatio, pixelRatio);
+		}
+		ctx.save();
+		var strokeMatrix = parentStrokeMatrix
+				? parentStrokeMatrix.chain(matrix)
+				: this._canScaleStroke && !this.getStrokeScaling(true)
+					&& getViewMatrix(globalMatrix),
+			clip = !direct && param.clipItem,
+			transform = !strokeMatrix || clip;
+		if (direct) {
+			ctx.globalAlpha = opacity;
+			if (nativeBlend)
+				ctx.globalCompositeOperation = blendMode;
+		} else if (transform) {
+			ctx.translate(-itemOffset.x, -itemOffset.y);
+		}
+		if (transform)
+			(direct ? matrix : getViewMatrix(globalMatrix)).applyToContext(ctx);
+		if (clip)
+			param.clipItem.draw(ctx, param.extend({ clip: true }));
+		if (strokeMatrix) {
+			ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+			var offset = param.offset;
+			if (offset)
+				ctx.translate(-offset.x, -offset.y);
+		}
+		this._draw(ctx, param, strokeMatrix);
+		ctx.restore();
+		matrices.pop();
+		if (param.clip && !param.dontFinish)
+			ctx.clip();
+		if (!direct) {
+			BlendMode.process(blendMode, ctx, mainCtx, opacity,
+					itemOffset.subtract(prevOffset).multiply(pixelRatio));
+			CanvasProvider.release(ctx);
+			param.offset = prevOffset;
+		}
+	},
+
+	_isUpdated: function(updateVersion) {
+		var parent = this._parent;
+		if (parent instanceof CompoundPath)
+			return parent._isUpdated(updateVersion);
+		var updated = this._updateVersion === updateVersion;
+		if (!updated && parent && parent._visible
+				&& parent._isUpdated(updateVersion)) {
+			this._updateVersion = updateVersion;
+			updated = true;
+		}
+		return updated;
+	},
+
+	_drawSelection: function(ctx, matrix, size, selectedItems, updateVersion) {
+		if ((this._drawSelected || this._boundsSelected)
+				&& this._isUpdated(updateVersion)) {
+			var layer,
+				color = this.getSelectedColor(true)
+					|| (layer = this.getLayer()) && layer.getSelectedColor(true),
+				mx = matrix.chain(this.getGlobalMatrix(true));
+			ctx.strokeStyle = ctx.fillStyle = color
+					? color.toCanvasStyle(ctx) : '#009dec';
+			if (this._drawSelected)
+				this._drawSelected(ctx, mx, selectedItems);
+			if (this._boundsSelected) {
+				var half = size / 2,
+					coords = mx._transformCorners(this.getInternalBounds());
+				ctx.beginPath();
+				for (var i = 0; i < 8; i++)
+					ctx[i === 0 ? 'moveTo' : 'lineTo'](coords[i], coords[++i]);
+				ctx.closePath();
+				ctx.stroke();
+				for (var i = 0; i < 8; i++)
+					ctx.fillRect(coords[i] - half, coords[++i] - half,
+							size, size);
+			}
+		}
+	},
+
+	_canComposite: function() {
+		return false;
+	}
+}, Base.each(['down', 'drag', 'up', 'move'], function(key) {
+	this['removeOn' + Base.capitalize(key)] = function() {
+		var hash = {};
+		hash[key] = true;
+		return this.removeOn(hash);
+	};
+}, {
+
+	removeOn: function(obj) {
+		for (var name in obj) {
+			if (obj[name]) {
+				var key = 'mouse' + name,
+					project = this._project,
+					sets = project._removeSets = project._removeSets || {};
+				sets[key] = sets[key] || {};
+				sets[key][this._id] = this;
+			}
+		}
+		return this;
+	}
+}));
+
+var Group = Item.extend({
+	_class: 'Group',
+	_selectChildren: true,
+	_serializeFields: {
+		children: []
+	},
+
+	initialize: function Group(arg) {
+		this._children = [];
+		this._namedChildren = {};
+		if (!this._initialize(arg))
+			this.addChildren(Array.isArray(arg) ? arg : arguments);
+	},
+
+	_changed: function _changed(flags) {
+		_changed.base.call(this, flags);
+		if (flags & 1026) {
+			this._clipItem = undefined;
+		}
+	},
+
+	_getClipItem: function() {
+		var clipItem = this._clipItem;
+		if (clipItem === undefined) {
+			clipItem = null;
+			var children = this._children;
+			for (var i = 0, l = children.length; i < l; i++) {
+				if (children[i]._clipMask) {
+					clipItem = children[i];
+					break;
+				}
+			}
+			this._clipItem = clipItem;
+		}
+		return clipItem;
+	},
+
+	isClipped: function() {
+		return !!this._getClipItem();
+	},
+
+	setClipped: function(clipped) {
+		var child = this.getFirstChild();
+		if (child)
+			child.setClipMask(clipped);
+	},
+
+	_draw: function(ctx, param) {
+		var clip = param.clip,
+			clipItem = !clip && this._getClipItem(),
+			draw = true;
+		param = param.extend({ clipItem: clipItem, clip: false });
+		if (clip) {
+			ctx.beginPath();
+			param.dontStart = param.dontFinish = true;
+		} else if (clipItem) {
+			clipItem.draw(ctx, param.extend({ clip: true }));
+		}
+		if (draw) {
+			var children = this._children;
+			for (var i = 0, l = children.length; i < l; i++) {
+				var item = children[i];
+				if (item !== clipItem)
+					item.draw(ctx, param);
+			}
+		}
+	}
+});
+
+var Layer = Group.extend({
+	_class: 'Layer',
+
+	initialize: function Layer() {
+		Group.apply(this, arguments);
+	},
+
+	_getOwner: function() {
+		return this._parent || this._index != null && this._project;
+	},
+
+	isInserted: function isInserted() {
+		return this._parent ? isInserted.base.call(this) : this._index != null;
+	},
+
+	activate: function() {
+		this._project._activeLayer = this;
+	},
+
+	_hitTestSelf: function() {
+		return null;
+	}
+});
+
+var Shape = Item.extend({
+	_class: 'Shape',
+	_applyMatrix: false,
+	_canApplyMatrix: false,
+	_canScaleStroke: true,
+	_boundsSelected: true,
+	_serializeFields: {
+		type: null,
+		size: null,
+		radius: null
+	},
+
+	initialize: function Shape(props) {
+		this._initialize(props);
+	},
+
+	_equals: function(item) {
+		return this._type === item._type
+			&& this._size.equals(item._size)
+			&& Base.equals(this._radius, item._radius);
+	},
+
+	copyContent: function(source) {
+		this.setType(source._type);
+		this.setSize(source._size);
+		this.setRadius(source._radius);
+	},
+
+	getType: function() {
+		return this._type;
+	},
+
+	setType: function(type) {
+		this._type = type;
+	},
+
+	getShape: '#getType',
+	setShape: '#setType',
+
+	getSize: function() {
+		var size = this._size;
+		return new LinkedSize(size.width, size.height, this, 'setSize');
+	},
+
+	setSize: function() {
+		var size = Size.read(arguments);
+		if (!this._size) {
+			this._size = size.clone();
+		} else if (!this._size.equals(size)) {
+			var type = this._type,
+				width = size.width,
+				height = size.height;
+			if (type === 'rectangle') {
+				var radius = Size.min(this._radius, size.divide(2));
+				this._radius.set(radius.width, radius.height);
+			} else if (type === 'circle') {
+				width = height = (width + height) / 2;
+				this._radius = width / 2;
+			} else if (type === 'ellipse') {
+				this._radius.set(width / 2, height / 2);
+			}
+			this._size.set(width, height);
+			this._changed(9);
+		}
+	},
+
+	getRadius: function() {
+		var rad = this._radius;
+		return this._type === 'circle'
+				? rad
+				: new LinkedSize(rad.width, rad.height, this, 'setRadius');
+	},
+
+	setRadius: function(radius) {
+		var type = this._type;
+		if (type === 'circle') {
+			if (radius === this._radius)
+				return;
+			var size = radius * 2;
+			this._radius = radius;
+			this._size.set(size, size);
+		} else {
+			radius = Size.read(arguments);
+			if (!this._radius) {
+				this._radius = radius.clone();
+			} else {
+				if (this._radius.equals(radius))
+					return;
+				this._radius.set(radius.width, radius.height);
+				if (type === 'rectangle') {
+					var size = Size.max(this._size, radius.multiply(2));
+					this._size.set(size.width, size.height);
+				} else if (type === 'ellipse') {
+					this._size.set(radius.width * 2, radius.height * 2);
+				}
+			}
+		}
+		this._changed(9);
+	},
+
+	isEmpty: function() {
+		return false;
+	},
+
+	toPath: function(insert) {
+		var path = new Path[Base.capitalize(this._type)]({
+			center: new Point(),
+			size: this._size,
+			radius: this._radius,
+			insert: false
+		});
+		path.copyAttributes(this);
+		if (paper.settings.applyMatrix)
+			path.setApplyMatrix(true);
+		if (insert === undefined || insert)
+			path.insertAbove(this);
+		return path;
+	},
+
+	toShape: '#clone',
+
+	_draw: function(ctx, param, strokeMatrix) {
+		var style = this._style,
+			hasFill = style.hasFill(),
+			hasStroke = style.hasStroke(),
+			dontPaint = param.dontFinish || param.clip,
+			untransformed = !strokeMatrix;
+		if (hasFill || hasStroke || dontPaint) {
+			var type = this._type,
+				radius = this._radius,
+				isCircle = type === 'circle';
+			if (!param.dontStart)
+				ctx.beginPath();
+			if (untransformed && isCircle) {
+				ctx.arc(0, 0, radius, 0, Math.PI * 2, true);
+			} else {
+				var rx = isCircle ? radius : radius.width,
+					ry = isCircle ? radius : radius.height,
+					size = this._size,
+					width = size.width,
+					height = size.height;
+				if (untransformed && type === 'rectangle' && rx === 0 && ry === 0) {
+					ctx.rect(-width / 2, -height / 2, width, height);
+				} else {
+					var x = width / 2,
+						y = height / 2,
+						kappa = 1 - 0.5522847498307936,
+						cx = rx * kappa,
+						cy = ry * kappa,
+						c = [
+							-x, -y + ry,
+							-x, -y + cy,
+							-x + cx, -y,
+							-x + rx, -y,
+							x - rx, -y,
+							x - cx, -y,
+							x, -y + cy,
+							x, -y + ry,
+							x, y - ry,
+							x, y - cy,
+							x - cx, y,
+							x - rx, y,
+							-x + rx, y,
+							-x + cx, y,
+							-x, y - cy,
+							-x, y - ry
+						];
+					if (strokeMatrix)
+						strokeMatrix.transform(c, c, 32);
+					ctx.moveTo(c[0], c[1]);
+					ctx.bezierCurveTo(c[2], c[3], c[4], c[5], c[6], c[7]);
+					if (x !== rx)
+						ctx.lineTo(c[8], c[9]);
+					ctx.bezierCurveTo(c[10], c[11], c[12], c[13], c[14], c[15]);
+					if (y !== ry)
+						ctx.lineTo(c[16], c[17]);
+					ctx.bezierCurveTo(c[18], c[19], c[20], c[21], c[22], c[23]);
+					if (x !== rx)
+						ctx.lineTo(c[24], c[25]);
+					ctx.bezierCurveTo(c[26], c[27], c[28], c[29], c[30], c[31]);
+				}
+			}
+			ctx.closePath();
+		}
+		if (!dontPaint && (hasFill || hasStroke)) {
+			this._setStyles(ctx);
+			if (hasFill) {
+				ctx.fill(style.getFillRule());
+				ctx.shadowBlur = 0;
+			}
+			if (hasStroke)
+				ctx.stroke();
+		}
+	},
+
+	_canComposite: function() {
+		return !(this.hasFill() && this.hasStroke());
+	},
+
+	_getBounds: function(getter, matrix) {
+		var rect = new Rectangle(this._size).setCenter(0, 0),
+			strokeWidth = getter === 'getStrokeBounds' && this.hasStroke()
+				&& this.getStrokeWidth(),
+			scaling = strokeWidth && this.getStrokeScaling();
+		if (strokeWidth && scaling)
+			rect = rect.expand(strokeWidth);
+		if (matrix)
+			rect = matrix._transformBounds(rect);
+		if (strokeWidth && !scaling)
+			rect = rect.expand(strokeWidth);
+		return rect;
+	}
+},
+new function() {
+	function getCornerCenter(that, point, expand) {
+		var radius = that._radius;
+		if (!radius.isZero()) {
+			var halfSize = that._size.divide(2);
+			for (var i = 0; i < 4; i++) {
+				var dir = new Point(i & 1 ? 1 : -1, i > 1 ? 1 : -1),
+					corner = dir.multiply(halfSize),
+					center = corner.subtract(dir.multiply(radius)),
+					rect = new Rectangle(corner, center);
+				if ((expand ? rect.expand(expand) : rect).contains(point))
+					return center;
+			}
+		}
+	}
+
+	function getEllipseRadius(point, radius) {
+		var angle = point.getAngleInRadians(),
+			width = radius.width * 2,
+			height = radius.height * 2,
+			x = width * Math.sin(angle),
+			y = height * Math.cos(angle);
+		return width * height / (2 * Math.sqrt(x * x + y * y));
+	}
+
+	return {
+		_contains: function _contains(point) {
+			if (this._type === 'rectangle') {
+				var center = getCornerCenter(this, point);
+				return center
+						? point.subtract(center).divide(this._radius)
+							.getLength() <= 1
+						: _contains.base.call(this, point);
+			} else {
+				return point.divide(this.size).getLength() <= 0.5;
+			}
+		},
+
+		_hitTestSelf: function _hitTestSelf(point, options) {
+			var hit = false;
+			if (this.hasStroke()) {
+				var type = this._type,
+					radius = this._radius,
+					strokeWidth = this.getStrokeWidth() + 2 * options.tolerance;
+				if (type === 'rectangle') {
+					var center = getCornerCenter(this, point, strokeWidth);
+					if (center) {
+						var pt = point.subtract(center);
+						hit = 2 * Math.abs(pt.getLength()
+								- getEllipseRadius(pt, radius)) <= strokeWidth;
+					} else {
+						var rect = new Rectangle(this._size).setCenter(0, 0),
+							outer = rect.expand(strokeWidth),
+							inner = rect.expand(-strokeWidth);
+						hit = outer._containsPoint(point)
+								&& !inner._containsPoint(point);
+					}
+				} else {
+					if (type === 'ellipse')
+						radius = getEllipseRadius(point, radius);
+					hit = 2 * Math.abs(point.getLength() - radius)
+							<= strokeWidth;
+				}
+			}
+			return hit
+					? new HitResult('stroke', this)
+					: _hitTestSelf.base.apply(this, arguments);
+		}
+	};
+}, {
+
+statics: new function() {
+	function createShape(type, point, size, radius, args) {
+		var item = new Shape(Base.getNamed(args));
+		item._type = type;
+		item._size = size;
+		item._radius = radius;
+		return item.translate(point);
+	}
+
+	return {
+		Circle: function() {
+			var center = Point.readNamed(arguments, 'center'),
+				radius = Base.readNamed(arguments, 'radius');
+			return createShape('circle', center, new Size(radius * 2), radius,
+					arguments);
+		},
+
+		Rectangle: function() {
+			var rect = Rectangle.readNamed(arguments, 'rectangle'),
+				radius = Size.min(Size.readNamed(arguments, 'radius'),
+						rect.getSize(true).divide(2));
+			return createShape('rectangle', rect.getCenter(true),
+					rect.getSize(true), radius, arguments);
+		},
+
+		Ellipse: function() {
+			var ellipse = Shape._readEllipse(arguments),
+				radius = ellipse.radius;
+			return createShape('ellipse', ellipse.center, radius.multiply(2),
+					radius, arguments);
+		},
+
+		_readEllipse: function(args) {
+			var center,
+				radius;
+			if (Base.hasNamed(args, 'radius')) {
+				center = Point.readNamed(args, 'center');
+				radius = Size.readNamed(args, 'radius');
+			} else {
+				var rect = Rectangle.readNamed(args, 'rectangle');
+				center = rect.getCenter(true);
+				radius = rect.getSize(true).divide(2);
+			}
+			return { center: center, radius: radius };
+		}
+	};
+}});
+
+var Raster = Item.extend({
+	_class: 'Raster',
+	_applyMatrix: false,
+	_canApplyMatrix: false,
+	_boundsGetter: 'getBounds',
+	_boundsSelected: true,
+	_serializeFields: {
+		crossOrigin: null,
+		source: null
+	},
+
+	initialize: function Raster(object, position) {
+		if (!this._initialize(object,
+				position !== undefined && Point.read(arguments, 1))) {
+			if (typeof object === 'string') {
+				this.setSource(object);
+			} else {
+				this.setImage(object);
+			}
+		}
+		if (!this._size) {
+			this._size = new Size();
+			this._loaded = false;
+		}
+	},
+
+	_equals: function(item) {
+		return this.getSource() === item.getSource();
+	},
+
+	copyContent: function(source) {
+		var image = source._image,
+			canvas = source._canvas;
+		if (image) {
+			this.setImage(image);
+		} else if (canvas) {
+			var copyCanvas = CanvasProvider.getCanvas(source._size);
+			copyCanvas.getContext('2d').drawImage(canvas, 0, 0);
+			this.setImage(copyCanvas);
+		}
+		this._crossOrigin = source._crossOrigin;
+	},
+
+	getSize: function() {
+		var size = this._size;
+		return new LinkedSize(size ? size.width : 0, size ? size.height : 0,
+				this, 'setSize');
+	},
+
+	setSize: function() {
+		var size = Size.read(arguments);
+		if (!size.equals(this._size)) {
+			if (size.width > 0 && size.height > 0) {
+				var element = this.getElement();
+				this.setImage(CanvasProvider.getCanvas(size));
+				if (element)
+					this.getContext(true).drawImage(element, 0, 0,
+							size.width, size.height);
+			} else {
+				if (this._canvas)
+					CanvasProvider.release(this._canvas);
+				this._size = size.clone();
+			}
+		}
+	},
+
+	getWidth: function() {
+		return this._size ? this._size.width : 0;
+	},
+
+	setWidth: function(width) {
+		this.setSize(width, this.getHeight());
+	},
+
+	getHeight: function() {
+		return this._size ? this._size.height : 0;
+	},
+
+	setHeight: function(height) {
+		this.setSize(this.getWidth(), height);
+	},
+
+	isEmpty: function() {
+		var size = this._size;
+		return !size || size.width === 0 && size.height === 0;
+	},
+
+	getResolution: function() {
+		var matrix = this._matrix,
+			orig = new Point(0, 0).transform(matrix),
+			u = new Point(1, 0).transform(matrix).subtract(orig),
+			v = new Point(0, 1).transform(matrix).subtract(orig);
+		return new Size(
+			72 / u.getLength(),
+			72 / v.getLength()
+		);
+	},
+
+	getPpi: '#getResolution',
+
+	getImage: function() {
+		return this._image;
+	},
+
+	setImage: function(image) {
+		if (this._canvas)
+			CanvasProvider.release(this._canvas);
+		if (image && image.getContext) {
+			this._image = null;
+			this._canvas = image;
+			this._loaded = true;
+		} else {
+			this._image = image;
+			this._canvas = null;
+			this._loaded = image && image.complete;
+		}
+		this._size = new Size(
+				image ? image.naturalWidth || image.width : 0,
+				image ? image.naturalHeight || image.height : 0);
+		this._context = null;
+		this._changed(521);
+	},
+
+	getCanvas: function() {
+		if (!this._canvas) {
+			var ctx = CanvasProvider.getContext(this._size);
+			try {
+				if (this._image)
+					ctx.drawImage(this._image, 0, 0);
+				this._canvas = ctx.canvas;
+			} catch (e) {
+				CanvasProvider.release(ctx);
+			}
+		}
+		return this._canvas;
+	},
+
+	setCanvas: '#setImage',
+
+	getContext: function(modify) {
+		if (!this._context)
+			this._context = this.getCanvas().getContext('2d');
+		if (modify) {
+			this._image = null;
+			this._changed(513);
+		}
+		return this._context;
+	},
+
+	setContext: function(context) {
+		this._context = context;
+	},
+
+	getSource: function() {
+		return this._image && this._image.src || this.toDataURL();
+	},
+
+	setSource: function(src) {
+		var that = this,
+			crossOrigin = this._crossOrigin,
+			image;
+
+		function loaded() {
+			var view = that.getView();
+			if (view) {
+				paper = view._scope;
+				that.setImage(image);
+				that.emit('load');
+				view.update();
+			}
+		}
+
+		image = document.getElementById(src) || new Image();
+		if (crossOrigin)
+			image.crossOrigin = crossOrigin;
+		if (image.naturalWidth && image.naturalHeight) {
+			setTimeout(loaded, 0);
+		} else {
+			DomEvent.add(image, { load: loaded });
+			if (!image.src)
+				image.src = src;
+		}
+		this.setImage(image);
+	},
+
+	getCrossOrigin: function() {
+		return this._image && this._image.crossOrigin || this._crossOrigin || '';
+	},
+
+	setCrossOrigin: function(crossOrigin) {
+		this._crossOrigin = crossOrigin;
+		if (this._image)
+			this._image.crossOrigin = crossOrigin;
+	},
+
+	getElement: function() {
+		return this._canvas || this._loaded && this._image;
+	}
+}, {
+	beans: false,
+
+	getSubCanvas: function() {
+		var rect = Rectangle.read(arguments),
+			ctx = CanvasProvider.getContext(rect.getSize());
+		ctx.drawImage(this.getCanvas(), rect.x, rect.y,
+				rect.width, rect.height, 0, 0, rect.width, rect.height);
+		return ctx.canvas;
+	},
+
+	getSubRaster: function() {
+		var rect = Rectangle.read(arguments),
+			raster = new Raster(Item.NO_INSERT);
+		raster.setImage(this.getSubCanvas(rect));
+		raster.translate(rect.getCenter().subtract(this.getSize().divide(2)));
+		raster._matrix.preConcatenate(this._matrix);
+		raster.insertAbove(this);
+		return raster;
+	},
+
+	toDataURL: function() {
+		var src = this._image && this._image.src;
+		if (/^data:/.test(src))
+			return src;
+		var canvas = this.getCanvas();
+		return canvas ? canvas.toDataURL.apply(canvas, arguments) : null;
+	},
+
+	drawImage: function(image ) {
+		var point = Point.read(arguments, 1);
+		this.getContext(true).drawImage(image, point.x, point.y);
+	},
+
+	getAverageColor: function(object) {
+		var bounds, path;
+		if (!object) {
+			bounds = this.getBounds();
+		} else if (object instanceof PathItem) {
+			path = object;
+			bounds = object.getBounds();
+		} else if (object.width) {
+			bounds = new Rectangle(object);
+		} else if (object.x) {
+			bounds = new Rectangle(object.x - 0.5, object.y - 0.5, 1, 1);
+		}
+		var sampleSize = 32,
+			width = Math.min(bounds.width, sampleSize),
+			height = Math.min(bounds.height, sampleSize);
+		var ctx = Raster._sampleContext;
+		if (!ctx) {
+			ctx = Raster._sampleContext = CanvasProvider.getContext(
+					new Size(sampleSize));
+		} else {
+			ctx.clearRect(0, 0, sampleSize + 1, sampleSize + 1);
+		}
+		ctx.save();
+		var matrix = new Matrix()
+				.scale(width / bounds.width, height / bounds.height)
+				.translate(-bounds.x, -bounds.y);
+		matrix.applyToContext(ctx);
+		if (path)
+			path.draw(ctx, new Base({ clip: true, matrices: [matrix] }));
+		this._matrix.applyToContext(ctx);
+		var element = this.getElement(),
+			size = this._size;
+		if (element)
+			ctx.drawImage(element, -size.width / 2, -size.height / 2);
+		ctx.restore();
+		var pixels = ctx.getImageData(0.5, 0.5, Math.ceil(width),
+				Math.ceil(height)).data,
+			channels = [0, 0, 0],
+			total = 0;
+		for (var i = 0, l = pixels.length; i < l; i += 4) {
+			var alpha = pixels[i + 3];
+			total += alpha;
+			alpha /= 255;
+			channels[0] += pixels[i] * alpha;
+			channels[1] += pixels[i + 1] * alpha;
+			channels[2] += pixels[i + 2] * alpha;
+		}
+		for (var i = 0; i < 3; i++)
+			channels[i] /= total;
+		return total ? Color.read(channels) : null;
+	},
+
+	getPixel: function() {
+		var point = Point.read(arguments);
+		var data = this.getContext().getImageData(point.x, point.y, 1, 1).data;
+		return new Color('rgb', [data[0] / 255, data[1] / 255, data[2] / 255],
+				data[3] / 255);
+	},
+
+	setPixel: function() {
+		var point = Point.read(arguments),
+			color = Color.read(arguments),
+			components = color._convert('rgb'),
+			alpha = color._alpha,
+			ctx = this.getContext(true),
+			imageData = ctx.createImageData(1, 1),
+			data = imageData.data;
+		data[0] = components[0] * 255;
+		data[1] = components[1] * 255;
+		data[2] = components[2] * 255;
+		data[3] = alpha != null ? alpha * 255 : 255;
+		ctx.putImageData(imageData, point.x, point.y);
+	},
+
+	createImageData: function() {
+		var size = Size.read(arguments);
+		return this.getContext().createImageData(size.width, size.height);
+	},
+
+	getImageData: function() {
+		var rect = Rectangle.read(arguments);
+		if (rect.isEmpty())
+			rect = new Rectangle(this._size);
+		return this.getContext().getImageData(rect.x, rect.y,
+				rect.width, rect.height);
+	},
+
+	setImageData: function(data ) {
+		var point = Point.read(arguments, 1);
+		this.getContext(true).putImageData(data, point.x, point.y);
+	},
+
+	_getBounds: function(getter, matrix) {
+		var rect = new Rectangle(this._size).setCenter(0, 0);
+		return matrix ? matrix._transformBounds(rect) : rect;
+	},
+
+	_hitTestSelf: function(point) {
+		if (this._contains(point)) {
+			var that = this;
+			return new HitResult('pixel', that, {
+				offset: point.add(that._size.divide(2)).round(),
+				color: {
+					get: function() {
+						return that.getPixel(this.offset);
+					}
+				}
+			});
+		}
+	},
+
+	_draw: function(ctx) {
+		var element = this.getElement();
+		if (element) {
+			ctx.globalAlpha = this._opacity;
+			ctx.drawImage(element,
+					-this._size.width / 2, -this._size.height / 2);
+		}
+	},
+
+	_canComposite: function() {
+		return true;
+	}
+});
+
+var PlacedSymbol = Item.extend({
+	_class: 'PlacedSymbol',
+	_applyMatrix: false,
+	_canApplyMatrix: false,
+	_boundsGetter: { getBounds: 'getStrokeBounds' },
+	_boundsSelected: true,
+	_serializeFields: {
+		symbol: null
+	},
+
+	initialize: function PlacedSymbol(arg0, arg1) {
+		if (!this._initialize(arg0,
+				arg1 !== undefined && Point.read(arguments, 1)))
+			this.setSymbol(arg0 instanceof Symbol ? arg0 : new Symbol(arg0));
+	},
+
+	_equals: function(item) {
+		return this._symbol === item._symbol;
+	},
+
+	copyContent: function(source) {
+		this.setSymbol(source._symbol);
+	},
+
+	getSymbol: function() {
+		return this._symbol;
+	},
+
+	setSymbol: function(symbol) {
+		this._symbol = symbol;
+		this._changed(9);
+	},
+
+	isEmpty: function() {
+		return this._symbol._definition.isEmpty();
+	},
+
+	_getBounds: function(getter, matrix, cacheItem) {
+		var definition = this.symbol._definition;
+		return definition._getCachedBounds(getter,
+				matrix && matrix.chain(definition._matrix), cacheItem);
+	},
+
+	_hitTestSelf: function(point, options) {
+		var res = this._symbol._definition._hitTest(point, options);
+		if (res)
+			res.item = this;
+		return res;
+	},
+
+	_draw: function(ctx, param) {
+		this.symbol._definition.draw(ctx, param);
+	}
+
+});
+
+var HitResult = Base.extend({
+	_class: 'HitResult',
+
+	initialize: function HitResult(type, item, values) {
+		this.type = type;
+		this.item = item;
+		if (values) {
+			values.enumerable = true;
+			this.inject(values);
+		}
+	},
+
+	statics: {
+		getOptions: function(options) {
+			return new Base({
+				type: null,
+				tolerance: paper.settings.hitTolerance,
+				fill: !options,
+				stroke: !options,
+				segments: !options,
+				handles: false,
+				ends: false,
+				center: false,
+				bounds: false,
+				guides: false,
+				selected: false
+			}, options);
+		}
+	}
+});
+
+var Segment = Base.extend({
+	_class: 'Segment',
+	beans: true,
+
+	initialize: function Segment(arg0, arg1, arg2, arg3, arg4, arg5) {
+		var count = arguments.length,
+			point, handleIn, handleOut;
+		if (count === 0) {
+		} else if (count === 1) {
+			if (arg0 && 'point' in arg0) {
+				point = arg0.point;
+				handleIn = arg0.handleIn;
+				handleOut = arg0.handleOut;
+			} else {
+				point = arg0;
+			}
+		} else if (count === 2 && typeof arg0 === 'number') {
+			point = arguments;
+		} else if (count <= 3) {
+			point = arg0;
+			handleIn = arg1;
+			handleOut = arg2;
+		} else {
+			point = arg0 !== undefined ? [ arg0, arg1 ] : null;
+			handleIn = arg2 !== undefined ? [ arg2, arg3 ] : null;
+			handleOut = arg4 !== undefined ? [ arg4, arg5 ] : null;
+		}
+		new SegmentPoint(point, this, '_point');
+		new SegmentPoint(handleIn, this, '_handleIn');
+		new SegmentPoint(handleOut, this, '_handleOut');
+	},
+
+	_serialize: function(options) {
+		return Base.serialize(this.hasHandles()
+				? [this._point, this._handleIn, this._handleOut]
+				: this._point,
+				options, true);
+	},
+
+	_changed: function(point) {
+		var path = this._path;
+		if (!path)
+			return;
+		var curves = path._curves,
+			index = this._index,
+			curve;
+		if (curves) {
+			if ((!point || point === this._point || point === this._handleIn)
+					&& (curve = index > 0 ? curves[index - 1] : path._closed
+						? curves[curves.length - 1] : null))
+				curve._changed();
+			if ((!point || point === this._point || point === this._handleOut)
+					&& (curve = curves[index]))
+				curve._changed();
+		}
+		path._changed(25);
+	},
+
+	getPoint: function() {
+		return this._point;
+	},
+
+	setPoint: function() {
+		var point = Point.read(arguments);
+		this._point.set(point.x, point.y);
+	},
+
+	getHandleIn: function() {
+		return this._handleIn;
+	},
+
+	setHandleIn: function() {
+		var point = Point.read(arguments);
+		this._handleIn.set(point.x, point.y);
+	},
+
+	getHandleOut: function() {
+		return this._handleOut;
+	},
+
+	setHandleOut: function() {
+		var point = Point.read(arguments);
+		this._handleOut.set(point.x, point.y);
+	},
+
+	hasHandles: function() {
+		return !this._handleIn.isZero() || !this._handleOut.isZero();
+	},
+
+	clearHandles: function() {
+		this._handleIn.set(0, 0);
+		this._handleOut.set(0, 0);
+	},
+
+	_selectionState: 0,
+
+	isSelected: function(_point) {
+		var state = this._selectionState;
+		return !_point ? !!(state & 7)
+			: _point === this._point ? !!(state & 4)
+			: _point === this._handleIn ? !!(state & 1)
+			: _point === this._handleOut ? !!(state & 2)
+			: false;
+	},
+
+	setSelected: function(selected, _point) {
+		var path = this._path,
+			selected = !!selected,
+			state = this._selectionState,
+			oldState = state,
+			flag = !_point ? 7
+					: _point === this._point ? 4
+					: _point === this._handleIn ? 1
+					: _point === this._handleOut ? 2
+					: 0;
+		if (selected) {
+			state |= flag;
+		} else {
+			state &= ~flag;
+		}
+		this._selectionState = state;
+		if (path && state !== oldState) {
+			path._updateSelection(this, oldState, state);
+			path._changed(129);
+		}
+	},
+
+	getIndex: function() {
+		return this._index !== undefined ? this._index : null;
+	},
+
+	getPath: function() {
+		return this._path || null;
+	},
+
+	getCurve: function() {
+		var path = this._path,
+			index = this._index;
+		if (path) {
+			if (index > 0 && !path._closed
+					&& index === path._segments.length - 1)
+				index--;
+			return path.getCurves()[index] || null;
+		}
+		return null;
+	},
+
+	getLocation: function() {
+		var curve = this.getCurve();
+		return curve
+				? new CurveLocation(curve, this === curve._segment1 ? 0 : 1)
+				: null;
+	},
+
+	getNext: function() {
+		var segments = this._path && this._path._segments;
+		return segments && (segments[this._index + 1]
+				|| this._path._closed && segments[0]) || null;
+	},
+
+	smooth: function(options, _first, _last) {
+		var opts = options || {},
+			type = opts.type,
+			factor = opts.factor,
+			prev = this.getPrevious(),
+			next = this.getNext(),
+			p0 = (prev || this)._point,
+			p1 = this._point,
+			p2 = (next || this)._point,
+			d1 = p0.getDistance(p1),
+			d2 = p1.getDistance(p2);
+		if (!type || type === 'catmull-rom') {
+			var a = factor === undefined ? 0.5 : factor,
+				d1_a = Math.pow(d1, a),
+				d1_2a = d1_a * d1_a,
+				d2_a = Math.pow(d2, a),
+				d2_2a = d2_a * d2_a;
+			if (!_first && prev) {
+				var A = 2 * d2_2a + 3 * d2_a * d1_a + d1_2a,
+					N = 3 * d2_a * (d2_a + d1_a);
+				this.setHandleIn(N !== 0
+					? new Point(
+						(d2_2a * p0._x + A * p1._x - d1_2a * p2._x) / N - p1._x,
+						(d2_2a * p0._y + A * p1._y - d1_2a * p2._y) / N - p1._y)
+					: new Point());
+			}
+			if (!_last && next) {
+				var A = 2 * d1_2a + 3 * d1_a * d2_a + d2_2a,
+					N = 3 * d1_a * (d1_a + d2_a);
+				this.setHandleOut(N !== 0
+					? new Point(
+						(d1_2a * p2._x + A * p1._x - d2_2a * p0._x) / N - p1._x,
+						(d1_2a * p2._y + A * p1._y - d2_2a * p0._y) / N - p1._y)
+					: new Point());
+			}
+		} else if (type === 'geometric') {
+			if (prev && next) {
+				var vector = p0.subtract(p2),
+					t = factor === undefined ? 0.4 : factor,
+					k = t * d1 / (d1 + d2);
+				if (!_first)
+					this.setHandleIn(vector.multiply(k));
+				if (!_last)
+					this.setHandleOut(vector.multiply(k - t));
+			}
+		} else {
+			throw new Error('Smoothing method \'' + type + '\' not supported.');
+		}
+	},
+
+	getPrevious: function() {
+		var segments = this._path && this._path._segments;
+		return segments && (segments[this._index - 1]
+				|| this._path._closed && segments[segments.length - 1]) || null;
+	},
+
+	isFirst: function() {
+		return this._index === 0;
+	},
+
+	isLast: function() {
+		var path = this._path;
+		return path && this._index === path._segments.length - 1 || false;
+	},
+
+	reverse: function() {
+		var handleIn = this._handleIn,
+			handleOut = this._handleOut,
+			inX = handleIn._x,
+			inY = handleIn._y;
+		handleIn.set(handleOut._x, handleOut._y);
+		handleOut.set(inX, inY);
+	},
+
+	reversed: function() {
+		return new Segment(this._point, this._handleOut, this._handleIn);
+	},
+
+	remove: function() {
+		return this._path ? !!this._path.removeSegment(this._index) : false;
+	},
+
+	clone: function() {
+		return new Segment(this._point, this._handleIn, this._handleOut);
+	},
+
+	equals: function(segment) {
+		return segment === this || segment && this._class === segment._class
+				&& this._point.equals(segment._point)
+				&& this._handleIn.equals(segment._handleIn)
+				&& this._handleOut.equals(segment._handleOut)
+				|| false;
+	},
+
+	toString: function() {
+		var parts = [ 'point: ' + this._point ];
+		if (!this._handleIn.isZero())
+			parts.push('handleIn: ' + this._handleIn);
+		if (!this._handleOut.isZero())
+			parts.push('handleOut: ' + this._handleOut);
+		return '{ ' + parts.join(', ') + ' }';
+	},
+
+	transform: function(matrix) {
+		this._transformCoordinates(matrix, new Array(6), true);
+		this._changed();
+	},
+
+	_transformCoordinates: function(matrix, coords, change) {
+		var point = this._point,
+			handleIn = !change || !this._handleIn.isZero()
+					? this._handleIn : null,
+			handleOut = !change || !this._handleOut.isZero()
+					? this._handleOut : null,
+			x = point._x,
+			y = point._y,
+			i = 2;
+		coords[0] = x;
+		coords[1] = y;
+		if (handleIn) {
+			coords[i++] = handleIn._x + x;
+			coords[i++] = handleIn._y + y;
+		}
+		if (handleOut) {
+			coords[i++] = handleOut._x + x;
+			coords[i++] = handleOut._y + y;
+		}
+		if (matrix) {
+			matrix._transformCoordinates(coords, coords, i / 2);
+			x = coords[0];
+			y = coords[1];
+			if (change) {
+				point._x = x;
+				point._y = y;
+				i  = 2;
+				if (handleIn) {
+					handleIn._x = coords[i++] - x;
+					handleIn._y = coords[i++] - y;
+				}
+				if (handleOut) {
+					handleOut._x = coords[i++] - x;
+					handleOut._y = coords[i++] - y;
+				}
+			} else {
+				if (!handleIn) {
+					coords[i++] = x;
+					coords[i++] = y;
+				}
+				if (!handleOut) {
+					coords[i++] = x;
+					coords[i++] = y;
+				}
+			}
+		}
+		return coords;
+	}
+});
+
+var SegmentPoint = Point.extend({
+	initialize: function SegmentPoint(point, owner, key) {
+		var x, y, selected;
+		if (!point) {
+			x = y = 0;
+		} else if ((x = point[0]) !== undefined) {
+			y = point[1];
+		} else {
+			var pt = point;
+			if ((x = pt.x) === undefined) {
+				pt = Point.read(arguments);
+				x = pt.x;
+			}
+			y = pt.y;
+			selected = pt.selected;
+		}
+		this._x = x;
+		this._y = y;
+		this._owner = owner;
+		owner[key] = this;
+		if (selected)
+			this.setSelected(true);
+	},
+
+	set: function(x, y) {
+		this._x = x;
+		this._y = y;
+		this._owner._changed(this);
+		return this;
+	},
+
+	_serialize: function(options) {
+		var f = options.formatter,
+			x = f.number(this._x),
+			y = f.number(this._y);
+		return this.isSelected()
+				? { x: x, y: y, selected: true }
+				: [x, y];
+	},
+
+	getX: function() {
+		return this._x;
+	},
+
+	setX: function(x) {
+		this._x = x;
+		this._owner._changed(this);
+	},
+
+	getY: function() {
+		return this._y;
+	},
+
+	setY: function(y) {
+		this._y = y;
+		this._owner._changed(this);
+	},
+
+	isZero: function() {
+		return Numerical.isZero(this._x) && Numerical.isZero(this._y);
+	},
+
+	setSelected: function(selected) {
+		this._owner.setSelected(selected, this);
+	},
+
+	isSelected: function() {
+		return this._owner.isSelected(this);
+	}
+});
+
+var Curve = Base.extend({
+	_class: 'Curve',
+
+	initialize: function Curve(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
+		var count = arguments.length,
+			seg1, seg2,
+			point1, point2,
+			handle1, handle2;
+		if (count === 3) {
+			this._path = arg0;
+			seg1 = arg1;
+			seg2 = arg2;
+		} else if (count === 0) {
+			seg1 = new Segment();
+			seg2 = new Segment();
+		} else if (count === 1) {
+			if ('segment1' in arg0) {
+				seg1 = new Segment(arg0.segment1);
+				seg2 = new Segment(arg0.segment2);
+			} else if ('point1' in arg0) {
+				point1 = arg0.point1;
+				handle1 = arg0.handle1;
+				handle2 = arg0.handle2;
+				point2 = arg0.point2;
+			} else if (Array.isArray(arg0)) {
+				point1 = [arg0[0], arg0[1]];
+				point2 = [arg0[6], arg0[7]];
+				handle1 = [arg0[2] - arg0[0], arg0[3] - arg0[1]];
+				handle2 = [arg0[4] - arg0[6], arg0[5] - arg0[7]];
+			}
+		} else if (count === 2) {
+			seg1 = new Segment(arg0);
+			seg2 = new Segment(arg1);
+		} else if (count === 4) {
+			point1 = arg0;
+			handle1 = arg1;
+			handle2 = arg2;
+			point2 = arg3;
+		} else if (count === 8) {
+			point1 = [arg0, arg1];
+			point2 = [arg6, arg7];
+			handle1 = [arg2 - arg0, arg3 - arg1];
+			handle2 = [arg4 - arg6, arg5 - arg7];
+		}
+		this._segment1 = seg1 || new Segment(point1, null, handle1);
+		this._segment2 = seg2 || new Segment(point2, handle2, null);
+	},
+
+	_serialize: function(options) {
+		return Base.serialize(this.hasHandles()
+				? [this.getPoint1(), this.getHandle1(), this.getHandle2(),
+					this.getPoint2()]
+				: [this.getPoint1(), this.getPoint2()],
+				options, true);
+	},
+
+	_changed: function() {
+		this._length = this._bounds = undefined;
+	},
+
+	clone: function() {
+		return new Curve(this._segment1, this._segment2);
+	},
+
+	toString: function() {
+		var parts = [ 'point1: ' + this._segment1._point ];
+		if (!this._segment1._handleOut.isZero())
+			parts.push('handle1: ' + this._segment1._handleOut);
+		if (!this._segment2._handleIn.isZero())
+			parts.push('handle2: ' + this._segment2._handleIn);
+		parts.push('point2: ' + this._segment2._point);
+		return '{ ' + parts.join(', ') + ' }';
+	},
+
+	remove: function() {
+		var removed = false;
+		if (this._path) {
+			var segment2 = this._segment2,
+				handleOut = segment2._handleOut;
+			removed = segment2.remove();
+			if (removed)
+				this._segment1._handleOut.set(handleOut.x, handleOut.y);
+		}
+		return removed;
+	},
+
+	getPoint1: function() {
+		return this._segment1._point;
+	},
+
+	setPoint1: function() {
+		var point = Point.read(arguments);
+		this._segment1._point.set(point.x, point.y);
+	},
+
+	getPoint2: function() {
+		return this._segment2._point;
+	},
+
+	setPoint2: function() {
+		var point = Point.read(arguments);
+		this._segment2._point.set(point.x, point.y);
+	},
+
+	getHandle1: function() {
+		return this._segment1._handleOut;
+	},
+
+	setHandle1: function() {
+		var point = Point.read(arguments);
+		this._segment1._handleOut.set(point.x, point.y);
+	},
+
+	getHandle2: function() {
+		return this._segment2._handleIn;
+	},
+
+	setHandle2: function() {
+		var point = Point.read(arguments);
+		this._segment2._handleIn.set(point.x, point.y);
+	},
+
+	getSegment1: function() {
+		return this._segment1;
+	},
+
+	getSegment2: function() {
+		return this._segment2;
+	},
+
+	getPath: function() {
+		return this._path;
+	},
+
+	getIndex: function() {
+		return this._segment1._index;
+	},
+
+	getNext: function() {
+		var curves = this._path && this._path._curves;
+		return curves && (curves[this._segment1._index + 1]
+				|| this._path._closed && curves[0]) || null;
+	},
+
+	getPrevious: function() {
+		var curves = this._path && this._path._curves;
+		return curves && (curves[this._segment1._index - 1]
+				|| this._path._closed && curves[curves.length - 1]) || null;
+	},
+
+	isFirst: function() {
+		return this._segment1._index === 0;
+	},
+
+	isLast: function() {
+		var path = this._path;
+		return path && this._segment1._index === path._curves.length - 1
+				|| false;
+	},
+
+	isSelected: function() {
+		return this.getPoint1().isSelected()
+				&& this.getHandle2().isSelected()
+				&& this.getHandle2().isSelected()
+				&& this.getPoint2().isSelected();
+	},
+
+	setSelected: function(selected) {
+		this.getPoint1().setSelected(selected);
+		this.getHandle1().setSelected(selected);
+		this.getHandle2().setSelected(selected);
+		this.getPoint2().setSelected(selected);
+	},
+
+	getValues: function(matrix) {
+		return Curve.getValues(this._segment1, this._segment2, matrix);
+	},
+
+	getPoints: function() {
+		var coords = this.getValues(),
+			points = [];
+		for (var i = 0; i < 8; i += 2)
+			points.push(new Point(coords[i], coords[i + 1]));
+		return points;
+	},
+
+	getLength: function() {
+		if (this._length == null)
+			this._length = Curve.getLength(this.getValues(), 0, 1);
+		return this._length;
+	},
+
+	getArea: function() {
+		return Curve.getArea(this.getValues());
+	},
+
+	getLine: function() {
+		return new Line(this._segment1._point, this._segment2._point);
+	},
+
+	getPart: function(from, to) {
+		return new Curve(Curve.getPart(this.getValues(), from, to));
+	},
+
+	getPartLength: function(from, to) {
+		return Curve.getLength(this.getValues(), from, to);
+	},
+
+	getIntersections: function(curve) {
+		return Curve._getIntersections(this.getValues(),
+				curve && curve !== this ? curve.getValues() : null,
+				this, curve, [], {});
+	},
+
+	_getParameter: function(offset, isParameter) {
+		return isParameter
+				? offset
+				: offset && offset.curve === this
+					? offset.parameter
+					: offset === undefined && isParameter === undefined
+						? 0.5
+						: this.getParameterAt(offset, 0);
+	},
+
+	divide: function(offset, isParameter, _setHandles) {
+		var parameter = this._getParameter(offset, isParameter),
+			tMin = 4e-7,
+			tMax = 1 - tMin,
+			res = null;
+		if (parameter >= tMin && parameter <= tMax) {
+			var parts = Curve.subdivide(this.getValues(), parameter),
+				left = parts[0],
+				right = parts[1],
+				setHandles = _setHandles || this.hasHandles(),
+				segment1 = this._segment1,
+				segment2 = this._segment2,
+				path = this._path;
+			if (setHandles) {
+				segment1._handleOut.set(left[2] - left[0], left[3] - left[1]);
+				segment2._handleIn.set(right[4] - right[6],right[5] - right[7]);
+			}
+			var x = left[6], y = left[7],
+				segment = new Segment(new Point(x, y),
+						setHandles && new Point(left[4] - x, left[5] - y),
+						setHandles && new Point(right[2] - x, right[3] - y));
+			if (path) {
+				path.insert(segment1._index + 1, segment);
+				res = this.getNext();
+			} else {
+				this._segment2 = segment;
+				res = new Curve(segment, segment2);
+			}
+		}
+		return res;
+	},
+
+	split: function(offset, isParameter) {
+		return this._path
+			? this._path.split(this._segment1._index,
+					this._getParameter(offset, isParameter))
+			: null;
+	},
+
+	reversed: function() {
+		return new Curve(this._segment2.reversed(), this._segment1.reversed());
+	},
+
+	clearHandles: function() {
+		this._segment1._handleOut.set(0, 0);
+		this._segment2._handleIn.set(0, 0);
+	},
+
+statics: {
+	getValues: function(segment1, segment2, matrix) {
+		var p1 = segment1._point,
+			h1 = segment1._handleOut,
+			h2 = segment2._handleIn,
+			p2 = segment2._point,
+			values = [
+				p1._x, p1._y,
+				p1._x + h1._x, p1._y + h1._y,
+				p2._x + h2._x, p2._y + h2._y,
+				p2._x, p2._y
+			];
+		if (matrix)
+			matrix._transformCoordinates(values, values, 4);
+		return values;
+	},
+
+	subdivide: function(v, t) {
+		var p1x = v[0], p1y = v[1],
+			c1x = v[2], c1y = v[3],
+			c2x = v[4], c2y = v[5],
+			p2x = v[6], p2y = v[7];
+		if (t === undefined)
+			t = 0.5;
+		var u = 1 - t,
+			p3x = u * p1x + t * c1x, p3y = u * p1y + t * c1y,
+			p4x = u * c1x + t * c2x, p4y = u * c1y + t * c2y,
+			p5x = u * c2x + t * p2x, p5y = u * c2y + t * p2y,
+			p6x = u * p3x + t * p4x, p6y = u * p3y + t * p4y,
+			p7x = u * p4x + t * p5x, p7y = u * p4y + t * p5y,
+			p8x = u * p6x + t * p7x, p8y = u * p6y + t * p7y;
+		return [
+			[p1x, p1y, p3x, p3y, p6x, p6y, p8x, p8y],
+			[p8x, p8y, p7x, p7y, p5x, p5y, p2x, p2y]
+		];
+	},
+
+	solveCubic: function (v, coord, val, roots, min, max) {
+		var p1 = v[coord],
+			c1 = v[coord + 2],
+			c2 = v[coord + 4],
+			p2 = v[coord + 6],
+			c = 3 * (c1 - p1),
+			b = 3 * (c2 - c1) - c,
+			a = p2 - p1 - c - b;
+		return Numerical.solveCubic(a, b, c, p1 - val, roots, min, max);
+	},
+
+	getParameterOf: function(v, point) {
+		var p1 = new Point(v[0], v[1]),
+			p2 = new Point(v[6], v[7]),
+			epsilon = 1e-12,
+			t = point.isClose(p1, epsilon) ? 0
+			  : point.isClose(p2, epsilon) ? 1
+			  : null;
+		if (t !== null)
+			return t;
+		var coords = [point.x, point.y],
+			roots = [],
+			geomEpsilon = 2e-7;
+		for (var c = 0; c < 2; c++) {
+			var count = Curve.solveCubic(v, c, coords[c], roots, 0, 1);
+			for (var i = 0; i < count; i++) {
+				t = roots[i];
+				if (point.isClose(Curve.getPoint(v, t), geomEpsilon))
+					return t;
+			}
+		}
+		return point.isClose(p1, geomEpsilon) ? 0
+			 : point.isClose(p2, geomEpsilon) ? 1
+			 : null;
+	},
+
+	getNearestParameter: function(v, point) {
+		if (Curve.isStraight(v)) {
+			var p1x = v[0], p1y = v[1],
+				p2x = v[6], p2y = v[7],
+				vx = p2x - p1x, vy = p2y - p1y,
+				det = vx * vx + vy * vy;
+			if (det === 0)
+				return 0;
+			var u = ((point.x - p1x) * vx + (point.y - p1y) * vy) / det;
+			return u < 1e-12 ? 0
+				 : u > 0.999999999999 ? 1
+				 : Curve.getParameterOf(v,
+					new Point(p1x + u * vx, p1y + u * vy));
+		}
+
+		var count = 100,
+			minDist = Infinity,
+			minT = 0;
+
+		function refine(t) {
+			if (t >= 0 && t <= 1) {
+				var dist = point.getDistance(Curve.getPoint(v, t), true);
+				if (dist < minDist) {
+					minDist = dist;
+					minT = t;
+					return true;
+				}
+			}
+		}
+
+		for (var i = 0; i <= count; i++)
+			refine(i / count);
+
+		var step = 1 / (count * 2);
+		while (step > 4e-7) {
+			if (!refine(minT - step) && !refine(minT + step))
+				step /= 2;
+		}
+		return minT;
+	},
+
+	getPart: function(v, from, to) {
+		var flip = from > to;
+		if (flip) {
+			var tmp = from;
+			from = to;
+			to = tmp;
+		}
+		if (from > 0)
+			v = Curve.subdivide(v, from)[1];
+		if (to < 1)
+			v = Curve.subdivide(v, (to - from) / (1 - from))[0];
+		return flip
+				? [v[6], v[7], v[4], v[5], v[2], v[3], v[0], v[1]]
+				: v;
+	},
+
+	isFlatEnough: function(v, tolerance) {
+		var p1x = v[0], p1y = v[1],
+			c1x = v[2], c1y = v[3],
+			c2x = v[4], c2y = v[5],
+			p2x = v[6], p2y = v[7],
+			ux = 3 * c1x - 2 * p1x - p2x,
+			uy = 3 * c1y - 2 * p1y - p2y,
+			vx = 3 * c2x - 2 * p2x - p1x,
+			vy = 3 * c2y - 2 * p2y - p1y;
+		return Math.max(ux * ux, vx * vx) + Math.max(uy * uy, vy * vy)
+				< 10 * tolerance * tolerance;
+	},
+
+	getArea: function(v) {
+		var p1x = v[0], p1y = v[1],
+			p2x = v[6], p2y = v[7],
+			h1x = (v[2] + p1x) / 2,
+			h1y = (v[3] + p1y) / 2,
+			h2x = (v[4] + v[6]) / 2,
+			h2y = (v[5] + v[7]) / 2;
+		return 6 * ((p1x - h1x) * (h1y + p1y)
+				  + (h1x - h2x) * (h2y + h1y)
+				  + (h2x - p2x) * (p2y + h2y)) / 10;
+	},
+
+	getBounds: function(v) {
+		var min = v.slice(0, 2),
+			max = min.slice(),
+			roots = [0, 0];
+		for (var i = 0; i < 2; i++)
+			Curve._addBounds(v[i], v[i + 2], v[i + 4], v[i + 6],
+					i, 0, min, max, roots);
+		return new Rectangle(min[0], min[1], max[0] - min[0], max[1] - min[1]);
+	},
+
+	_addBounds: function(v0, v1, v2, v3, coord, padding, min, max, roots) {
+		function add(value, padding) {
+			var left = value - padding,
+				right = value + padding;
+			if (left < min[coord])
+				min[coord] = left;
+			if (right > max[coord])
+				max[coord] = right;
+		}
+		var a = 3 * (v1 - v2) - v0 + v3,
+			b = 2 * (v0 + v2) - 4 * v1,
+			c = v1 - v0,
+			count = Numerical.solveQuadratic(a, b, c, roots),
+			tMin = 4e-7,
+			tMax = 1 - tMin;
+		add(v3, 0);
+		for (var i = 0; i < count; i++) {
+			var t = roots[i],
+				u = 1 - t;
+			if (tMin < t && t < tMax)
+				add(u * u * u * v0
+					+ 3 * u * u * t * v1
+					+ 3 * u * t * t * v2
+					+ t * t * t * v3,
+					padding);
+		}
+	}
+}}, Base.each(
+	['getBounds', 'getStrokeBounds', 'getHandleBounds', 'getRoughBounds'],
+	function(name) {
+		this[name] = function() {
+			if (!this._bounds)
+				this._bounds = {};
+			var bounds = this._bounds[name];
+			if (!bounds) {
+				var path = this._path;
+				bounds = this._bounds[name] = Path[name](
+						[this._segment1, this._segment2], false,
+						path && path.getStyle());
+			}
+			return bounds.clone();
+		};
+	},
+{
+
+}), Base.each({
+	isStraight: function(l, h1, h2) {
+		if (h1.isZero() && h2.isZero()) {
+			return true;
+		} else if (l.isZero()) {
+			return false;
+		} else if (h1.isCollinear(l) && h2.isCollinear(l)) {
+			var div = l.dot(l),
+				p1 = l.dot(h1) / div,
+				p2 = l.dot(h2) / div;
+			return p1 >= 0 && p1 <= 1 && p2 <= 0 && p2 >= -1;
+		}
+		return false;
+	},
+
+	isLinear: function(l, h1, h2) {
+		var third = l.divide(3);
+		return h1.equals(third) && h2.negate().equals(third);
+	}
+}, function(test, name) {
+	this[name] = function() {
+		var seg1 = this._segment1,
+			seg2 = this._segment2;
+		return test(seg2._point.subtract(seg1._point),
+				seg1._handleOut, seg2._handleIn);
+	};
+
+	this.statics[name] = function(v) {
+		var p1x = v[0], p1y = v[1],
+			p2x = v[6], p2y = v[7];
+		return test(new Point(p2x - p1x, p2y - p1y),
+				new Point(v[2] - p1x, v[3] - p1y),
+				new Point(v[4] - p2x, v[5] - p2y));
+	};
+}, {
+	statics: {},
+
+	hasHandles: function() {
+		return !this._segment1._handleOut.isZero()
+				|| !this._segment2._handleIn.isZero();
+	},
+
+	isCollinear: function(curve) {
+		return curve && this.isStraight() && curve.isStraight()
+				&& this.getLine().isCollinear(curve.getLine());
+	},
+
+	isHorizontal: function() {
+		return this.isStraight() && Math.abs(this.getTangentAt(0.5, true).y)
+				< 1e-7;
+	},
+
+	isVertical: function() {
+		return this.isStraight() && Math.abs(this.getTangentAt(0.5, true).x)
+				< 1e-7;
+	}
+}), {
+	beans: false,
+
+	getParameterAt: function(offset, start) {
+		return Curve.getParameterAt(this.getValues(), offset, start);
+	},
+
+	getParameterOf: function() {
+		return Curve.getParameterOf(this.getValues(), Point.read(arguments));
+	},
+
+	getLocationAt: function(offset, isParameter) {
+		var t = isParameter ? offset : this.getParameterAt(offset);
+		return t != null && t >= 0 && t <= 1
+				? new CurveLocation(this, t)
+				: null;
+	},
+
+	getLocationOf: function() {
+		return this.getLocationAt(this.getParameterOf(Point.read(arguments)),
+				true);
+	},
+
+	getOffsetOf: function() {
+		var loc = this.getLocationOf.apply(this, arguments);
+		return loc ? loc.getOffset() : null;
+	},
+
+	getNearestLocation: function() {
+		var point = Point.read(arguments),
+			values = this.getValues(),
+			t = Curve.getNearestParameter(values, point),
+			pt = Curve.getPoint(values, t);
+		return new CurveLocation(this, t, pt, null, point.getDistance(pt));
+	},
+
+	getNearestPoint: function() {
+		return this.getNearestLocation.apply(this, arguments).getPoint();
+	}
+
+},
+new function() {
+	var methods = ['getPoint', 'getTangent', 'getNormal', 'getWeightedTangent',
+		'getWeightedNormal', 'getCurvature'];
+	return Base.each(methods,
+	function(name) {
+		this[name + 'At'] = function(offset, isParameter) {
+			var values = this.getValues();
+			return Curve[name](values, isParameter ? offset
+					: Curve.getParameterAt(values, offset, 0));
+		};
+	}, {
+		statics: {
+			evaluateMethods: methods
+		}
+	});
+},
+new function() {
+
+	function getLengthIntegrand(v) {
+		var p1x = v[0], p1y = v[1],
+			c1x = v[2], c1y = v[3],
+			c2x = v[4], c2y = v[5],
+			p2x = v[6], p2y = v[7],
+
+			ax = 9 * (c1x - c2x) + 3 * (p2x - p1x),
+			bx = 6 * (p1x + c2x) - 12 * c1x,
+			cx = 3 * (c1x - p1x),
+
+			ay = 9 * (c1y - c2y) + 3 * (p2y - p1y),
+			by = 6 * (p1y + c2y) - 12 * c1y,
+			cy = 3 * (c1y - p1y);
+
+		return function(t) {
+			var dx = (ax * t + bx) * t + cx,
+				dy = (ay * t + by) * t + cy;
+			return Math.sqrt(dx * dx + dy * dy);
+		};
+	}
+
+	function getIterations(a, b) {
+		return Math.max(2, Math.min(16, Math.ceil(Math.abs(b - a) * 32)));
+	}
+
+	function evaluate(v, t, type, normalized) {
+		if (t == null || t < 0 || t > 1)
+			return null;
+		var p1x = v[0], p1y = v[1],
+			c1x = v[2], c1y = v[3],
+			c2x = v[4], c2y = v[5],
+			p2x = v[6], p2y = v[7],
+			tMin = 4e-7,
+			tMax = 1 - tMin,
+			isZero = Numerical.isZero,
+			x, y;
+		if (isZero(c1x - p1x) && isZero(c1y - p1y)) {
+			c1x = p1x;
+			c1y = p1y;
+		}
+		if (isZero(c2x - p2x) && isZero(c2y - p2y)) {
+			c2x = p2x;
+			c2y = p2y;
+		}
+		if (type === 0 && (t < tMin || t > tMax)) {
+			var zero = t < tMin;
+			x = zero ? p1x : p2x;
+			y = zero ? p1y : p2y;
+		} else {
+			var cx = 3 * (c1x - p1x),
+				bx = 3 * (c2x - c1x) - cx,
+				ax = p2x - p1x - cx - bx,
+
+				cy = 3 * (c1y - p1y),
+				by = 3 * (c2y - c1y) - cy,
+				ay = p2y - p1y - cy - by;
+			if (type === 0) {
+				x = ((ax * t + bx) * t + cx) * t + p1x;
+				y = ((ay * t + by) * t + cy) * t + p1y;
+			} else {
+				if (t < tMin) {
+					x = cx;
+					y = cy;
+				} else if (t > tMax) {
+					x = 3 * (p2x - c2x);
+					y = 3 * (p2y - c2y);
+				} else {
+					x = (3 * ax * t + 2 * bx) * t + cx;
+					y = (3 * ay * t + 2 * by) * t + cy;
+				}
+				if (normalized) {
+					if (x === 0 && y === 0 && (t < tMin || t > tMax)) {
+						x = c2x - c1x;
+						y = c2y - c1y;
+					}
+					var len = Math.sqrt(x * x + y * y);
+					if (len) {
+						x /= len;
+						y /= len;
+					}
+				}
+				if (type === 3) {
+					var x2 = 6 * ax * t + 2 * bx,
+						y2 = 6 * ay * t + 2 * by,
+						d = Math.pow(x * x + y * y, 3 / 2);
+					x = d !== 0 ? (x * y2 - y * x2) / d : 0;
+					y = 0;
+				}
+			}
+		}
+		return type === 2 ? new Point(y, -x) : new Point(x, y);
+	}
+
+	return { statics: {
+
+		getLength: function(v, a, b) {
+			if (a === undefined)
+				a = 0;
+			if (b === undefined)
+				b = 1;
+			if (a === 0 && b === 1 && Curve.isStraight(v)) {
+				var dx = v[6] - v[0],
+					dy = v[7] - v[1];
+				return Math.sqrt(dx * dx + dy * dy);
+			}
+			var ds = getLengthIntegrand(v);
+			return Numerical.integrate(ds, a, b, getIterations(a, b));
+		},
+
+		getParameterAt: function(v, offset, start) {
+			if (start === undefined)
+				start = offset < 0 ? 1 : 0;
+			if (offset === 0)
+				return start;
+			var abs = Math.abs,
+				forward = offset > 0,
+				a = forward ? start : 0,
+				b = forward ? 1 : start,
+				ds = getLengthIntegrand(v),
+				rangeLength = Numerical.integrate(ds, a, b,
+						getIterations(a, b));
+			if (abs(offset - rangeLength) < 1e-12) {
+				return forward ? b : a;
+			} else if (abs(offset) > rangeLength) {
+				return null;
+			}
+			var guess = offset / rangeLength,
+				length = 0;
+			function f(t) {
+				length += Numerical.integrate(ds, start, t,
+						getIterations(start, t));
+				start = t;
+				return length - offset;
+			}
+			return Numerical.findRoot(f, ds, start + guess, a, b, 32,
+					1e-12);
+		},
+
+		getPoint: function(v, t) {
+			return evaluate(v, t, 0, false);
+		},
+
+		getTangent: function(v, t) {
+			return evaluate(v, t, 1, true);
+		},
+
+		getWeightedTangent: function(v, t) {
+			return evaluate(v, t, 1, false);
+		},
+
+		getNormal: function(v, t) {
+			return evaluate(v, t, 2, true);
+		},
+
+		getWeightedNormal: function(v, t) {
+			return evaluate(v, t, 2, false);
+		},
+
+		getCurvature: function(v, t) {
+			return evaluate(v, t, 3, false).x;
+		}
+	}};
+},
+new function() {
+
+	function addLocation(locations, param, v1, c1, t1, p1, v2, c2, t2, p2,
+			overlap) {
+		var excludeStart = !overlap && param.excludeStart,
+			excludeEnd = !overlap && param.excludeEnd,
+			tMin = 4e-7,
+			tMax = 1 - tMin;
+		if (t1 == null)
+			t1 = Curve.getParameterOf(v1, p1);
+		if (t1 !== null && t1 >= (excludeStart ? tMin : 0) &&
+			t1 <= (excludeEnd ? tMax : 1)) {
+			if (t2 == null)
+				t2 = Curve.getParameterOf(v2, p2);
+			if (t2 !== null && t2 >= (excludeEnd ? tMin : 0) &&
+				t2 <= (excludeStart ? tMax : 1)) {
+				var renormalize = param.renormalize;
+				if (renormalize) {
+					var res = renormalize(t1, t2);
+					t1 = res[0];
+					t2 = res[1];
+				}
+				var loc1 = new CurveLocation(c1, t1,
+						p1 || Curve.getPoint(v1, t1), overlap),
+					loc2 = new CurveLocation(c2, t2,
+						p2 || Curve.getPoint(v2, t2), overlap),
+					flip = loc1.getPath() === loc2.getPath()
+						&& loc1.getIndex() > loc2.getIndex(),
+					loc = flip ? loc2 : loc1,
+					include = param.include;
+				loc1._intersection = loc2;
+				loc2._intersection = loc1;
+				if (!include || include(loc)) {
+					CurveLocation.insert(locations, loc, true);
+				}
+			}
+		}
+	}
+
+	function addCurveIntersections(v1, v2, c1, c2, locations, param, tMin, tMax,
+			uMin, uMax, reverse, recursion) {
+		if (++recursion >= 26)
+			return;
+		var q0x = v2[0], q0y = v2[1], q3x = v2[6], q3y = v2[7],
+			getSignedDistance = Line.getSignedDistance,
+			d1 = getSignedDistance(q0x, q0y, q3x, q3y, v2[2], v2[3]),
+			d2 = getSignedDistance(q0x, q0y, q3x, q3y, v2[4], v2[5]),
+			factor = d1 * d2 > 0 ? 3 / 4 : 4 / 9,
+			dMin = factor * Math.min(0, d1, d2),
+			dMax = factor * Math.max(0, d1, d2),
+			dp0 = getSignedDistance(q0x, q0y, q3x, q3y, v1[0], v1[1]),
+			dp1 = getSignedDistance(q0x, q0y, q3x, q3y, v1[2], v1[3]),
+			dp2 = getSignedDistance(q0x, q0y, q3x, q3y, v1[4], v1[5]),
+			dp3 = getSignedDistance(q0x, q0y, q3x, q3y, v1[6], v1[7]),
+			hull = getConvexHull(dp0, dp1, dp2, dp3),
+			top = hull[0],
+			bottom = hull[1],
+			tMinClip,
+			tMaxClip;
+		if (d1 === 0 && d2 === 0
+				&& dp0 === 0 && dp1 === 0 && dp2 === 0 && dp3 === 0
+			|| (tMinClip = clipConvexHull(top, bottom, dMin, dMax)) == null
+			|| (tMaxClip = clipConvexHull(top.reverse(), bottom.reverse(),
+				dMin, dMax)) == null)
+			return;
+		var tMinNew = tMin + (tMax - tMin) * tMinClip,
+			tMaxNew = tMin + (tMax - tMin) * tMaxClip;
+		if (Math.max(uMax - uMin, tMaxNew - tMinNew)
+				< 1e-7) {
+			var t = (tMinNew + tMaxNew) / 2,
+				u = (uMin + uMax) / 2;
+			v1 = c1.getValues();
+			v2 = c2.getValues();
+			addLocation(locations, param,
+				reverse ? v2 : v1, reverse ? c2 : c1, reverse ? u : t, null,
+				reverse ? v1 : v2, reverse ? c1 : c2, reverse ? t : u, null);
+		} else {
+			v1 = Curve.getPart(v1, tMinClip, tMaxClip);
+			if (tMaxClip - tMinClip > 0.8) {
+				if (tMaxNew - tMinNew > uMax - uMin) {
+					var parts = Curve.subdivide(v1, 0.5),
+						t = (tMinNew + tMaxNew) / 2;
+					addCurveIntersections(
+							v2, parts[0], c2, c1, locations, param,
+							uMin, uMax, tMinNew, t, !reverse, recursion);
+					addCurveIntersections(
+							v2, parts[1], c2, c1, locations, param,
+							uMin, uMax, t, tMaxNew, !reverse, recursion);
+				} else {
+					var parts = Curve.subdivide(v2, 0.5),
+						u = (uMin + uMax) / 2;
+					addCurveIntersections(
+							parts[0], v1, c2, c1, locations, param,
+							uMin, u, tMinNew, tMaxNew, !reverse, recursion);
+					addCurveIntersections(
+							parts[1], v1, c2, c1, locations, param,
+							u, uMax, tMinNew, tMaxNew, !reverse, recursion);
+				}
+			} else {
+				addCurveIntersections(v2, v1, c2, c1, locations, param,
+						uMin, uMax, tMinNew, tMaxNew, !reverse, recursion);
+			}
+		}
+	}
+
+	function getConvexHull(dq0, dq1, dq2, dq3) {
+		var p0 = [ 0, dq0 ],
+			p1 = [ 1 / 3, dq1 ],
+			p2 = [ 2 / 3, dq2 ],
+			p3 = [ 1, dq3 ],
+			dist1 = dq1 - (2 * dq0 + dq3) / 3,
+			dist2 = dq2 - (dq0 + 2 * dq3) / 3,
+			hull;
+		if (dist1 * dist2 < 0) {
+			hull = [[p0, p1, p3], [p0, p2, p3]];
+		} else {
+			var distRatio = dist1 / dist2;
+			hull = [
+				distRatio >= 2 ? [p0, p1, p3]
+				: distRatio <= 0.5 ? [p0, p2, p3]
+				: [p0, p1, p2, p3],
+				[p0, p3]
+			];
+		}
+		return (dist1 || dist2) < 0 ? hull.reverse() : hull;
+	}
+
+	function clipConvexHull(hullTop, hullBottom, dMin, dMax) {
+		if (hullTop[0][1] < dMin) {
+			return clipConvexHullPart(hullTop, true, dMin);
+		} else if (hullBottom[0][1] > dMax) {
+			return clipConvexHullPart(hullBottom, false, dMax);
+		} else {
+			return hullTop[0][0];
+		}
+	}
+
+	function clipConvexHullPart(part, top, threshold) {
+		var px = part[0][0],
+			py = part[0][1];
+		for (var i = 1, l = part.length; i < l; i++) {
+			var qx = part[i][0],
+				qy = part[i][1];
+			if (top ? qy >= threshold : qy <= threshold) {
+				return qy === threshold ? qx
+						: px + (threshold - py) * (qx - px) / (qy - py);
+			}
+			px = qx;
+			py = qy;
+		}
+		return null;
+	}
+
+	function addCurveLineIntersections(v1, v2, c1, c2, locations, param) {
+		var flip = Curve.isStraight(v1),
+			vc = flip ? v2 : v1,
+			vl = flip ? v1 : v2,
+			lx1 = vl[0], ly1 = vl[1],
+			lx2 = vl[6], ly2 = vl[7],
+			ldx = lx2 - lx1,
+			ldy = ly2 - ly1,
+			angle = Math.atan2(-ldy, ldx),
+			sin = Math.sin(angle),
+			cos = Math.cos(angle),
+			rvc = [];
+		for(var i = 0; i < 8; i += 2) {
+			var x = vc[i] - lx1,
+				y = vc[i + 1] - ly1;
+			rvc.push(
+				x * cos - y * sin,
+				x * sin + y * cos);
+		}
+		var roots = [],
+			count = Curve.solveCubic(rvc, 1, 0, roots, 0, 1);
+		for (var i = 0; i < count; i++) {
+			var tc = roots[i],
+				pc = Curve.getPoint(vc, tc),
+				tl = Curve.getParameterOf(vl, pc);
+			if (tl !== null) {
+				var pl = Curve.getPoint(vl, tl),
+					t1 = flip ? tl : tc,
+					t2 = flip ? tc : tl;
+				if (!param.excludeEnd || t2 > Numerical.CURVETIME_EPSILON) {
+					addLocation(locations, param,
+							v1, c1, t1, flip ? pl : pc,
+							v2, c2, t2, flip ? pc : pl);
+				}
+			}
+		}
+	}
+
+	function addLineIntersection(v1, v2, c1, c2, locations, param) {
+		var pt = Line.intersect(
+				v1[0], v1[1], v1[6], v1[7],
+				v2[0], v2[1], v2[6], v2[7]);
+		if (pt) {
+			addLocation(locations, param, v1, c1, null, pt, v2, c2, null, pt);
+		}
+	}
+
+	return { statics: {
+		_getIntersections: function(v1, v2, c1, c2, locations, param) {
+			if (!v2) {
+				return Curve._getSelfIntersection(v1, c1, locations, param);
+			}
+			var epsilon = 2e-7,
+				c1p1x = v1[0], c1p1y = v1[1],
+				c1p2x = v1[6], c1p2y = v1[7],
+				c2p1x = v2[0], c2p1y = v2[1],
+				c2p2x = v2[6], c2p2y = v2[7],
+				c1s1x = (3 * v1[2] + c1p1x) / 4,
+				c1s1y = (3 * v1[3] + c1p1y) / 4,
+				c1s2x = (3 * v1[4] + c1p2x) / 4,
+				c1s2y = (3 * v1[5] + c1p2y) / 4,
+				c2s1x = (3 * v2[2] + c2p1x) / 4,
+				c2s1y = (3 * v2[3] + c2p1y) / 4,
+				c2s2x = (3 * v2[4] + c2p2x) / 4,
+				c2s2y = (3 * v2[5] + c2p2y) / 4,
+				min = Math.min,
+				max = Math.max;
+			if (!(	max(c1p1x, c1s1x, c1s2x, c1p2x) + epsilon >
+					min(c2p1x, c2s1x, c2s2x, c2p2x) &&
+					min(c1p1x, c1s1x, c1s2x, c1p2x) - epsilon <
+					max(c2p1x, c2s1x, c2s2x, c2p2x) &&
+					max(c1p1y, c1s1y, c1s2y, c1p2y) + epsilon >
+					min(c2p1y, c2s1y, c2s2y, c2p2y) &&
+					min(c1p1y, c1s1y, c1s2y, c1p2y) - epsilon <
+					max(c2p1y, c2s1y, c2s2y, c2p2y)))
+				return locations;
+			var overlaps = Curve.getOverlaps(v1, v2);
+			if (overlaps) {
+				for (var i = 0; i < 2; i++) {
+					var overlap = overlaps[i];
+					addLocation(locations, param,
+						v1, c1, overlap[0], null,
+						v2, c2, overlap[1], null, true);
+				}
+				return locations;
+			}
+
+			var straight1 = Curve.isStraight(v1),
+				straight2 = Curve.isStraight(v2),
+				straight = straight1 && straight2,
+				before = locations.length;
+			(straight
+				? addLineIntersection
+				: straight1 || straight2
+					? addCurveLineIntersections
+					: addCurveIntersections)(
+						v1, v2, c1, c2, locations, param,
+						0, 1, 0, 1, 0, 0);
+			if (straight && locations.length > before)
+				return locations;
+			var c1p1 = new Point(c1p1x, c1p1y),
+				c1p2 = new Point(c1p2x, c1p2y),
+				c2p1 = new Point(c2p1x, c2p1y),
+				c2p2 = new Point(c2p2x, c2p2y);
+			if (c1p1.isClose(c2p1, epsilon))
+				addLocation(locations, param, v1, c1, 0, c1p1, v2, c2, 0, c2p1);
+			if (!param.excludeStart && c1p1.isClose(c2p2, epsilon))
+				addLocation(locations, param, v1, c1, 0, c1p1, v2, c2, 1, c2p2);
+			if (!param.excludeEnd && c1p2.isClose(c2p1, epsilon))
+				addLocation(locations, param, v1, c1, 1, c1p2, v2, c2, 0, c2p1);
+			if (c1p2.isClose(c2p2, epsilon))
+				addLocation(locations, param, v1, c1, 1, c1p2, v2, c2, 1, c2p2);
+			return locations;
+		},
+
+		_getSelfIntersection: function(v1, c1, locations, param) {
+			var p1x = v1[0], p1y = v1[1],
+				h1x = v1[2], h1y = v1[3],
+				h2x = v1[4], h2y = v1[5],
+				p2x = v1[6], p2y = v1[7];
+			var line = new Line(p1x, p1y, p2x, p2y, false),
+				side1 = line.getSide(new Point(h1x, h1y), true),
+				side2 = line.getSide(new Point(h2x, h2y), true);
+			if (side1 === side2) {
+				var edgeSum = (p1x - h2x) * (h1y - p2y)
+							+ (h1x - p2x) * (h2y - p1y);
+				if (edgeSum * side1 > 0)
+					return locations;
+			}
+			var ax = p2x - 3 * h2x + 3 * h1x - p1x,
+				bx = h2x - 2 * h1x + p1x,
+				cx = h1x - p1x,
+				ay = p2y - 3 * h2y + 3 * h1y - p1y,
+				by = h2y - 2 * h1y + p1y,
+				cy = h1y - p1y,
+				ac = ay * cx - ax * cy,
+				ab = ay * bx - ax * by,
+				bc = by * cx - bx * cy;
+			if (ac * ac - 4 * ab * bc < 0) {
+				var roots = [],
+					tSplit,
+					count = Numerical.solveCubic(
+							ax * ax  + ay * ay,
+							3 * (ax * bx + ay * by),
+							2 * (bx * bx + by * by) + ax * cx + ay * cy,
+							bx * cx + by * cy,
+							roots, 0, 1);
+				if (count > 0) {
+					for (var i = 0, maxCurvature = 0; i < count; i++) {
+						var curvature = Math.abs(
+								c1.getCurvatureAt(roots[i], true));
+						if (curvature > maxCurvature) {
+							maxCurvature = curvature;
+							tSplit = roots[i];
+						}
+					}
+					var parts = Curve.subdivide(v1, tSplit);
+					param.excludeEnd = true;
+					param.renormalize = function(t1, t2) {
+						return [t1 * tSplit, t2 * (1 - tSplit) + tSplit];
+					};
+					Curve._getIntersections(parts[0], parts[1], c1, c1,
+							locations, param);
+				}
+			}
+			return locations;
+		},
+
+		getOverlaps: function(v1, v2) {
+			var abs = Math.abs,
+				timeEpsilon = 4e-7,
+				geomEpsilon = 2e-7,
+				straight1 = Curve.isStraight(v1),
+				straight2 = Curve.isStraight(v2),
+				straightBoth =	straight1 && straight2;
+
+			function getSquaredLineLength(v) {
+				var x = v[6] - v[0],
+					y = v[7] - v[1];
+				return x * x + y * y;
+			}
+
+			var flip = getSquaredLineLength(v1) < getSquaredLineLength(v2),
+				l1 = flip ? v2 : v1,
+				l2 = flip ? v1 : v2,
+				line = new Line(l1[0], l1[1], l1[6], l1[7]);
+			if (line.getDistance(new Point(l2[0], l2[1])) < geomEpsilon &&
+				line.getDistance(new Point(l2[6], l2[7])) < geomEpsilon) {
+				if (!straightBoth &&
+					line.getDistance(new Point(l1[2], l1[3])) < geomEpsilon &&
+					line.getDistance(new Point(l1[4], l1[5])) < geomEpsilon &&
+					line.getDistance(new Point(l2[2], l2[3])) < geomEpsilon &&
+					line.getDistance(new Point(l2[4], l2[5])) < geomEpsilon) {
+					straight1 = straight2 = straightBoth = true;
+				}
+			} else if (straightBoth) {
+				return null;
+			}
+			if (straight1 ^ straight2) {
+				return null;
+			}
+
+			var v = [v1, v2],
+				pairs = [];
+			for (var i = 0, t1 = 0;
+					i < 2 && pairs.length < 2;
+					i += t1 === 0 ? 0 : 1, t1 = t1 ^ 1) {
+				var t2 = Curve.getParameterOf(v[i ^ 1], new Point(
+						v[i][t1 === 0 ? 0 : 6],
+						v[i][t1 === 0 ? 1 : 7]));
+				if (t2 != null) {
+					var pair = i === 0 ? [t1, t2] : [t2, t1];
+					if (pairs.length === 0 ||
+						abs(pair[0] - pairs[0][0]) > timeEpsilon &&
+						abs(pair[1] - pairs[0][1]) > timeEpsilon)
+						pairs.push(pair);
+				}
+				if (i === 1 && pairs.length === 0)
+					break;
+			}
+			if (pairs.length !== 2) {
+				pairs = null;
+			} else if (!straightBoth) {
+				var o1 = Curve.getPart(v1, pairs[0][0], pairs[1][0]),
+					o2 = Curve.getPart(v2, pairs[0][1], pairs[1][1]);
+				if (abs(o2[2] - o1[2]) > geomEpsilon ||
+					abs(o2[3] - o1[3]) > geomEpsilon ||
+					abs(o2[4] - o1[4]) > geomEpsilon ||
+					abs(o2[5] - o1[5]) > geomEpsilon)
+					pairs = null;
+			}
+			return pairs;
+		}
+	}};
+});
+
+var CurveLocation = Base.extend({
+	_class: 'CurveLocation',
+	beans: true,
+
+	initialize: function CurveLocation(curve, parameter, point,
+			_overlap, _distance) {
+		if (parameter > 0.9999996) {
+			var next = curve.getNext();
+			if (next) {
+				parameter = 0;
+				curve = next;
+			}
+		}
+		this._id = UID.get(CurveLocation);
+		this._setCurve(curve);
+		this._parameter = parameter;
+		this._point = point || curve.getPointAt(parameter, true);
+		this._overlap = _overlap;
+		this._distance = _distance;
+		this._intersection = this._next = this._prev = null;
+	},
+
+	_setCurve: function(curve) {
+		var path = curve._path;
+		this._path = path;
+		this._version = path ? path._version : 0;
+		this._curve = curve;
+		this._segment = null;
+		this._segment1 = curve._segment1;
+		this._segment2 = curve._segment2;
+	},
+
+	_setSegment: function(segment) {
+		this._setCurve(segment.getCurve());
+		this._segment = segment;
+		this._parameter = segment === this._segment1 ? 0 : 1;
+		this._point = segment._point.clone();
+	},
+
+	getSegment: function() {
+		var curve = this.getCurve(),
+			segment = this._segment;
+		if (!segment) {
+			var parameter = this.getParameter();
+			if (parameter === 0) {
+				segment = curve._segment1;
+			} else if (parameter === 1) {
+				segment = curve._segment2;
+			} else if (parameter != null) {
+				segment = curve.getPartLength(0, parameter)
+					< curve.getPartLength(parameter, 1)
+						? curve._segment1
+						: curve._segment2;
+			}
+			this._segment = segment;
+		}
+		return segment;
+	},
+
+	getCurve: function() {
+		var path = this._path,
+			that = this;
+		if (path && path._version !== this._version) {
+			this._parameter = this._curve = this._offset = null;
+		}
+
+		function trySegment(segment) {
+			var curve = segment && segment.getCurve();
+			if (curve && (that._parameter = curve.getParameterOf(that._point))
+					!= null) {
+				that._setCurve(curve);
+				that._segment = segment;
+				return curve;
+			}
+		}
+
+		return this._curve
+			|| trySegment(this._segment)
+			|| trySegment(this._segment1)
+			|| trySegment(this._segment2.getPrevious());
+	},
+
+	getPath: function() {
+		var curve = this.getCurve();
+		return curve && curve._path;
+	},
+
+	getIndex: function() {
+		var curve = this.getCurve();
+		return curve && curve.getIndex();
+	},
+
+	getParameter: function() {
+		var curve = this.getCurve(),
+			parameter = this._parameter;
+		return curve && parameter == null
+			? this._parameter = curve.getParameterOf(this._point)
+			: parameter;
+	},
+
+	getPoint: function() {
+		return this._point;
+	},
+
+	getOffset: function() {
+		var offset = this._offset;
+		if (offset == null) {
+			offset = 0;
+			var path = this.getPath(),
+				index = this.getIndex();
+			if (path && index != null) {
+				var curves = path.getCurves();
+				for (var i = 0; i < index; i++)
+					offset += curves[i].getLength();
+			}
+			this._offset = offset += this.getCurveOffset();
+		}
+		return offset;
+	},
+
+	getCurveOffset: function() {
+		var curve = this.getCurve(),
+			parameter = this.getParameter();
+		return parameter != null && curve && curve.getPartLength(0, parameter);
+	},
+
+	getIntersection: function() {
+		return this._intersection;
+	},
+
+	getDistance: function() {
+		return this._distance;
+	},
+
+	divide: function() {
+		var curve = this.getCurve(),
+			res = null;
+		if (curve) {
+			res = curve.divide(this.getParameter(), true);
+			if (res)
+				this._setSegment(res._segment1);
+		}
+		return res;
+	},
+
+	split: function() {
+		var curve = this.getCurve();
+		return curve ? curve.split(this.getParameter(), true) : null;
+	},
+
+	equals: function(loc, _ignoreOther) {
+		var res = this === loc,
+			epsilon = 2e-7;
+		if (!res && loc instanceof CurveLocation
+				&& this.getPath() === loc.getPath()
+				&& this.getPoint().isClose(loc.getPoint(), epsilon)) {
+			var c1 = this.getCurve(),
+				c2 = loc.getCurve(),
+				abs = Math.abs,
+				diff = abs(
+					((c1.isLast() && c2.isFirst() ? -1 : c1.getIndex())
+							+ this.getParameter()) -
+					((c2.isLast() && c1.isFirst() ? -1 : c2.getIndex())
+							+ loc.getParameter()));
+			res = (diff < 4e-7
+				|| ((diff = abs(this.getOffset() - loc.getOffset())) < epsilon
+					|| abs(this.getPath().getLength() - diff) < epsilon))
+				&& (_ignoreOther
+					|| (!this._intersection && !loc._intersection
+						|| this._intersection && this._intersection.equals(
+								loc._intersection, true)));
+		}
+		return res;
+	},
+
+	toString: function() {
+		var parts = [],
+			point = this.getPoint(),
+			f = Formatter.instance;
+		if (point)
+			parts.push('point: ' + point);
+		var index = this.getIndex();
+		if (index != null)
+			parts.push('index: ' + index);
+		var parameter = this.getParameter();
+		if (parameter != null)
+			parts.push('parameter: ' + f.number(parameter));
+		if (this._distance != null)
+			parts.push('distance: ' + f.number(this._distance));
+		return '{ ' + parts.join(', ') + ' }';
+	},
+
+	isTouching: function() {
+		var inter = this._intersection;
+		if (inter && this.getTangent().isCollinear(inter.getTangent())) {
+			var curve1 = this.getCurve(),
+				curve2 = inter.getCurve();
+			return !(curve1.isStraight() && curve2.isStraight()
+					&& curve1.getLine().intersect(curve2.getLine()));
+		}
+		return false;
+	},
+
+	isCrossing: function() {
+		var inter = this._intersection;
+		if (!inter)
+			return false;
+		var t1 = this.getParameter(),
+			t2 = inter.getParameter(),
+			tMin = 4e-7,
+			tMax = 1 - tMin,
+			t1Inside = t1 > tMin && t1 < tMax,
+			t2Inside = t2 > tMin && t2 < tMax;
+		if (t1Inside && t2Inside)
+			return !this.isTouching();
+		var c2 = this.getCurve(),
+			c1 = t1 <= tMin ? c2.getPrevious() : c2,
+			c4 = inter.getCurve(),
+			c3 = t2 <= tMin ? c4.getPrevious() : c4;
+		if (t1 >= tMax)
+			c2 = c2.getNext();
+		if (t2 >= tMax)
+			c4 = c4.getNext();
+		if (!c1 || !c2 || !c3 || !c4)
+			return false;
+		if (t1Inside || t2Inside) {
+			var c = t1Inside ? c2 : c4;
+			if (c.isStraight()) {
+				var l = c.getLine(),
+					l1 = t1Inside ? c3 : c1,
+					l2 = t1Inside ? c4 : c2,
+					straight1 = l1.isStraight(),
+					straight2 = l2.isStraight();
+				if (straight1 || straight2) {
+					return straight1 && l.intersect(l1.getLine()) ||
+						   straight2 && l.intersect(l2.getLine());
+				}
+			}
+		}
+
+		function isInRange(angle, min, max) {
+			return min < max
+				? angle > min && angle < max
+				: angle > min && angle <= 180 || angle >= -180 && angle < max;
+		}
+
+		var v2 = c2.getTangentAt(t1Inside ? t1 : tMin, true),
+			v1 = (t1Inside ? v2 : c1.getTangentAt(tMax, true)).negate(),
+			v4 = c4.getTangentAt(t2Inside ? t2 : tMin, true),
+			v3 = (t2Inside ? v4 : c3.getTangentAt(tMax, true)).negate(),
+			a1 = v1.getAngle(),
+			a2 = v2.getAngle(),
+			a3 = v3.getAngle(),
+			a4 = v4.getAngle();
+		return !!(t1Inside
+				? (isInRange(a1, a3, a4) ^ isInRange(a2, a3, a4)) &&
+				  (isInRange(a1, a4, a3) ^ isInRange(a2, a4, a3))
+				: (isInRange(a3, a1, a2) ^ isInRange(a4, a1, a2)) &&
+				  (isInRange(a3, a2, a1) ^ isInRange(a4, a2, a1)));
+	},
+
+	hasOverlap: function() {
+		return !!this._overlap;
+	}
+}, Base.each(Curve.evaluateMethods, function(name) {
+	var get = name + 'At';
+	this[name] = function() {
+		var parameter = this.getParameter(),
+			curve = this.getCurve();
+		return parameter != null && curve && curve[get](parameter, true);
+	};
+}, {
+	preserve: true
+}),
+new function() {
+
+	function insert(locations, loc, merge) {
+		var length = locations.length,
+			l = 0,
+			r = length - 1;
+
+		function search(index, dir) {
+			for (var i = index + dir; i >= -1 && i <= length; i += dir) {
+				var loc2 = locations[((i % length) + length) % length];
+				if (!loc.getPoint().isClose(loc2.getPoint(),
+						2e-7))
+					break;
+				if (loc.equals(loc2))
+					return loc2;
+			}
+			return null;
+		}
+
+		while (l <= r) {
+			var m = (l + r) >>> 1,
+				loc2 = locations[m],
+				found;
+			if (merge && (found = loc.equals(loc2) ? loc2
+					: (search(m, -1) || search(m, 1)))) {
+				if (loc._overlap) {
+					found._overlap = found._intersection._overlap = true;
+				}
+				return found;
+			}
+		var path1 = loc.getPath(),
+			path2 = loc2.getPath(),
+			diff = path1 === path2
+				? (loc.getIndex() + loc.getParameter())
+				- (loc2.getIndex() + loc2.getParameter())
+				: path1._id - path2._id;
+			if (diff < 0) {
+				r = m - 1;
+			} else {
+				l = m + 1;
+			}
+		}
+		locations.splice(l, 0, loc);
+		return loc;
+	}
+
+	return { statics: {
+		insert: insert,
+
+		expand: function(locations) {
+			var expanded = locations.slice();
+			for (var i = locations.length - 1; i >= 0; i--) {
+				insert(expanded, locations[i]._intersection, false);
+			}
+			return expanded;
+		}
+	}};
+});
+
+var PathItem = Item.extend({
+	_class: 'PathItem',
+	_canScaleStroke: true,
+
+	initialize: function PathItem() {
+	},
+
+	getIntersections: function(path, include, _matrix, _returnFirst) {
+		var self = this === path || !path,
+			matrix1 = this._matrix.orNullIfIdentity(),
+			matrix2 = self ? matrix1
+				: (_matrix || path._matrix).orNullIfIdentity();
+		if (!self && !this.getBounds(matrix1).touches(path.getBounds(matrix2)))
+			return [];
+		var curves1 = this.getCurves(),
+			curves2 = self ? curves1 : path.getCurves(),
+			length1 = curves1.length,
+			length2 = self ? length1 : curves2.length,
+			values2 = [],
+			arrays = [],
+			locations,
+			path;
+		for (var i = 0; i < length2; i++)
+			values2[i] = curves2[i].getValues(matrix2);
+		for (var i = 0; i < length1; i++) {
+			var curve1 = curves1[i],
+				values1 = self ? values2[i] : curve1.getValues(matrix1),
+				path1 = curve1.getPath();
+			if (path1 !== path) {
+				path = path1;
+				locations = [];
+				arrays.push(locations);
+			}
+			if (self) {
+				Curve._getSelfIntersection(values1, curve1, locations, {
+					include: include,
+					excludeStart: length1 === 1 &&
+							curve1.getPoint1().equals(curve1.getPoint2())
+				});
+			}
+			for (var j = self ? i + 1 : 0; j < length2; j++) {
+				if (_returnFirst && locations.length)
+					return locations;
+				var curve2 = curves2[j];
+				Curve._getIntersections(
+					values1, values2[j], curve1, curve2, locations,
+					{
+						include: include,
+						excludeStart: self && curve1.getPrevious() === curve2,
+						excludeEnd: self && curve1.getNext() === curve2
+					}
+				);
+			}
+		}
+		locations = [];
+		for (var i = 0, l = arrays.length; i < l; i++) {
+			locations.push.apply(locations, arrays[i]);
+		}
+		return locations;
+	},
+
+	getCrossings: function(path) {
+		return this.getIntersections(path, function(inter) {
+			return inter._overlap || inter.isCrossing();
+		});
+	},
+
+	_asPathItem: function() {
+		return this;
+	},
+
+	setPathData: function(data) {
+
+		var parts = data.match(/[mlhvcsqtaz][^mlhvcsqtaz]*/ig),
+			coords,
+			relative = false,
+			previous,
+			control,
+			current = new Point(),
+			start = new Point();
+
+		function getCoord(index, coord) {
+			var val = +coords[index];
+			if (relative)
+				val += current[coord];
+			return val;
+		}
+
+		function getPoint(index) {
+			return new Point(
+				getCoord(index, 'x'),
+				getCoord(index + 1, 'y')
+			);
+		}
+
+		this.clear();
+
+		for (var i = 0, l = parts && parts.length; i < l; i++) {
+			var part = parts[i],
+				command = part[0],
+				lower = command.toLowerCase();
+			coords = part.match(/[+-]?(?:\d*\.\d+|\d+\.?)(?:[eE][+-]?\d+)?/g);
+			var length = coords && coords.length;
+			relative = command === lower;
+			if (previous === 'z' && !/[mz]/.test(lower))
+				this.moveTo(current = start);
+			switch (lower) {
+			case 'm':
+			case 'l':
+				var move = lower === 'm';
+				for (var j = 0; j < length; j += 2)
+					this[j === 0 && move ? 'moveTo' : 'lineTo'](
+							current = getPoint(j));
+				control = current;
+				if (move)
+					start = current;
+				break;
+			case 'h':
+			case 'v':
+				var coord = lower === 'h' ? 'x' : 'y';
+				for (var j = 0; j < length; j++) {
+					current[coord] = getCoord(j, coord);
+					this.lineTo(current);
+				}
+				control = current;
+				break;
+			case 'c':
+				for (var j = 0; j < length; j += 6) {
+					this.cubicCurveTo(
+							getPoint(j),
+							control = getPoint(j + 2),
+							current = getPoint(j + 4));
+				}
+				break;
+			case 's':
+				for (var j = 0; j < length; j += 4) {
+					this.cubicCurveTo(
+							/[cs]/.test(previous)
+									? current.multiply(2).subtract(control)
+									: current,
+							control = getPoint(j),
+							current = getPoint(j + 2));
+					previous = lower;
+				}
+				break;
+			case 'q':
+				for (var j = 0; j < length; j += 4) {
+					this.quadraticCurveTo(
+							control = getPoint(j),
+							current = getPoint(j + 2));
+				}
+				break;
+			case 't':
+				for (var j = 0; j < length; j += 2) {
+					this.quadraticCurveTo(
+							control = (/[qt]/.test(previous)
+									? current.multiply(2).subtract(control)
+									: current),
+							current = getPoint(j));
+					previous = lower;
+				}
+				break;
+			case 'a':
+				for (var j = 0; j < length; j += 7) {
+					this.arcTo(current = getPoint(j + 5),
+							new Size(+coords[j], +coords[j + 1]),
+							+coords[j + 2], +coords[j + 4], +coords[j + 3]);
+				}
+				break;
+			case 'z':
+				this.closePath(true);
+				break;
+			}
+			previous = lower;
+		}
+	},
+
+	_canComposite: function() {
+		return !(this.hasFill() && this.hasStroke());
+	},
+
+	_contains: function(point) {
+		var winding = point.isInside(this.getInternalHandleBounds())
+				&& this._getWinding(point);
+		return !!(this.getFillRule() === 'evenodd' ? winding & 1 : winding);
+	}
+
+});
+
+var Path = PathItem.extend({
+	_class: 'Path',
+	_serializeFields: {
+		segments: [],
+		closed: false
+	},
+
+	initialize: function Path(arg) {
+		this._closed = false;
+		this._segments = [];
+		this._version = 0;
+		var segments = Array.isArray(arg)
+			? typeof arg[0] === 'object'
+				? arg
+				: arguments
+			: arg && (arg.size === undefined && (arg.x !== undefined
+					|| arg.point !== undefined))
+				? arguments
+				: null;
+		if (segments && segments.length > 0) {
+			this.setSegments(segments);
+		} else {
+			this._curves = undefined;
+			this._selectedSegmentState = 0;
+			if (!segments && typeof arg === 'string') {
+				this.setPathData(arg);
+				arg = null;
+			}
+		}
+		this._initialize(!segments && arg);
+	},
+
+	_equals: function(item) {
+		return this._closed === item._closed
+				&& Base.equals(this._segments, item._segments);
+	},
+
+	copyContent: function(source) {
+		this.setSegments(source._segments);
+		this._closed = source._closed;
+		var clockwise = source._clockwise;
+		if (clockwise !== undefined)
+			this._clockwise = clockwise;
+	},
+
+	_changed: function _changed(flags) {
+		_changed.base.call(this, flags);
+		if (flags & 8) {
+			this._length = this._area = this._clockwise = this._monoCurves =
+					undefined;
+			if (flags & 16) {
+				this._version++;
+			} else if (this._curves) {
+			   for (var i = 0, l = this._curves.length; i < l; i++)
+					this._curves[i]._changed();
+			}
+		} else if (flags & 32) {
+			this._bounds = undefined;
+		}
+	},
+
+	getStyle: function() {
+		var parent = this._parent;
+		return (parent instanceof CompoundPath ? parent : this)._style;
+	},
+
+	getSegments: function() {
+		return this._segments;
+	},
+
+	setSegments: function(segments) {
+		var fullySelected = this.isFullySelected();
+		this._segments.length = 0;
+		this._selectedSegmentState = 0;
+		this._curves = undefined;
+		if (segments && segments.length > 0)
+			this._add(Segment.readAll(segments));
+		if (fullySelected)
+			this.setFullySelected(true);
+	},
+
+	getFirstSegment: function() {
+		return this._segments[0];
+	},
+
+	getLastSegment: function() {
+		return this._segments[this._segments.length - 1];
+	},
+
+	getCurves: function() {
+		var curves = this._curves,
+			segments = this._segments;
+		if (!curves) {
+			var length = this._countCurves();
+			curves = this._curves = new Array(length);
+			for (var i = 0; i < length; i++)
+				curves[i] = new Curve(this, segments[i],
+					segments[i + 1] || segments[0]);
+		}
+		return curves;
+	},
+
+	getFirstCurve: function() {
+		return this.getCurves()[0];
+	},
+
+	getLastCurve: function() {
+		var curves = this.getCurves();
+		return curves[curves.length - 1];
+	},
+
+	isClosed: function() {
+		return this._closed;
+	},
+
+	setClosed: function(closed) {
+		if (this._closed != (closed = !!closed)) {
+			this._closed = closed;
+			if (this._curves) {
+				var length = this._curves.length = this._countCurves();
+				if (closed)
+					this._curves[length - 1] = new Curve(this,
+						this._segments[length - 1], this._segments[0]);
+			}
+			this._changed(25);
+		}
+	}
+}, {
+	beans: true,
+
+	getPathData: function(_matrix, _precision) {
+		var segments = this._segments,
+			length = segments.length,
+			f = new Formatter(_precision),
+			coords = new Array(6),
+			first = true,
+			curX, curY,
+			prevX, prevY,
+			inX, inY,
+			outX, outY,
+			parts = [];
+
+		function addSegment(segment, skipLine) {
+			segment._transformCoordinates(_matrix, coords, false);
+			curX = coords[0];
+			curY = coords[1];
+			if (first) {
+				parts.push('M' + f.pair(curX, curY));
+				first = false;
+			} else {
+				inX = coords[2];
+				inY = coords[3];
+				if (inX === curX && inY === curY
+						&& outX === prevX && outY === prevY) {
+					if (!skipLine)
+						parts.push('l' + f.pair(curX - prevX, curY - prevY));
+				} else {
+					parts.push('c' + f.pair(outX - prevX, outY - prevY)
+							+ ' ' + f.pair(inX - prevX, inY - prevY)
+							+ ' ' + f.pair(curX - prevX, curY - prevY));
+				}
+			}
+			prevX = curX;
+			prevY = curY;
+			outX = coords[4];
+			outY = coords[5];
+		}
+
+		if (length === 0)
+			return '';
+
+		for (var i = 0; i < length; i++)
+			addSegment(segments[i]);
+		if (this._closed && length > 0) {
+			addSegment(segments[0], true);
+			parts.push('z');
+		}
+		return parts.join('');
+	}
+}, {
+
+	isEmpty: function() {
+		return this._segments.length === 0;
+	},
+
+	_transformContent: function(matrix) {
+		var segments = this._segments,
+			coords = new Array(6);
+		for (var i = 0, l = segments.length; i < l; i++)
+			segments[i]._transformCoordinates(matrix, coords, true);
+		return true;
+	},
+
+	_add: function(segs, index) {
+		var segments = this._segments,
+			curves = this._curves,
+			amount = segs.length,
+			append = index == null,
+			index = append ? segments.length : index;
+		for (var i = 0; i < amount; i++) {
+			var segment = segs[i];
+			if (segment._path)
+				segment = segs[i] = segment.clone();
+			segment._path = this;
+			segment._index = index + i;
+			if (segment._selectionState)
+				this._updateSelection(segment, 0, segment._selectionState);
+		}
+		if (append) {
+			segments.push.apply(segments, segs);
+		} else {
+			segments.splice.apply(segments, [index, 0].concat(segs));
+			for (var i = index + amount, l = segments.length; i < l; i++)
+				segments[i]._index = i;
+		}
+		if (curves) {
+			var total = this._countCurves(),
+				start = index > 0 && index + amount - 1 === total ? index - 1
+					: index,
+				insert = start,
+				end = Math.min(start + amount, total);
+			if (segs._curves) {
+				curves.splice.apply(curves, [start, 0].concat(segs._curves));
+				insert += segs._curves.length;
+			}
+			for (var i = insert; i < end; i++)
+				curves.splice(i, 0, new Curve(this, null, null));
+			this._adjustCurves(start, end);
+		}
+		this._changed(25);
+		return segs;
+	},
+
+	_adjustCurves: function(start, end) {
+		var segments = this._segments,
+			curves = this._curves,
+			curve;
+		for (var i = start; i < end; i++) {
+			curve = curves[i];
+			curve._path = this;
+			curve._segment1 = segments[i];
+			curve._segment2 = segments[i + 1] || segments[0];
+			curve._changed();
+		}
+		if (curve = curves[this._closed && start === 0 ? segments.length - 1
+				: start - 1]) {
+			curve._segment2 = segments[start] || segments[0];
+			curve._changed();
+		}
+		if (curve = curves[end]) {
+			curve._segment1 = segments[end];
+			curve._changed();
+		}
+	},
+
+	_countCurves: function() {
+		var length = this._segments.length;
+		return !this._closed && length > 0 ? length - 1 : length;
+	},
+
+	add: function(segment1 ) {
+		return arguments.length > 1 && typeof segment1 !== 'number'
+			? this._add(Segment.readAll(arguments))
+			: this._add([ Segment.read(arguments) ])[0];
+	},
+
+	insert: function(index, segment1 ) {
+		return arguments.length > 2 && typeof segment1 !== 'number'
+			? this._add(Segment.readAll(arguments, 1), index)
+			: this._add([ Segment.read(arguments, 1) ], index)[0];
+	},
+
+	addSegment: function() {
+		return this._add([ Segment.read(arguments) ])[0];
+	},
+
+	insertSegment: function(index ) {
+		return this._add([ Segment.read(arguments, 1) ], index)[0];
+	},
+
+	addSegments: function(segments) {
+		return this._add(Segment.readAll(segments));
+	},
+
+	insertSegments: function(index, segments) {
+		return this._add(Segment.readAll(segments), index);
+	},
+
+	removeSegment: function(index) {
+		return this.removeSegments(index, index + 1)[0] || null;
+	},
+
+	removeSegments: function(start, end, _includeCurves) {
+		start = start || 0;
+		end = Base.pick(end, this._segments.length);
+		var segments = this._segments,
+			curves = this._curves,
+			count = segments.length,
+			removed = segments.splice(start, end - start),
+			amount = removed.length;
+		if (!amount)
+			return removed;
+		for (var i = 0; i < amount; i++) {
+			var segment = removed[i];
+			if (segment._selectionState)
+				this._updateSelection(segment, segment._selectionState, 0);
+			segment._index = segment._path = null;
+		}
+		for (var i = start, l = segments.length; i < l; i++)
+			segments[i]._index = i;
+		if (curves) {
+			var index = start > 0 && end === count + (this._closed ? 1 : 0)
+					? start - 1
+					: start,
+				curves = curves.splice(index, amount);
+			for (var i = curves.length - 1; i >= 0; i--)
+				curves[i]._path = null;
+			if (_includeCurves)
+				removed._curves = curves.slice(1);
+			this._adjustCurves(index, index);
+		}
+		this._changed(25);
+		return removed;
+	},
+
+	clear: '#removeSegments',
+
+	hasHandles: function() {
+		var segments = this._segments;
+		for (var i = 0, l = segments.length; i < l; i++) {
+			if (segments[i].hasHandles())
+				return true;
+		}
+		return false;
+	},
+
+	clearHandles: function() {
+		var segments = this._segments;
+		for (var i = 0, l = segments.length; i < l; i++)
+			segments[i].clearHandles();
+	},
+
+	getLength: function() {
+		if (this._length == null) {
+			var curves = this.getCurves(),
+				length = 0;
+			for (var i = 0, l = curves.length; i < l; i++)
+				length += curves[i].getLength();
+			this._length = length;
+		}
+		return this._length;
+	},
+
+	getArea: function() {
+		if (this._area == null) {
+			var segments = this._segments,
+				count = segments.length,
+				last = count - 1,
+				area = 0;
+			for (var i = 0, l = this._closed ? count : last; i < l; i++) {
+				area += Curve.getArea(Curve.getValues(
+						segments[i], segments[i < last ? i + 1 : 0]));
+			}
+			this._area = area;
+		}
+		return this._area;
+	},
+
+	isClockwise: function() {
+		if (this._clockwise !== undefined)
+			return this._clockwise;
+		return this.getArea() >= 0;
+	},
+
+	setClockwise: function(clockwise) {
+		if (this.isClockwise() != (clockwise = !!clockwise))
+			this.reverse();
+		this._clockwise = clockwise;
+	},
+
+	isFullySelected: function() {
+		var length = this._segments.length;
+		return this._selected && length > 0 && this._selectedSegmentState
+				=== length * 7;
+	},
+
+	setFullySelected: function(selected) {
+		if (selected)
+			this._selectSegments(true);
+		this.setSelected(selected);
+	},
+
+	setSelected: function setSelected(selected) {
+		if (!selected)
+			this._selectSegments(false);
+		setSelected.base.call(this, selected);
+	},
+
+	_selectSegments: function(selected) {
+		var length = this._segments.length;
+		this._selectedSegmentState = selected
+				? length * 7 : 0;
+		for (var i = 0; i < length; i++)
+			this._segments[i]._selectionState = selected
+					? 7 : 0;
+	},
+
+	_updateSelection: function(segment, oldState, newState) {
+		segment._selectionState = newState;
+		var total = this._selectedSegmentState += newState - oldState;
+		if (total > 0)
+			this.setSelected(true);
+	},
+
+	flatten: function(maxDistance) {
+		var iterator = new PathIterator(this, 64, 0.1),
+			pos = 0,
+			step = iterator.length / Math.ceil(iterator.length / maxDistance),
+			end = iterator.length + (this._closed ? -step : step) / 2;
+		var segments = [];
+		while (pos <= end) {
+			segments.push(new Segment(iterator.getPointAt(pos)));
+			pos += step;
+		}
+		this.setSegments(segments);
+	},
+
+	reduce: function(options) {
+		var curves = this.getCurves(),
+			simplify = options && options.simplify,
+			tolerance = simplify ? 2e-7 : 0;
+		for (var i = curves.length - 1; i >= 0; i--) {
+			var curve = curves[i];
+			if (!curve.hasHandles() && (curve.getLength() < tolerance
+					|| simplify && curve.isCollinear(curve.getNext())))
+				curve.remove();
+		}
+		return this;
+	},
+
+	simplify: function(tolerance) {
+		if (this._segments.length > 2) {
+			var fitter = new PathFitter(this, tolerance || 2.5);
+			this.setSegments(fitter.fit());
+		}
+	},
+
+	split: function(index, parameter) {
+		if (parameter === null)
+			return null;
+		if (arguments.length === 1) {
+			var arg = index;
+			if (typeof arg === 'number')
+				arg = this.getLocationAt(arg);
+			if (!arg)
+				return null;
+			index = arg.index;
+			parameter = arg.parameter;
+		}
+		var tMin = 4e-7,
+			tMax = 1 - tMin;
+		if (parameter >= tMax) {
+			index++;
+			parameter--;
+		}
+		var curves = this.getCurves();
+		if (index >= 0 && index < curves.length) {
+			if (parameter >= tMin) {
+				curves[index++].divide(parameter, true);
+			}
+			var segs = this.removeSegments(index, this._segments.length, true),
+				path;
+			if (this._closed) {
+				this.setClosed(false);
+				path = this;
+			} else {
+				path = new Path(Item.NO_INSERT);
+				path.insertAbove(this, true);
+				path.copyAttributes(this);
+			}
+			path._add(segs, 0);
+			this.addSegment(segs[0]);
+			return path;
+		}
+		return null;
+	},
+
+	reverse: function() {
+		this._segments.reverse();
+		for (var i = 0, l = this._segments.length; i < l; i++) {
+			var segment = this._segments[i];
+			var handleIn = segment._handleIn;
+			segment._handleIn = segment._handleOut;
+			segment._handleOut = handleIn;
+			segment._index = i;
+		}
+		this._curves = null;
+		if (this._clockwise !== undefined)
+			this._clockwise = !this._clockwise;
+		this._changed(9);
+	},
+
+	join: function(path) {
+		if (path) {
+			var segments = path._segments,
+				last1 = this.getLastSegment(),
+				last2 = path.getLastSegment();
+			if (!last2)
+				return this;
+			if (last1 && last1._point.equals(last2._point))
+				path.reverse();
+			var first2 = path.getFirstSegment();
+			if (last1 && last1._point.equals(first2._point)) {
+				last1.setHandleOut(first2._handleOut);
+				this._add(segments.slice(1));
+			} else {
+				var first1 = this.getFirstSegment();
+				if (first1 && first1._point.equals(first2._point))
+					path.reverse();
+				last2 = path.getLastSegment();
+				if (first1 && first1._point.equals(last2._point)) {
+					first1.setHandleIn(last2._handleIn);
+					this._add(segments.slice(0, segments.length - 1), 0);
+				} else {
+					this._add(segments.slice());
+				}
+			}
+			if (path._closed)
+				this._add([segments[0]]);
+			path.remove();
+		}
+		var first = this.getFirstSegment(),
+			last = this.getLastSegment();
+		if (first !== last && first._point.equals(last._point)) {
+			first.setHandleIn(last._handleIn);
+			last.remove();
+			this.setClosed(true);
+		}
+		return this;
+	},
+
+	toShape: function(insert) {
+		if (!this._closed)
+			return null;
+
+		var segments = this._segments,
+			type,
+			size,
+			radius,
+			topCenter;
+
+		function isCollinear(i, j) {
+			var seg1 = segments[i],
+				seg2 = seg1.getNext(),
+				seg3 = segments[j],
+				seg4 = seg3.getNext();
+			return seg1._handleOut.isZero() && seg2._handleIn.isZero()
+					&& seg3._handleOut.isZero() && seg4._handleIn.isZero()
+					&& seg2._point.subtract(seg1._point).isCollinear(
+						seg4._point.subtract(seg3._point));
+		}
+
+		function isOrthogonal(i) {
+			var seg2 = segments[i],
+				seg1 = seg2.getPrevious(),
+				seg3 = seg2.getNext();
+			return seg1._handleOut.isZero() && seg2._handleIn.isZero()
+					&& seg2._handleOut.isZero() && seg3._handleIn.isZero()
+					&& seg2._point.subtract(seg1._point).isOrthogonal(
+						seg3._point.subtract(seg2._point));
+		}
+
+		function isArc(i) {
+			var seg1 = segments[i],
+				seg2 = seg1.getNext(),
+				handle1 = seg1._handleOut,
+				handle2 = seg2._handleIn,
+				kappa = 0.5522847498307936;
+			if (handle1.isOrthogonal(handle2)) {
+				var pt1 = seg1._point,
+					pt2 = seg2._point,
+					corner = new Line(pt1, handle1, true).intersect(
+							new Line(pt2, handle2, true), true);
+				return corner && Numerical.isZero(handle1.getLength() /
+						corner.subtract(pt1).getLength() - kappa)
+					&& Numerical.isZero(handle2.getLength() /
+						corner.subtract(pt2).getLength() - kappa);
+			}
+			return false;
+		}
+
+		function getDistance(i, j) {
+			return segments[i]._point.getDistance(segments[j]._point);
+		}
+
+		if (!this.hasHandles() && segments.length === 4
+				&& isCollinear(0, 2) && isCollinear(1, 3) && isOrthogonal(1)) {
+			type = Shape.Rectangle;
+			size = new Size(getDistance(0, 3), getDistance(0, 1));
+			topCenter = segments[1]._point.add(segments[2]._point).divide(2);
+		} else if (segments.length === 8 && isArc(0) && isArc(2) && isArc(4)
+				&& isArc(6) && isCollinear(1, 5) && isCollinear(3, 7)) {
+			type = Shape.Rectangle;
+			size = new Size(getDistance(1, 6), getDistance(0, 3));
+			radius = size.subtract(new Size(getDistance(0, 7),
+					getDistance(1, 2))).divide(2);
+			topCenter = segments[3]._point.add(segments[4]._point).divide(2);
+		} else if (segments.length === 4
+				&& isArc(0) && isArc(1) && isArc(2) && isArc(3)) {
+			if (Numerical.isZero(getDistance(0, 2) - getDistance(1, 3))) {
+				type = Shape.Circle;
+				radius = getDistance(0, 2) / 2;
+			} else {
+				type = Shape.Ellipse;
+				radius = new Size(getDistance(2, 0) / 2, getDistance(3, 1) / 2);
+			}
+			topCenter = segments[1]._point;
+		}
+
+		if (type) {
+			var center = this.getPosition(true),
+				shape = new type({
+					center: center,
+					size: size,
+					radius: radius,
+					insert: false
+				});
+			shape.copyAttributes(this, true);
+			shape._matrix.preConcatenate(this._matrix);
+			shape.rotate(topCenter.subtract(center).getAngle() + 90);
+			if (insert === undefined || insert)
+				shape.insertAbove(this);
+			return shape;
+		}
+		return null;
+	},
+
+	toPath: '#clone',
+
+	_hitTestSelf: function(point, options) {
+		var that = this,
+			style = this.getStyle(),
+			segments = this._segments,
+			numSegments = segments.length,
+			closed = this._closed,
+			tolerancePadding = options._tolerancePadding,
+			strokePadding = tolerancePadding,
+			join, cap, miterLimit,
+			area, loc, res,
+			hitStroke = options.stroke && style.hasStroke(),
+			hitFill = options.fill && style.hasFill(),
+			hitCurves = options.curves,
+			radius = hitStroke
+					? style.getStrokeWidth() / 2
+					: hitFill && options.tolerance > 0 || hitCurves
+						? 0 : null;
+		if (radius !== null) {
+			if (radius > 0) {
+				join = style.getStrokeJoin();
+				cap = style.getStrokeCap();
+				miterLimit = radius * style.getMiterLimit();
+				strokePadding = tolerancePadding.add(new Point(radius, radius));
+			} else {
+				join = cap = 'round';
+			}
+		}
+
+		function isCloseEnough(pt, padding) {
+			return point.subtract(pt).divide(padding).length <= 1;
+		}
+
+		function checkSegmentPoint(seg, pt, name) {
+			if (!options.selected || pt.isSelected()) {
+				var anchor = seg._point;
+				if (pt !== anchor)
+					pt = pt.add(anchor);
+				if (isCloseEnough(pt, strokePadding)) {
+					return new HitResult(name, that, {
+						segment: seg,
+						point: pt
+					});
+				}
+			}
+		}
+
+		function checkSegmentPoints(seg, ends) {
+			return (ends || options.segments)
+				&& checkSegmentPoint(seg, seg._point, 'segment')
+				|| (!ends && options.handles) && (
+					checkSegmentPoint(seg, seg._handleIn, 'handle-in') ||
+					checkSegmentPoint(seg, seg._handleOut, 'handle-out'));
+		}
+
+		function addToArea(point) {
+			area.add(point);
+		}
+
+		function checkSegmentStroke(segment) {
+			if (join !== 'round' || cap !== 'round') {
+				area = new Path({ internal: true, closed: true });
+				if (closed || segment._index > 0
+						&& segment._index < numSegments - 1) {
+					if (join !== 'round' && (segment._handleIn.isZero()
+							|| segment._handleOut.isZero()))
+						Path._addBevelJoin(segment, join, radius, miterLimit,
+								addToArea, true);
+				} else if (cap !== 'round') {
+					Path._addSquareCap(segment, cap, radius, addToArea, true);
+				}
+				if (!area.isEmpty()) {
+					var loc;
+					return area.contains(point)
+						|| (loc = area.getNearestLocation(point))
+							&& isCloseEnough(loc.getPoint(), tolerancePadding);
+				}
+			}
+			return isCloseEnough(segment._point, strokePadding);
+		}
+
+		if (options.ends && !options.segments && !closed) {
+			if (res = checkSegmentPoints(segments[0], true)
+					|| checkSegmentPoints(segments[numSegments - 1], true))
+				return res;
+		} else if (options.segments || options.handles) {
+			for (var i = 0; i < numSegments; i++)
+				if (res = checkSegmentPoints(segments[i]))
+					return res;
+		}
+		if (radius !== null) {
+			loc = this.getNearestLocation(point);
+			if (loc) {
+				var parameter = loc.getParameter();
+				if (parameter === 0 || parameter === 1 && numSegments > 1) {
+					if (!checkSegmentStroke(loc.getSegment()))
+						loc = null;
+				} else if (!isCloseEnough(loc.getPoint(), strokePadding)) {
+					loc = null;
+				}
+			}
+			if (!loc && join === 'miter' && numSegments > 1) {
+				for (var i = 0; i < numSegments; i++) {
+					var segment = segments[i];
+					if (point.getDistance(segment._point) <= miterLimit
+							&& checkSegmentStroke(segment)) {
+						loc = segment.getLocation();
+						break;
+					}
+				}
+			}
+		}
+		return !loc && hitFill && this._contains(point)
+				|| loc && !hitStroke && !hitCurves
+					? new HitResult('fill', this)
+					: loc
+						? new HitResult(hitStroke ? 'stroke' : 'curve', this, {
+							location: loc,
+							point: loc.getPoint()
+						})
+						: null;
+	}
+
+}, Base.each(Curve.evaluateMethods,
+	function(name) {
+		this[name + 'At'] = function(offset, isParameter) {
+			var loc = this.getLocationAt(offset, isParameter);
+			return loc && loc[name]();
+		};
+	},
+{
+	beans: false,
+
+	getLocationOf: function() {
+		var point = Point.read(arguments),
+			curves = this.getCurves();
+		for (var i = 0, l = curves.length; i < l; i++) {
+			var loc = curves[i].getLocationOf(point);
+			if (loc)
+				return loc;
+		}
+		return null;
+	},
+
+	getOffsetOf: function() {
+		var loc = this.getLocationOf.apply(this, arguments);
+		return loc ? loc.getOffset() : null;
+	},
+
+	getLocationAt: function(offset, isParameter) {
+		var curves = this.getCurves(),
+			length = 0;
+		if (isParameter) {
+			var index = ~~offset,
+				curve = curves[index];
+			return curve ? curve.getLocationAt(offset - index, true) : null;
+		}
+		for (var i = 0, l = curves.length; i < l; i++) {
+			var start = length,
+				curve = curves[i];
+			length += curve.getLength();
+			if (length > offset) {
+				return curve.getLocationAt(offset - start);
+			}
+		}
+		if (curves.length > 0 && offset <= this.getLength())
+			return new CurveLocation(curves[curves.length - 1], 1);
+		return null;
+	},
+
+	getNearestLocation: function() {
+		var point = Point.read(arguments),
+			curves = this.getCurves(),
+			minDist = Infinity,
+			minLoc = null;
+		for (var i = 0, l = curves.length; i < l; i++) {
+			var loc = curves[i].getNearestLocation(point);
+			if (loc._distance < minDist) {
+				minDist = loc._distance;
+				minLoc = loc;
+			}
+		}
+		return minLoc;
+	},
+
+	getNearestPoint: function() {
+		return this.getNearestLocation.apply(this, arguments).getPoint();
+	},
+
+	smooth: function(options) {
+		function getIndex(value, _default) {
+			var index = value && value.index;
+			if (index != null) {
+				var path = value.path;
+				if (path && path !== that)
+					throw new Error(value._class + ' ' + index + ' of ' + path
+							+ ' is not part of ' + that);
+				if (_default && value instanceof Curve)
+					index++;
+			} else {
+				index = typeof value === 'number' ? value : _default;
+			}
+			return Math.min(index < 0 && closed
+					? index % length
+					: index < 0 ? index + length : index, length - 1);
+		}
+
+		var that = this,
+			opts = options || {},
+			type = opts.type || 'asymmetric',
+			segments = this._segments,
+			length = segments.length,
+			closed = this._closed,
+			loop = closed && opts.from === undefined && opts.to === undefined,
+			from = getIndex(opts.from, 0),
+			to = getIndex(opts.to, length - 1);
+		if (from > to) {
+			if (closed) {
+				from -= length;
+			} else {
+				var tmp = from;
+				from = to;
+				to = tmp;
+			}
+		}
+		if (/^(?:asymmetric|continuous)$/.test(type)) {
+			var asymmetric = type === 'asymmetric',
+				min = Math.min,
+				amount = to - from + 1,
+				n = amount - 1,
+				padding = loop ? min(amount, 4) : 1,
+				paddingLeft = padding,
+				paddingRight = padding,
+				knots = [];
+			if (!closed) {
+				paddingLeft = min(1, from);
+				paddingRight = min(1, length - to - 1);
+			}
+			n += paddingLeft + paddingRight;
+			if (n <= 1)
+				return;
+			for (var i = 0, j = from - paddingLeft; i <= n; i++, j++) {
+				knots[i] = segments[(j < 0 ? j + length : j) % length]._point;
+			}
+
+			var x = knots[0]._x + 2 * knots[1]._x,
+				y = knots[0]._y + 2 * knots[1]._y,
+				f = 2,
+				n_1 = n - 1,
+				rx = [x],
+				ry = [y],
+				rf = [f],
+				px = [],
+				py = [];
+			for (var i = 1; i < n; i++) {
+				var internal = i < n_1,
+					a = internal ? 1 : asymmetric ? 1 : 2,
+					b = internal ? 4 : asymmetric ? 2 : 7,
+					u = internal ? 4 : asymmetric ? 3 : 8,
+					v = internal ? 2 : asymmetric ? 0 : 1,
+					m = a / f;
+				f = rf[i] = b - m;
+				x = rx[i] = u * knots[i]._x + v * knots[i + 1]._x - m * x;
+				y = ry[i] = u * knots[i]._y + v * knots[i + 1]._y - m * y;
+			}
+
+			px[n_1] = rx[n_1] / rf[n_1];
+			py[n_1] = ry[n_1] / rf[n_1];
+			for (var i = n - 2; i >= 0; i--) {
+				px[i] = (rx[i] - px[i + 1]) / rf[i];
+				py[i] = (ry[i] - py[i + 1]) / rf[i];
+			}
+			px[n] = (3 * knots[n]._x - px[n_1]) / 2;
+			py[n] = (3 * knots[n]._y - py[n_1]) / 2;
+
+			for (var i = paddingLeft, max = n - paddingRight, j = from;
+					i <= max; i++, j++) {
+				var segment = segments[j < 0 ? j + length : j],
+					pt = segment._point,
+					hx = px[i] - pt._x,
+					hy = py[i] - pt._y;
+				if (loop || i < max)
+					segment.setHandleOut(hx, hy);
+				if (loop || i > paddingLeft)
+					segment.setHandleIn(-hx, -hy);
+			}
+		} else {
+			for (var i = from; i <= to; i++) {
+				segments[i < 0 ? i + length : i].smooth(opts,
+						!loop && i === from, !loop && i === to);
+			}
+		}
+	}
+}),
+new function() {
+
+	function drawHandles(ctx, segments, matrix, size) {
+		var half = size / 2;
+
+		function drawHandle(index) {
+			var hX = coords[index],
+				hY = coords[index + 1];
+			if (pX != hX || pY != hY) {
+				ctx.beginPath();
+				ctx.moveTo(pX, pY);
+				ctx.lineTo(hX, hY);
+				ctx.stroke();
+				ctx.beginPath();
+				ctx.arc(hX, hY, half, 0, Math.PI * 2, true);
+				ctx.fill();
+			}
+		}
+
+		var coords = new Array(6);
+		for (var i = 0, l = segments.length; i < l; i++) {
+			var segment = segments[i];
+			segment._transformCoordinates(matrix, coords, false);
+			var state = segment._selectionState,
+				pX = coords[0],
+				pY = coords[1];
+			if (state & 1)
+				drawHandle(2);
+			if (state & 2)
+				drawHandle(4);
+			ctx.fillRect(pX - half, pY - half, size, size);
+			if (!(state & 4)) {
+				var fillStyle = ctx.fillStyle;
+				ctx.fillStyle = '#ffffff';
+				ctx.fillRect(pX - half + 1, pY - half + 1, size - 2, size - 2);
+				ctx.fillStyle = fillStyle;
+			}
+		}
+	}
+
+	function drawSegments(ctx, path, matrix) {
+		var segments = path._segments,
+			length = segments.length,
+			coords = new Array(6),
+			first = true,
+			curX, curY,
+			prevX, prevY,
+			inX, inY,
+			outX, outY;
+
+		function drawSegment(segment) {
+			if (matrix) {
+				segment._transformCoordinates(matrix, coords, false);
+				curX = coords[0];
+				curY = coords[1];
+			} else {
+				var point = segment._point;
+				curX = point._x;
+				curY = point._y;
+			}
+			if (first) {
+				ctx.moveTo(curX, curY);
+				first = false;
+			} else {
+				if (matrix) {
+					inX = coords[2];
+					inY = coords[3];
+				} else {
+					var handle = segment._handleIn;
+					inX = curX + handle._x;
+					inY = curY + handle._y;
+				}
+				if (inX === curX && inY === curY
+						&& outX === prevX && outY === prevY) {
+					ctx.lineTo(curX, curY);
+				} else {
+					ctx.bezierCurveTo(outX, outY, inX, inY, curX, curY);
+				}
+			}
+			prevX = curX;
+			prevY = curY;
+			if (matrix) {
+				outX = coords[4];
+				outY = coords[5];
+			} else {
+				var handle = segment._handleOut;
+				outX = prevX + handle._x;
+				outY = prevY + handle._y;
+			}
+		}
+
+		for (var i = 0; i < length; i++)
+			drawSegment(segments[i]);
+		if (path._closed && length > 0)
+			drawSegment(segments[0]);
+	}
+
+	return {
+		_draw: function(ctx, param, strokeMatrix) {
+			var dontStart = param.dontStart,
+				dontPaint = param.dontFinish || param.clip,
+				style = this.getStyle(),
+				hasFill = style.hasFill(),
+				hasStroke = style.hasStroke(),
+				dashArray = style.getDashArray(),
+				dashLength = !paper.support.nativeDash && hasStroke
+						&& dashArray && dashArray.length;
+
+			if (!dontStart)
+				ctx.beginPath();
+
+			if (hasFill || hasStroke && !dashLength || dontPaint) {
+				drawSegments(ctx, this, strokeMatrix);
+				if (this._closed)
+					ctx.closePath();
+			}
+
+			function getOffset(i) {
+				return dashArray[((i % dashLength) + dashLength) % dashLength];
+			}
+
+			if (!dontPaint && (hasFill || hasStroke)) {
+				this._setStyles(ctx);
+				if (hasFill) {
+					ctx.fill(style.getFillRule());
+					ctx.shadowBlur = 0;
+				}
+				if (hasStroke) {
+					if (dashLength) {
+						if (!dontStart)
+							ctx.beginPath();
+						var iterator = new PathIterator(this, 32, 0.25,
+								strokeMatrix),
+							length = iterator.length,
+							from = -style.getDashOffset(), to,
+							i = 0;
+						from = from % length;
+						while (from > 0) {
+							from -= getOffset(i--) + getOffset(i--);
+						}
+						while (from < length) {
+							to = from + getOffset(i++);
+							if (from > 0 || to > 0)
+								iterator.drawPart(ctx,
+										Math.max(from, 0), Math.max(to, 0));
+							from = to + getOffset(i++);
+						}
+					}
+					ctx.stroke();
+				}
+			}
+		},
+
+		_drawSelected: function(ctx, matrix) {
+			ctx.beginPath();
+			drawSegments(ctx, this, matrix);
+			ctx.stroke();
+			drawHandles(ctx, this._segments, matrix, paper.settings.handleSize);
+		}
+	};
+},
+new function() {
+	function getCurrentSegment(that) {
+		var segments = that._segments;
+		if (segments.length === 0)
+			throw new Error('Use a moveTo() command first');
+		return segments[segments.length - 1];
+	}
+
+	return {
+		moveTo: function() {
+			var segments = this._segments;
+			if (segments.length === 1)
+				this.removeSegment(0);
+			if (!segments.length)
+				this._add([ new Segment(Point.read(arguments)) ]);
+		},
+
+		moveBy: function() {
+			throw new Error('moveBy() is unsupported on Path items.');
+		},
+
+		lineTo: function() {
+			this._add([ new Segment(Point.read(arguments)) ]);
+		},
+
+		cubicCurveTo: function() {
+			var handle1 = Point.read(arguments),
+				handle2 = Point.read(arguments),
+				to = Point.read(arguments),
+				current = getCurrentSegment(this);
+			current.setHandleOut(handle1.subtract(current._point));
+			this._add([ new Segment(to, handle2.subtract(to)) ]);
+		},
+
+		quadraticCurveTo: function() {
+			var handle = Point.read(arguments),
+				to = Point.read(arguments),
+				current = getCurrentSegment(this)._point;
+			this.cubicCurveTo(
+				handle.add(current.subtract(handle).multiply(1 / 3)),
+				handle.add(to.subtract(handle).multiply(1 / 3)),
+				to
+			);
+		},
+
+		curveTo: function() {
+			var through = Point.read(arguments),
+				to = Point.read(arguments),
+				t = Base.pick(Base.read(arguments), 0.5),
+				t1 = 1 - t,
+				current = getCurrentSegment(this)._point,
+				handle = through.subtract(current.multiply(t1 * t1))
+					.subtract(to.multiply(t * t)).divide(2 * t * t1);
+			if (handle.isNaN())
+				throw new Error(
+					'Cannot put a curve through points with parameter = ' + t);
+			this.quadraticCurveTo(handle, to);
+		},
+
+		arcTo: function() {
+			var current = getCurrentSegment(this),
+				from = current._point,
+				to = Point.read(arguments),
+				through,
+				peek = Base.peek(arguments),
+				clockwise = Base.pick(peek, true),
+				center, extent, vector, matrix;
+			if (typeof clockwise === 'boolean') {
+				var middle = from.add(to).divide(2),
+				through = middle.add(middle.subtract(from).rotate(
+						clockwise ? -90 : 90));
+			} else if (Base.remain(arguments) <= 2) {
+				through = to;
+				to = Point.read(arguments);
+			} else {
+				var radius = Size.read(arguments);
+				if (radius.isZero())
+					return this.lineTo(to);
+				var rotation = Base.read(arguments),
+					clockwise = !!Base.read(arguments),
+					large = !!Base.read(arguments),
+					middle = from.add(to).divide(2),
+					pt = from.subtract(middle).rotate(-rotation),
+					x = pt.x,
+					y = pt.y,
+					abs = Math.abs,
+					rx = abs(radius.width),
+					ry = abs(radius.height),
+					rxSq = rx * rx,
+					rySq = ry * ry,
+					xSq =  x * x,
+					ySq =  y * y;
+				var factor = Math.sqrt(xSq / rxSq + ySq / rySq);
+				if (factor > 1) {
+					rx *= factor;
+					ry *= factor;
+					rxSq = rx * rx;
+					rySq = ry * ry;
+				}
+				factor = (rxSq * rySq - rxSq * ySq - rySq * xSq) /
+						(rxSq * ySq + rySq * xSq);
+				if (abs(factor) < 1e-12)
+					factor = 0;
+				if (factor < 0)
+					throw new Error(
+							'Cannot create an arc with the given arguments');
+				center = new Point(rx * y / ry, -ry * x / rx)
+						.multiply((large === clockwise ? -1 : 1)
+							* Math.sqrt(factor))
+						.rotate(rotation).add(middle);
+				matrix = new Matrix().translate(center).rotate(rotation)
+						.scale(rx, ry);
+				vector = matrix._inverseTransform(from);
+				extent = vector.getDirectedAngle(matrix._inverseTransform(to));
+				if (!clockwise && extent > 0)
+					extent -= 360;
+				else if (clockwise && extent < 0)
+					extent += 360;
+			}
+			if (through) {
+				var l1 = new Line(from.add(through).divide(2),
+							through.subtract(from).rotate(90), true),
+					l2 = new Line(through.add(to).divide(2),
+							to.subtract(through).rotate(90), true),
+					line = new Line(from, to),
+					throughSide = line.getSide(through);
+				center = l1.intersect(l2, true);
+				if (!center) {
+					if (!throughSide)
+						return this.lineTo(to);
+					throw new Error(
+							'Cannot create an arc with the given arguments');
+				}
+				vector = from.subtract(center);
+				extent = vector.getDirectedAngle(to.subtract(center));
+				var centerSide = line.getSide(center);
+				if (centerSide === 0) {
+					extent = throughSide * Math.abs(extent);
+				} else if (throughSide === centerSide) {
+					extent += extent < 0 ? 360 : -360;
+				}
+			}
+			var ext = Math.abs(extent),
+				count = ext >= 360 ? 4 : Math.ceil(ext / 90),
+				inc = extent / count,
+				half = inc * Math.PI / 360,
+				z = 4 / 3 * Math.sin(half) / (1 + Math.cos(half)),
+				segments = [];
+			for (var i = 0; i <= count; i++) {
+				var pt = to,
+					out = null;
+				if (i < count) {
+					out = vector.rotate(90).multiply(z);
+					if (matrix) {
+						pt = matrix._transformPoint(vector);
+						out = matrix._transformPoint(vector.add(out))
+								.subtract(pt);
+					} else {
+						pt = center.add(vector);
+					}
+				}
+				if (i === 0) {
+					current.setHandleOut(out);
+				} else {
+					var _in = vector.rotate(-90).multiply(z);
+					if (matrix) {
+						_in = matrix._transformPoint(vector.add(_in))
+								.subtract(pt);
+					}
+					segments.push(new Segment(pt, _in, out));
+				}
+				vector = vector.rotate(inc);
+			}
+			this._add(segments);
+		},
+
+		lineBy: function() {
+			var to = Point.read(arguments),
+				current = getCurrentSegment(this)._point;
+			this.lineTo(current.add(to));
+		},
+
+		curveBy: function() {
+			var through = Point.read(arguments),
+				to = Point.read(arguments),
+				parameter = Base.read(arguments),
+				current = getCurrentSegment(this)._point;
+			this.curveTo(current.add(through), current.add(to), parameter);
+		},
+
+		cubicCurveBy: function() {
+			var handle1 = Point.read(arguments),
+				handle2 = Point.read(arguments),
+				to = Point.read(arguments),
+				current = getCurrentSegment(this)._point;
+			this.cubicCurveTo(current.add(handle1), current.add(handle2),
+					current.add(to));
+		},
+
+		quadraticCurveBy: function() {
+			var handle = Point.read(arguments),
+				to = Point.read(arguments),
+				current = getCurrentSegment(this)._point;
+			this.quadraticCurveTo(current.add(handle), current.add(to));
+		},
+
+		arcBy: function() {
+			var current = getCurrentSegment(this)._point,
+				point = current.add(Point.read(arguments)),
+				clockwise = Base.pick(Base.peek(arguments), true);
+			if (typeof clockwise === 'boolean') {
+				this.arcTo(point, clockwise);
+			} else {
+				this.arcTo(point, current.add(Point.read(arguments)));
+			}
+		},
+
+		closePath: function(join) {
+			this.setClosed(true);
+			if (join)
+				this.join();
+		}
+	};
+}, {
+
+	_getBounds: function(getter, matrix) {
+		return Path[getter](this._segments, this._closed, this.getStyle(),
+				matrix);
+	},
+
+statics: {
+	getBounds: function(segments, closed, style, matrix, strokePadding) {
+		var first = segments[0];
+		if (!first)
+			return new Rectangle();
+		var coords = new Array(6),
+			prevCoords = first._transformCoordinates(matrix, new Array(6), false),
+			min = prevCoords.slice(0, 2),
+			max = min.slice(),
+			roots = new Array(2);
+
+		function processSegment(segment) {
+			segment._transformCoordinates(matrix, coords, false);
+			for (var i = 0; i < 2; i++) {
+				Curve._addBounds(
+					prevCoords[i],
+					prevCoords[i + 4],
+					coords[i + 2],
+					coords[i],
+					i, strokePadding ? strokePadding[i] : 0, min, max, roots);
+			}
+			var tmp = prevCoords;
+			prevCoords = coords;
+			coords = tmp;
+		}
+
+		for (var i = 1, l = segments.length; i < l; i++)
+			processSegment(segments[i]);
+		if (closed)
+			processSegment(first);
+		return new Rectangle(min[0], min[1], max[0] - min[0], max[1] - min[1]);
+	},
+
+	getStrokeBounds: function(segments, closed, style, matrix) {
+		if (!style.hasStroke())
+			return Path.getBounds(segments, closed, style, matrix);
+		var length = segments.length - (closed ? 0 : 1),
+			radius = style.getStrokeWidth() / 2,
+			padding = Path._getPenPadding(radius, matrix),
+			bounds = Path.getBounds(segments, closed, style, matrix, padding),
+			join = style.getStrokeJoin(),
+			cap = style.getStrokeCap(),
+			miterLimit = radius * style.getMiterLimit();
+		var joinBounds = new Rectangle(new Size(padding).multiply(2));
+
+		function add(point) {
+			bounds = bounds.include(matrix
+				? matrix._transformPoint(point, point) : point);
+		}
+
+		function addRound(segment) {
+			bounds = bounds.unite(joinBounds.setCenter(matrix
+				? matrix._transformPoint(segment._point) : segment._point));
+		}
+
+		function addJoin(segment, join) {
+			var handleIn = segment._handleIn,
+				handleOut = segment._handleOut;
+			if (join === 'round' || !handleIn.isZero() && !handleOut.isZero()
+					&& handleIn.isCollinear(handleOut)) {
+				addRound(segment);
+			} else {
+				Path._addBevelJoin(segment, join, radius, miterLimit, add);
+			}
+		}
+
+		function addCap(segment, cap) {
+			if (cap === 'round') {
+				addRound(segment);
+			} else {
+				Path._addSquareCap(segment, cap, radius, add);
+			}
+		}
+
+		for (var i = 1; i < length; i++)
+			addJoin(segments[i], join);
+		if (closed) {
+			addJoin(segments[0], join);
+		} else if (length > 0) {
+			addCap(segments[0], cap);
+			addCap(segments[segments.length - 1], cap);
+		}
+		return bounds;
+	},
+
+	_getPenPadding: function(radius, matrix) {
+		if (!matrix)
+			return [radius, radius];
+		var mx = matrix.shiftless(),
+			hor = mx.transform(new Point(radius, 0)),
+			ver = mx.transform(new Point(0, radius)),
+			phi = hor.getAngleInRadians(),
+			a = hor.getLength(),
+			b = ver.getLength();
+		var sin = Math.sin(phi),
+			cos = Math.cos(phi),
+			tan = Math.tan(phi),
+			tx = Math.atan2(b * tan, a),
+			ty = Math.atan2(b, tan * a);
+		return [Math.abs(a * Math.cos(tx) * cos + b * Math.sin(tx) * sin),
+				Math.abs(b * Math.sin(ty) * cos + a * Math.cos(ty) * sin)];
+	},
+
+	_addBevelJoin: function(segment, join, radius, miterLimit, addPoint, area) {
+		var curve2 = segment.getCurve(),
+			curve1 = curve2.getPrevious(),
+			point = curve2.getPointAt(0, true),
+			normal1 = curve1.getNormalAt(1, true),
+			normal2 = curve2.getNormalAt(0, true),
+			step = normal1.getDirectedAngle(normal2) < 0 ? -radius : radius;
+		normal1.setLength(step);
+		normal2.setLength(step);
+		if (area) {
+			addPoint(point);
+			addPoint(point.add(normal1));
+		}
+		if (join === 'miter') {
+			var corner = new Line(
+					point.add(normal1),
+					new Point(-normal1.y, normal1.x), true
+				).intersect(new Line(
+					point.add(normal2),
+					new Point(-normal2.y, normal2.x), true
+				), true);
+			if (corner && point.getDistance(corner) <= miterLimit) {
+				addPoint(corner);
+				if (!area)
+					return;
+			}
+		}
+		if (!area)
+			addPoint(point.add(normal1));
+		addPoint(point.add(normal2));
+	},
+
+	_addSquareCap: function(segment, cap, radius, addPoint, area) {
+		var point = segment._point,
+			loc = segment.getLocation(),
+			normal = loc.getNormal().multiply(radius);
+		if (area) {
+			addPoint(point.subtract(normal));
+			addPoint(point.add(normal));
+		}
+		if (cap === 'square')
+			point = point.add(normal.rotate(loc.getParameter() === 0 ? -90 : 90));
+		addPoint(point.add(normal));
+		addPoint(point.subtract(normal));
+	},
+
+	getHandleBounds: function(segments, closed, style, matrix, strokePadding,
+			joinPadding) {
+		var coords = new Array(6),
+			x1 = Infinity,
+			x2 = -x1,
+			y1 = x1,
+			y2 = x2;
+		for (var i = 0, l = segments.length; i < l; i++) {
+			var segment = segments[i];
+			segment._transformCoordinates(matrix, coords, false);
+			for (var j = 0; j < 6; j += 2) {
+				var padding = j === 0 ? joinPadding : strokePadding,
+					paddingX = padding ? padding[0] : 0,
+					paddingY = padding ? padding[1] : 0,
+					x = coords[j],
+					y = coords[j + 1],
+					xn = x - paddingX,
+					xx = x + paddingX,
+					yn = y - paddingY,
+					yx = y + paddingY;
+				if (xn < x1) x1 = xn;
+				if (xx > x2) x2 = xx;
+				if (yn < y1) y1 = yn;
+				if (yx > y2) y2 = yx;
+			}
+		}
+		return new Rectangle(x1, y1, x2 - x1, y2 - y1);
+	},
+
+	getRoughBounds: function(segments, closed, style, matrix) {
+		var strokeRadius = style.hasStroke() ? style.getStrokeWidth() / 2 : 0,
+			joinRadius = strokeRadius;
+		if (strokeRadius > 0) {
+			if (style.getStrokeJoin() === 'miter')
+				joinRadius = strokeRadius * style.getMiterLimit();
+			if (style.getStrokeCap() === 'square')
+				joinRadius = Math.max(joinRadius, strokeRadius * Math.sqrt(2));
+		}
+		return Path.getHandleBounds(segments, closed, style, matrix,
+				Path._getPenPadding(strokeRadius, matrix),
+				Path._getPenPadding(joinRadius, matrix));
+	}
+}});
+
+Path.inject({ statics: new function() {
+
+	var kappa = 0.5522847498307936,
+		ellipseSegments = [
+			new Segment([-1, 0], [0, kappa ], [0, -kappa]),
+			new Segment([0, -1], [-kappa, 0], [kappa, 0 ]),
+			new Segment([1, 0], [0, -kappa], [0, kappa ]),
+			new Segment([0, 1], [kappa, 0 ], [-kappa, 0])
+		];
+
+	function createPath(segments, closed, args) {
+		var props = Base.getNamed(args),
+			path = new Path(props && props.insert === false && Item.NO_INSERT);
+		path._add(segments);
+		path._closed = closed;
+		return path.set(props);
+	}
+
+	function createEllipse(center, radius, args) {
+		var segments = new Array(4);
+		for (var i = 0; i < 4; i++) {
+			var segment = ellipseSegments[i];
+			segments[i] = new Segment(
+				segment._point.multiply(radius).add(center),
+				segment._handleIn.multiply(radius),
+				segment._handleOut.multiply(radius)
+			);
+		}
+		return createPath(segments, true, args);
+	}
+
+	return {
+		Line: function() {
+			return createPath([
+				new Segment(Point.readNamed(arguments, 'from')),
+				new Segment(Point.readNamed(arguments, 'to'))
+			], false, arguments);
+		},
+
+		Circle: function() {
+			var center = Point.readNamed(arguments, 'center'),
+				radius = Base.readNamed(arguments, 'radius');
+			return createEllipse(center, new Size(radius), arguments);
+		},
+
+		Rectangle: function() {
+			var rect = Rectangle.readNamed(arguments, 'rectangle'),
+				radius = Size.readNamed(arguments, 'radius', 0,
+						{ readNull: true }),
+				bl = rect.getBottomLeft(true),
+				tl = rect.getTopLeft(true),
+				tr = rect.getTopRight(true),
+				br = rect.getBottomRight(true),
+				segments;
+			if (!radius || radius.isZero()) {
+				segments = [
+					new Segment(bl),
+					new Segment(tl),
+					new Segment(tr),
+					new Segment(br)
+				];
+			} else {
+				radius = Size.min(radius, rect.getSize(true).divide(2));
+				var rx = radius.width,
+					ry = radius.height,
+					hx = rx * kappa,
+					hy = ry * kappa;
+				segments = [
+					new Segment(bl.add(rx, 0), null, [-hx, 0]),
+					new Segment(bl.subtract(0, ry), [0, hy]),
+					new Segment(tl.add(0, ry), null, [0, -hy]),
+					new Segment(tl.add(rx, 0), [-hx, 0], null),
+					new Segment(tr.subtract(rx, 0), null, [hx, 0]),
+					new Segment(tr.add(0, ry), [0, -hy], null),
+					new Segment(br.subtract(0, ry), null, [0, hy]),
+					new Segment(br.subtract(rx, 0), [hx, 0])
+				];
+			}
+			return createPath(segments, true, arguments);
+		},
+
+		RoundRectangle: '#Rectangle',
+
+		Ellipse: function() {
+			var ellipse = Shape._readEllipse(arguments);
+			return createEllipse(ellipse.center, ellipse.radius, arguments);
+		},
+
+		Oval: '#Ellipse',
+
+		Arc: function() {
+			var from = Point.readNamed(arguments, 'from'),
+				through = Point.readNamed(arguments, 'through'),
+				to = Point.readNamed(arguments, 'to'),
+				props = Base.getNamed(arguments),
+				path = new Path(props && props.insert === false
+						&& Item.NO_INSERT);
+			path.moveTo(from);
+			path.arcTo(through, to);
+			return path.set(props);
+		},
+
+		RegularPolygon: function() {
+			var center = Point.readNamed(arguments, 'center'),
+				sides = Base.readNamed(arguments, 'sides'),
+				radius = Base.readNamed(arguments, 'radius'),
+				step = 360 / sides,
+				three = sides % 3 === 0,
+				vector = new Point(0, three ? -radius : radius),
+				offset = three ? -1 : 0.5,
+				segments = new Array(sides);
+			for (var i = 0; i < sides; i++)
+				segments[i] = new Segment(center.add(
+					vector.rotate((i + offset) * step)));
+			return createPath(segments, true, arguments);
+		},
+
+		Star: function() {
+			var center = Point.readNamed(arguments, 'center'),
+				points = Base.readNamed(arguments, 'points') * 2,
+				radius1 = Base.readNamed(arguments, 'radius1'),
+				radius2 = Base.readNamed(arguments, 'radius2'),
+				step = 360 / points,
+				vector = new Point(0, -1),
+				segments = new Array(points);
+			for (var i = 0; i < points; i++)
+				segments[i] = new Segment(center.add(vector.rotate(step * i)
+						.multiply(i % 2 ? radius2 : radius1)));
+			return createPath(segments, true, arguments);
+		}
+	};
+}});
+
+var CompoundPath = PathItem.extend({
+	_class: 'CompoundPath',
+	_serializeFields: {
+		children: []
+	},
+
+	initialize: function CompoundPath(arg) {
+		this._children = [];
+		this._namedChildren = {};
+		if (!this._initialize(arg)) {
+			if (typeof arg === 'string') {
+				this.setPathData(arg);
+			} else {
+				this.addChildren(Array.isArray(arg) ? arg : arguments);
+			}
+		}
+	},
+
+	insertChildren: function insertChildren(index, items, _preserve) {
+		for (var i = items.length - 1; i >= 0; i--) {
+			var item = items[i];
+			if (item instanceof CompoundPath) {
+				items.splice.apply(items, [i, 1].concat(item.removeChildren()));
+				item.remove();
+			}
+		}
+		items = insertChildren.base.call(this, index, items, _preserve, Path);
+		for (var i = 0, l = !_preserve && items && items.length; i < l; i++) {
+			var item = items[i];
+			if (item._clockwise === undefined)
+				item.setClockwise(item._index === 0);
+		}
+		return items;
+	},
+
+	reverse: function() {
+		var children = this._children;
+		for (var i = 0, l = children.length; i < l; i++)
+			children[i].reverse();
+	},
+
+	reduce: function reduce(options) {
+		var children = this._children;
+		for (var i = children.length - 1; i >= 0; i--) {
+			var path = children[i].reduce(options);
+			if (path.isEmpty())
+				path.remove();
+		}
+		if (children.length === 0) {
+			var path = new Path(Item.NO_INSERT);
+			path.copyAttributes(this);
+			path.insertAbove(this);
+			this.remove();
+			return path;
+		}
+		return reduce.base.call(this);
+	},
+
+	smooth: function(options) {
+		var children = this._children;
+		for (var i = 0, l = children.length; i < l; i++)
+			children[i].smooth(options);
+	},
+
+	isClockwise: function() {
+		var child = this.getFirstChild();
+		return child && child.isClockwise();
+	},
+
+	setClockwise: function(clockwise) {
+		if (this.isClockwise() !== !!clockwise)
+			this.reverse();
+	},
+
+	getFirstSegment: function() {
+		var first = this.getFirstChild();
+		return first && first.getFirstSegment();
+	},
+
+	getLastSegment: function() {
+		var last = this.getLastChild();
+		return last && last.getLastSegment();
+	},
+
+	getCurves: function() {
+		var children = this._children,
+			curves = [];
+		for (var i = 0, l = children.length; i < l; i++)
+			curves.push.apply(curves, children[i].getCurves());
+		return curves;
+	},
+
+	getFirstCurve: function() {
+		var first = this.getFirstChild();
+		return first && first.getFirstCurve();
+	},
+
+	getLastCurve: function() {
+		var last = this.getLastChild();
+		return last && last.getFirstCurve();
+	},
+
+	getArea: function() {
+		var children = this._children,
+			area = 0;
+		for (var i = 0, l = children.length; i < l; i++)
+			area += children[i].getArea();
+		return area;
+	}
+}, {
+	beans: true,
+
+	getPathData: function(_matrix, _precision) {
+		var children = this._children,
+			paths = [];
+		for (var i = 0, l = children.length; i < l; i++) {
+			var child = children[i],
+				mx = child._matrix;
+			paths.push(child.getPathData(_matrix && !mx.isIdentity()
+					? _matrix.chain(mx) : _matrix, _precision));
+		}
+		return paths.join(' ');
+	}
+}, {
+	_getChildHitTestOptions: function(options) {
+		return options.class === Path || options.type === 'path'
+				? options
+				: new Base(options, { fill: false });
+	},
+
+	_draw: function(ctx, param, strokeMatrix) {
+		var children = this._children;
+		if (children.length === 0)
+			return;
+
+		param = param.extend({ dontStart: true, dontFinish: true });
+		ctx.beginPath();
+		for (var i = 0, l = children.length; i < l; i++)
+			children[i].draw(ctx, param, strokeMatrix);
+
+		if (!param.clip) {
+			this._setStyles(ctx);
+			var style = this._style;
+			if (style.hasFill()) {
+				ctx.fill(style.getFillRule());
+				ctx.shadowBlur = 0;
+			}
+			if (style.hasStroke())
+				ctx.stroke();
+		}
+	},
+
+	_drawSelected: function(ctx, matrix, selectedItems) {
+		var children = this._children;
+		for (var i = 0, l = children.length; i < l; i++) {
+			var child = children[i],
+				mx = child._matrix;
+			if (!selectedItems[child._id])
+				child._drawSelected(ctx, mx.isIdentity() ? matrix
+						: matrix.chain(mx));
+		}
+	}
+},
+new function() {
+	function getCurrentPath(that, check) {
+		var children = that._children;
+		if (check && children.length === 0)
+			throw new Error('Use a moveTo() command first');
+		return children[children.length - 1];
+	}
+
+	var fields = {
+		moveTo: function() {
+			var current = getCurrentPath(this),
+				path = current && current.isEmpty() ? current
+						: new Path(Item.NO_INSERT);
+			if (path !== current)
+				this.addChild(path);
+			path.moveTo.apply(path, arguments);
+		},
+
+		moveBy: function() {
+			var current = getCurrentPath(this, true),
+				last = current && current.getLastSegment(),
+				point = Point.read(arguments);
+			this.moveTo(last ? point.add(last._point) : point);
+		},
+
+		closePath: function(join) {
+			getCurrentPath(this, true).closePath(join);
+		}
+	};
+
+	Base.each(['lineTo', 'cubicCurveTo', 'quadraticCurveTo', 'curveTo', 'arcTo',
+			'lineBy', 'cubicCurveBy', 'quadraticCurveBy', 'curveBy', 'arcBy'],
+			function(key) {
+				fields[key] = function() {
+					var path = getCurrentPath(this, true);
+					path[key].apply(path, arguments);
+				};
+			}
+	);
+
+	return fields;
+});
+
+PathItem.inject(new function() {
+	var operators = {
+		unite:	   { 0: true, 1: true },
+		intersect: { 2: true },
+		subtract:  { 1: true },
+		exclude:   { 1: true }
+	};
+
+	function preparePath(path, resolve) {
+		var res = path.clone(false).reduce({ simplify: true })
+				.transform(null, true, true);
+		return resolve ? res.resolveCrossings() : res;
+	}
+
+	function finishResult(result, path1, path2) {
+		result.insertAbove(path2 && path1.isSibling(path2)
+				&& path1.getIndex() < path2.getIndex() ? path2 : path1);
+		result.copyAttributes(path1, true);
+		return result;
+	}
+
+	function createResult(ctor, paths, reduce) {
+		var result = new ctor(Item.NO_INSERT);
+		result.addChildren(paths, true);
+		if (reduce)
+			result = result.reduce({ simplify: true });
+		return result;
+	}
+
+	function computeBoolean(path1, path2, operation) {
+		var operator = operators[operation];
+		operator[operation] = true;
+		if (!path1._children && !path1._closed)
+			return computeOpenBoolean(path1, path2, operator);
+		var _path1 = preparePath(path1, true),
+			_path2 = path2 && path1 !== path2 && preparePath(path2, true);
+		if (_path2 && (operator.subtract || operator.exclude)
+				^ (_path2.isClockwise() !== _path1.isClockwise()))
+			_path2.reverse();
+		var crossings = divideLocations(
+				CurveLocation.expand(_path1.getCrossings(_path2))),
+			segments = [],
+			monoCurves = [],
+			overlapsOnly = true,
+			validOverlapsOnly = true;
+
+		function collect(paths) {
+			for (var i = 0, l = paths.length; i < l; i++) {
+				var path = paths[i];
+				segments.push.apply(segments, path._segments);
+				monoCurves.push.apply(monoCurves, path._getMonoCurves());
+			}
+		}
+
+		collect(_path1._children || [_path1]);
+		if (_path2)
+			collect(_path2._children || [_path2]);
+		for (var i = 0, l = crossings.length; i < l; i++) {
+			propagateWinding(crossings[i]._segment, _path1, _path2, monoCurves,
+					operator);
+		}
+		for (var i = 0, l = segments.length; i < l; i++) {
+			var segment = segments[i],
+				inter = segment._intersection;
+			if (segment._winding == null) {
+				propagateWinding(segment, _path1, _path2, monoCurves, operator);
+			}
+			if (!(inter && inter._overlap)) {
+				overlapsOnly = false;
+				if (operator[segment._winding])
+					validOverlapsOnly = false;
+			}
+		}
+		return finishResult(overlapsOnly
+				? (operator.unite || operator.intersect) && path1.getArea()
+					? path1.clone(false)
+					: new Path(Item.NO_INSERT)
+				: createResult(CompoundPath,
+					tracePaths(segments, operator, validOverlapsOnly),
+					!overlapsOnly), path1, path2);
+	}
+
+	function computeOpenBoolean(path1, path2, operator) {
+		if (!path2 || !path2._children && !path2._closed
+				|| !operator.subtract && !operator.intersect)
+			return null;
+		var _path1 = preparePath(path1, false),
+			_path2 = preparePath(path2, false),
+			crossings = _path1.getCrossings(_path2),
+			sub = operator.subtract,
+			paths = [];
+
+		function addPath(path) {
+			if (_path2.contains(path.getPointAt(path.getLength() / 2)) ^ sub) {
+				paths.unshift(path);
+				return true;
+			}
+		}
+
+		for (var i = crossings.length - 1; i >= 0; i--) {
+			var path = crossings[i].split();
+			if (path) {
+				if (addPath(path))
+					path.getFirstSegment().setHandleIn(0, 0);
+				_path1.getLastSegment().setHandleOut(0, 0);
+			}
+		}
+		addPath(_path1);
+		return finishResult(createResult(Group, paths), path1, path2);
+	}
+
+	function linkIntersections(from, to) {
+		var prev = from;
+		while (prev) {
+			if (prev === to)
+				return;
+			prev = prev._prev;
+		}
+		while (from._next && from._next !== to)
+			from = from._next;
+		if (!from._next) {
+			while (to._prev)
+				to = to._prev;
+			from._next = to;
+			to._prev = from;
+		}
+	}
+
+	function divideLocations(locations, include) {
+		var results = include && [],
+			tMin = 4e-7,
+			tMax = 1 - tMin,
+			noHandles = false,
+			clearCurves = [],
+			prevCurve,
+			prevT;
+
+		for (var i = locations.length - 1; i >= 0; i--) {
+			var loc = locations[i];
+			if (include) {
+				if (!include(loc))
+					continue;
+				results.unshift(loc);
+			}
+			var curve = loc._curve,
+				t = loc._parameter,
+				origT = t,
+				segment;
+			if (curve !== prevCurve) {
+				noHandles = !curve.hasHandles();
+			} else if (prevT > 0) {
+				t /= prevT;
+			}
+			if (t < tMin) {
+				segment = curve._segment1;
+			} else if (t > tMax) {
+				segment = curve._segment2;
+			} else {
+				var newCurve = curve.divide(t, true, true);
+				if (noHandles)
+					clearCurves.push(curve, newCurve);
+				segment = newCurve._segment1;
+			}
+			loc._setSegment(segment);
+			var inter = segment._intersection,
+				dest = loc._intersection;
+			if (inter) {
+				linkIntersections(inter, dest);
+				var other = inter;
+				while (other) {
+					linkIntersections(other._intersection, inter);
+					other = other._next;
+				}
+			} else {
+				segment._intersection = dest;
+			}
+			prevCurve = curve;
+			prevT = origT;
+		}
+		for (var i = 0, l = clearCurves.length; i < l; i++) {
+			clearCurves[i].clearHandles();
+		}
+		return results || locations;
+	}
+
+	function getWinding(point, curves, horizontal) {
+		var epsilon = 2e-7,
+			px = point.x,
+			py = point.y,
+			windLeft = 0,
+			windRight = 0,
+			length = curves.length,
+			roots = [],
+			abs = Math.abs;
+		if (horizontal) {
+			var yTop = -Infinity,
+				yBottom = Infinity,
+				yBefore = py - epsilon,
+				yAfter = py + epsilon;
+			for (var i = 0; i < length; i++) {
+				var values = curves[i].values,
+					count = Curve.solveCubic(values, 0, px, roots, 0, 1);
+				for (var j = count - 1; j >= 0; j--) {
+					var y = Curve.getPoint(values, roots[j]).y;
+					if (y < yBefore && y > yTop) {
+						yTop = y;
+					} else if (y > yAfter && y < yBottom) {
+						yBottom = y;
+					}
+				}
+			}
+			yTop = (yTop + py) / 2;
+			yBottom = (yBottom + py) / 2;
+			if (yTop > -Infinity)
+				windLeft = getWinding(new Point(px, yTop), curves);
+			if (yBottom < Infinity)
+				windRight = getWinding(new Point(px, yBottom), curves);
+		} else {
+			var xBefore = px - epsilon,
+				xAfter = px + epsilon,
+				start,
+				end = 0;
+			while (end < length) {
+				start = end;
+				var curve = curves[start],
+					last = curve.last,
+					prevWinding = last.winding,
+					prevXEnd = last.values[6];
+				end = start + curve.length;
+				for (var i = start; i < end; i++) {
+					var curve = curves[i],
+						winding = curve.winding,
+						values = curve.values,
+						yStart = values[1],
+						yEnd = values[7];
+					if (winding && (py >= yStart && py <= yEnd
+							|| py >= yEnd && py <= yStart)) {
+						var x = py === yStart ? values[0]
+							:	py === yEnd   ? values[6]
+							: Curve.solveCubic(values, 1, py, roots, 0, 1) === 1
+								? Curve.getPoint(values, roots[0]).x
+								: null;
+						if (x != null) {
+							var isWindingChange = winding === -prevWinding;
+							if (py !== yStart || isWindingChange
+									|| (x - px) * (prevXEnd - px) < 0) {
+								if (x < xBefore) {
+									windLeft += winding;
+								} else if (x > xAfter) {
+									windRight += winding;
+								} else if (py === yStart && isWindingChange) {
+									++windLeft;
+									++windRight;
+								}
+							}
+						}
+						prevWinding = winding;
+						prevXEnd = values[6];
+					}
+				}
+			}
+		}
+		return Math.max(abs(windLeft), abs(windRight));
+	}
+
+	function propagateWinding(segment, path1, path2, monoCurves, operator) {
+		var chain = [],
+			start = segment,
+			totalLength = 0,
+			windingSum = 0;
+		do {
+			var curve = segment.getCurve(),
+				length = curve.getLength();
+			chain.push({ segment: segment, curve: curve, length: length });
+			totalLength += length;
+			segment = segment.getNext();
+		} while (segment && !segment._intersection && segment !== start);
+		for (var i = 0; i < 3; i++) {
+			var length = totalLength * (i + 1) / 4;
+			for (var j = 0, l = chain.length; j < l; j++) {
+				var entry = chain[j],
+					curveLength = entry.length;
+				if (length <= curveLength) {
+					var curve = entry.curve,
+						path = curve._path,
+						parent = path._parent,
+						t = curve.getParameterAt(length),
+						pt = curve.getPointAt(t, true),
+						hor = Math.abs(curve.getTangentAt(t, true).y)
+								< 1e-7;
+					if (parent instanceof CompoundPath)
+						path = parent;
+					if (!(operator.subtract && path2
+							&& (path === path1 && path2._getWinding(pt, hor)
+							|| path === path2 && !path1._getWinding(pt, hor))))
+						windingSum += getWinding(pt, monoCurves, hor);
+					break;
+				}
+				length -= curveLength;
+			}
+		}
+		var winding = Math.round(windingSum / 3);
+		for (var j = chain.length - 1; j >= 0; j--)
+			chain[j].segment._winding = winding;
+	}
+
+	function tracePaths(segments, operator, validOverlapsOnly) {
+		var paths = [],
+			start,
+			otherStart;
+
+		function isValid(seg) {
+			return !!(!seg._visited && (!operator || operator[seg._winding]));
+		}
+
+		function isStart(seg) {
+			return seg === start || seg === otherStart;
+		}
+
+		function findBestIntersection(inter, strict) {
+			if (!inter._next)
+				return inter;
+			while (inter) {
+				var seg = inter._segment,
+					nextSeg = seg.getNext(),
+					nextInter = nextSeg._intersection;
+				if (isStart(seg) || isStart(nextSeg)
+					|| !seg._visited && !nextSeg._visited
+					&& (!operator
+						|| (!strict || isValid(seg))
+						&& (!(strict && nextInter && nextInter._overlap)
+							&& isValid(nextSeg)
+							|| !strict && nextInter
+							&& isValid(nextInter._segment))
+					))
+					return inter;
+				inter = inter._next;
+			}
+			return null;
+		}
+
+		for (var i = 0, l = segments.length; i < l; i++) {
+			var path = null,
+				finished = false,
+				seg = segments[i],
+				inter = seg._intersection,
+				handleIn;
+			if (!isValid(seg) || !validOverlapsOnly
+					&& inter && seg._winding && inter._overlap)
+				continue;
+			start = otherStart = null;
+			while (true) {
+				handleIn = path && seg._handleIn;
+				inter = inter && (findBestIntersection(inter, true)
+						|| findBestIntersection(inter, false)) || inter;
+				var other = inter && inter._segment;
+				if (isStart(seg)) {
+					finished = true;
+				} else if (other) {
+					if (isStart(other)) {
+						finished = true;
+						seg = other;
+					} else if (isValid(other)) {
+						if (operator && operator.intersect && inter._overlap)
+							seg._visited = true;
+						seg = other;
+					}
+				}
+				if (finished || seg._visited) {
+					seg._visited = true;
+					break;
+				}
+				if (validOverlapsOnly && !isValid(seg))
+					break;
+				if (!path) {
+					path = new Path(Item.NO_INSERT);
+					start = seg;
+					otherStart = other;
+				}
+				path.add(new Segment(seg._point, handleIn, seg._handleOut));
+				seg._visited = true;
+				seg = seg.getNext();
+				inter = seg._intersection;
+			}
+			if (finished) {
+				path.firstSegment.setHandleIn(handleIn);
+				path.setClosed(true);
+			} else if (path) {
+				var length = path.getLength();
+				if (length >= 2e-7) {
+					console.error('Boolean operation resulted in open path',
+							'segments =', path._segments.length,
+							'length =', length);
+				}
+				path = null;
+			}
+			if (path && (path._segments.length > 8
+					|| !Numerical.isZero(path.getArea()))) {
+				paths.push(path);
+				path = null;
+			}
+		}
+		return paths;
+	}
+
+	return {
+		_getWinding: function(point, horizontal) {
+			return getWinding(point, this._getMonoCurves(), horizontal);
+		},
+
+		unite: function(path) {
+			return computeBoolean(this, path, 'unite');
+		},
+
+		intersect: function(path) {
+			return computeBoolean(this, path, 'intersect');
+		},
+
+		subtract: function(path) {
+			return computeBoolean(this, path, 'subtract');
+		},
+
+		exclude: function(path) {
+			return computeBoolean(this, path, 'exclude');
+		},
+
+		divide: function(path) {
+			return finishResult(createResult(Group,
+				[this.subtract(path), this.intersect(path)], true), this, path);
+		},
+
+		resolveCrossings: function() {
+			var children = this._children,
+				paths = children || [this];
+
+			function hasOverlap(seg) {
+				var inter = seg && seg._intersection;
+				return inter && inter._overlap;
+			}
+
+			var hasOverlaps = false,
+				hasCrossings = false,
+				intersections = this.getIntersections(null, function(inter) {
+					return inter._overlap && (hasOverlaps = true)
+							|| inter.isCrossing() && (hasCrossings = true);
+				});
+			intersections = CurveLocation.expand(intersections);
+			if (hasOverlaps) {
+				var overlaps = divideLocations(intersections, function(inter) {
+					return inter._overlap;
+				});
+				for (var i = overlaps.length - 1; i >= 0; i--) {
+					var seg = overlaps[i]._segment,
+						prev = seg.getPrevious(),
+						next = seg.getNext();
+					if (seg._path && hasOverlap(prev) && hasOverlap(next)) {
+						seg.remove();
+						prev._handleOut.set(0, 0);
+						next._handleIn.set(0, 0);
+						var curve = prev.getCurve();
+						if (curve.isStraight() && curve.getLength() === 0)
+							prev.remove();
+					}
+				}
+			}
+			if (hasCrossings) {
+				divideLocations(intersections, hasOverlaps && function(inter) {
+					var curve1 = inter.getCurve(),
+						curve2 = inter._intersection._curve,
+						seg = inter._segment;
+					if (curve1 && curve2 && curve1._path && curve2._path) {
+						return true;
+					} else if (seg) {
+						seg._intersection = null;
+					}
+				});
+				paths = tracePaths(Base.each(paths, function(path) {
+					this.push.apply(this, path._segments);
+				}, []));
+			}
+			var length = paths.length,
+				item;
+			if (length > 1) {
+				paths = paths.slice().sort(function (a, b) {
+					return b.getBounds().getArea() - a.getBounds().getArea();
+				});
+				var first = paths[0],
+					items = [first],
+					excluded = {},
+					isNonZero = this.getFillRule() === 'nonzero',
+					windings = isNonZero && Base.each(paths, function(path) {
+						this.push(path.isClockwise() ? 1 : -1);
+					}, []);
+				for (var i = 1; i < length; i++) {
+					var path = paths[i],
+						point = path.getInteriorPoint(),
+						isContained = false,
+						container = null,
+						exclude = false;
+					for (var j = i - 1; j >= 0 && !container; j--) {
+						if (paths[j].contains(point)) {
+							if (isNonZero && !isContained) {
+								windings[i] += windings[j];
+								if (windings[i] && windings[j]) {
+									exclude = excluded[i] = true;
+									break;
+								}
+							}
+							isContained = true;
+							container = !excluded[j] && paths[j];
+						}
+					}
+					if (!exclude) {
+						path.setClockwise(container ? !container.isClockwise()
+								: first.isClockwise());
+						items.push(path);
+					}
+				}
+				paths = items;
+				length = items.length;
+			}
+			if (length > 1 && children) {
+				if (paths !== children) {
+					this.setChildren(paths, true);
+				}
+				item = this;
+			} else if (length === 1 && !children) {
+				if (paths[0] !== this)
+					this.setSegments(paths[0].removeSegments());
+				item = this;
+			}
+			if (!item) {
+				item = new CompoundPath(Item.NO_INSERT);
+				item.addChildren(paths, true);
+				item = item.reduce();
+				item.copyAttributes(this);
+				this.replaceWith(item);
+			}
+			return item;
+		}
+	};
+});
+
+Path.inject({
+	_getMonoCurves: function() {
+		var monoCurves = this._monoCurves,
+			last;
+
+		function insertCurve(v) {
+			var y0 = v[1],
+				y1 = v[7],
+				winding = Math.abs((y0 - y1) / (v[0] - v[6]))
+						< 2e-7
+					? 0
+					: y0 > y1
+						? -1
+						: 1,
+				curve = { values: v, winding: winding };
+			monoCurves.push(curve);
+			if (winding)
+				last = curve;
+		}
+
+		function handleCurve(v) {
+			if (Curve.getLength(v) === 0)
+				return;
+			var y0 = v[1],
+				y1 = v[3],
+				y2 = v[5],
+				y3 = v[7];
+			if (Curve.isStraight(v)
+					|| y0 >= y1 === y1 >= y2 && y1 >= y2 === y2 >= y3) {
+				insertCurve(v);
+			} else {
+				var a = 3 * (y1 - y2) - y0 + y3,
+					b = 2 * (y0 + y2) - 4 * y1,
+					c = y1 - y0,
+					tMin = 4e-7,
+					tMax = 1 - tMin,
+					roots = [],
+					n = Numerical.solveQuadratic(a, b, c, roots, tMin, tMax);
+				if (n === 0) {
+					insertCurve(v);
+				} else {
+					roots.sort();
+					var t = roots[0],
+						parts = Curve.subdivide(v, t);
+					insertCurve(parts[0]);
+					if (n > 1) {
+						t = (roots[1] - t) / (1 - t);
+						parts = Curve.subdivide(parts[1], t);
+						insertCurve(parts[0]);
+					}
+					insertCurve(parts[1]);
+				}
+			}
+		}
+
+		if (!monoCurves) {
+			monoCurves = this._monoCurves = [];
+			var curves = this.getCurves(),
+				segments = this._segments;
+			for (var i = 0, l = curves.length; i < l; i++)
+				handleCurve(curves[i].getValues());
+			if (!this._closed && segments.length > 1) {
+				var p1 = segments[segments.length - 1]._point,
+					p2 = segments[0]._point,
+					p1x = p1._x, p1y = p1._y,
+					p2x = p2._x, p2y = p2._y;
+				handleCurve([p1x, p1y, p1x, p1y, p2x, p2y, p2x, p2y]);
+			}
+			if (monoCurves.length > 0) {
+				var first = monoCurves[0];
+				first.length = monoCurves.length;
+				first.last = last;
+			}
+		}
+		return monoCurves;
+	},
+
+	getInteriorPoint: function() {
+		var bounds = this.getBounds(),
+			point = bounds.getCenter(true);
+		if (!this.contains(point)) {
+			var curves = this._getMonoCurves(),
+				roots = [],
+				y = point.y,
+				intercepts = [];
+			for (var i = 0, l = curves.length; i < l; i++) {
+				var values = curves[i].values;
+				if ((curves[i].winding === 1
+						&& y >= values[1] && y <= values[7]
+						|| y >= values[7] && y <= values[1])) {
+					var count = Curve.solveCubic(values, 1, y, roots, 0, 1);
+					for (var j = count - 1; j >= 0; j--) {
+						intercepts.push(Curve.getPoint(values, roots[j]).x);
+					}
+				}
+				if (intercepts.length > 1)
+					break;
+			}
+			point.x = (intercepts[0] + intercepts[1]) / 2;
+		}
+		return point;
+	}
+});
+
+CompoundPath.inject({
+	_getMonoCurves: function() {
+		var children = this._children,
+			monoCurves = [];
+		for (var i = 0, l = children.length; i < l; i++)
+			monoCurves.push.apply(monoCurves, children[i]._getMonoCurves());
+		return monoCurves;
+	}
+});
+
+var PathIterator = Base.extend({
+	_class: 'PathIterator',
+
+	initialize: function(path, maxRecursion, tolerance, matrix) {
+		var curves = [],
+			parts = [],
+			length = 0,
+			minDifference = 1 / (maxRecursion || 32),
+			segments = path._segments,
+			segment1 = segments[0],
+			segment2;
+
+		function addCurve(segment1, segment2) {
+			var curve = Curve.getValues(segment1, segment2, matrix);
+			curves.push(curve);
+			computeParts(curve, segment1._index, 0, 1);
+		}
+
+		function computeParts(curve, index, minT, maxT) {
+			if ((maxT - minT) > minDifference
+					&& !Curve.isFlatEnough(curve, tolerance || 0.25)) {
+				var split = Curve.subdivide(curve, 0.5),
+					halfT = (minT + maxT) / 2;
+				computeParts(split[0], index, minT, halfT);
+				computeParts(split[1], index, halfT, maxT);
+			} else {
+				var x = curve[6] - curve[0],
+					y = curve[7] - curve[1],
+					dist = Math.sqrt(x * x + y * y);
+				if (dist > 1e-6) {
+					length += dist;
+					parts.push({
+						offset: length,
+						value: maxT,
+						index: index
+					});
+				}
+			}
+		}
+
+		for (var i = 1, l = segments.length; i < l; i++) {
+			segment2 = segments[i];
+			addCurve(segment1, segment2);
+			segment1 = segment2;
+		}
+		if (path._closed)
+			addCurve(segment2, segments[0]);
+
+		this.curves = curves;
+		this.parts = parts;
+		this.length = length;
+		this.index = 0;
+	},
+
+	getParameterAt: function(offset) {
+		var i, j = this.index;
+		for (;;) {
+			i = j;
+			if (j === 0 || this.parts[--j].offset < offset)
+				break;
+		}
+		for (var l = this.parts.length; i < l; i++) {
+			var part = this.parts[i];
+			if (part.offset >= offset) {
+				this.index = i;
+				var prev = this.parts[i - 1];
+				var prevVal = prev && prev.index == part.index ? prev.value : 0,
+					prevLen = prev ? prev.offset : 0;
+				return {
+					value: prevVal + (part.value - prevVal)
+						* (offset - prevLen) / (part.offset - prevLen),
+					index: part.index
+				};
+			}
+		}
+		var part = this.parts[this.parts.length - 1];
+		return {
+			value: 1,
+			index: part.index
+		};
+	},
+
+	drawPart: function(ctx, from, to) {
+		from = this.getParameterAt(from);
+		to = this.getParameterAt(to);
+		for (var i = from.index; i <= to.index; i++) {
+			var curve = Curve.getPart(this.curves[i],
+					i == from.index ? from.value : 0,
+					i == to.index ? to.value : 1);
+			if (i == from.index)
+				ctx.moveTo(curve[0], curve[1]);
+			ctx.bezierCurveTo.apply(ctx, curve.slice(2));
+		}
+	}
+}, Base.each(Curve.evaluateMethods,
+	function(name) {
+		this[name + 'At'] = function(offset, weighted) {
+			var param = this.getParameterAt(offset);
+			return Curve[name](this.curves[param.index], param.value, weighted);
+		};
+	}, {})
+);
+
+var PathFitter = Base.extend({
+	initialize: function(path, error) {
+		var points = this.points = [],
+			segments = path._segments,
+			prev;
+		for (var i = 0, l = segments.length; i < l; i++) {
+			var point = segments[i].point.clone();
+			if (!prev || !prev.equals(point)) {
+				points.push(point);
+				prev = point;
+			}
+		}
+
+		if (path._closed) {
+			this.closed = true;
+			points.unshift(points[points.length - 1]);
+			points.push(points[1]);
+		}
+
+		this.error = error;
+	},
+
+	fit: function() {
+		var points = this.points,
+			length = points.length,
+			segments = this.segments = length > 0
+					? [new Segment(points[0])] : [];
+		if (length > 1)
+			this.fitCubic(0, length - 1,
+				points[1].subtract(points[0]).normalize(),
+				points[length - 2].subtract(points[length - 1]).normalize());
+
+		if (this.closed) {
+			segments.shift();
+			segments.pop();
+		}
+
+		return segments;
+	},
+
+	fitCubic: function(first, last, tan1, tan2) {
+		if (last - first == 1) {
+			var pt1 = this.points[first],
+				pt2 = this.points[last],
+				dist = pt1.getDistance(pt2) / 3;
+			this.addCurve([pt1, pt1.add(tan1.normalize(dist)),
+					pt2.add(tan2.normalize(dist)), pt2]);
+			return;
+		}
+		var uPrime = this.chordLengthParameterize(first, last),
+			maxError = Math.max(this.error, this.error * this.error),
+			split,
+			parametersInOrder = true;
+		for (var i = 0; i <= 4; i++) {
+			var curve = this.generateBezier(first, last, uPrime, tan1, tan2);
+			var max = this.findMaxError(first, last, curve, uPrime);
+			if (max.error < this.error && parametersInOrder) {
+				this.addCurve(curve);
+				return;
+			}
+			split = max.index;
+			if (max.error >= maxError)
+				break;
+			parametersInOrder = this.reparameterize(first, last, uPrime, curve);
+			maxError = max.error;
+		}
+		var V1 = this.points[split - 1].subtract(this.points[split]),
+			V2 = this.points[split].subtract(this.points[split + 1]),
+			tanCenter = V1.add(V2).divide(2).normalize();
+		this.fitCubic(first, split, tan1, tanCenter);
+		this.fitCubic(split, last, tanCenter.negate(), tan2);
+	},
+
+	addCurve: function(curve) {
+		var prev = this.segments[this.segments.length - 1];
+		prev.setHandleOut(curve[1].subtract(curve[0]));
+		this.segments.push(
+				new Segment(curve[3], curve[2].subtract(curve[3])));
+	},
+
+	generateBezier: function(first, last, uPrime, tan1, tan2) {
+		var epsilon = 1e-12,
+			pt1 = this.points[first],
+			pt2 = this.points[last],
+			C = [[0, 0], [0, 0]],
+			X = [0, 0];
+
+		for (var i = 0, l = last - first + 1; i < l; i++) {
+			var u = uPrime[i],
+				t = 1 - u,
+				b = 3 * u * t,
+				b0 = t * t * t,
+				b1 = b * t,
+				b2 = b * u,
+				b3 = u * u * u,
+				a1 = tan1.normalize(b1),
+				a2 = tan2.normalize(b2),
+				tmp = this.points[first + i]
+					.subtract(pt1.multiply(b0 + b1))
+					.subtract(pt2.multiply(b2 + b3));
+			C[0][0] += a1.dot(a1);
+			C[0][1] += a1.dot(a2);
+			C[1][0] = C[0][1];
+			C[1][1] += a2.dot(a2);
+			X[0] += a1.dot(tmp);
+			X[1] += a2.dot(tmp);
+		}
+
+		var detC0C1 = C[0][0] * C[1][1] - C[1][0] * C[0][1],
+			alpha1, alpha2;
+		if (Math.abs(detC0C1) > epsilon) {
+			var detC0X	= C[0][0] * X[1]	- C[1][0] * X[0],
+				detXC1	= X[0]	  * C[1][1] - X[1]	  * C[0][1];
+			alpha1 = detXC1 / detC0C1;
+			alpha2 = detC0X / detC0C1;
+		} else {
+			var c0 = C[0][0] + C[0][1],
+				c1 = C[1][0] + C[1][1];
+			if (Math.abs(c0) > epsilon) {
+				alpha1 = alpha2 = X[0] / c0;
+			} else if (Math.abs(c1) > epsilon) {
+				alpha1 = alpha2 = X[1] / c1;
+			} else {
+				alpha1 = alpha2 = 0;
+			}
+		}
+
+		var segLength = pt2.getDistance(pt1),
+			eps = epsilon * segLength,
+			handle1,
+			handle2;
+		if (alpha1 < eps || alpha2 < eps) {
+			alpha1 = alpha2 = segLength / 3;
+		} else {
+			var line = pt2.subtract(pt1);
+			handle1 = tan1.normalize(alpha1);
+			handle2 = tan2.normalize(alpha2);
+			if (handle1.dot(line) - handle2.dot(line) > segLength * segLength) {
+				alpha1 = alpha2 = segLength / 3;
+				handle1 = handle2 = null;
+			}
+		}
+
+		return [pt1, pt1.add(handle1 || tan1.normalize(alpha1)),
+				pt2.add(handle2 || tan2.normalize(alpha2)), pt2];
+	},
+
+	reparameterize: function(first, last, u, curve) {
+		for (var i = first; i <= last; i++) {
+			u[i - first] = this.findRoot(curve, this.points[i], u[i - first]);
+		}
+		for (var i = 1, l = u.length; i < l; i++) {
+			if (u[i] <= u[i - 1])
+				return false;
+		}
+		return true;
+	},
+
+	findRoot: function(curve, point, u) {
+		var curve1 = [],
+			curve2 = [];
+		for (var i = 0; i <= 2; i++) {
+			curve1[i] = curve[i + 1].subtract(curve[i]).multiply(3);
+		}
+		for (var i = 0; i <= 1; i++) {
+			curve2[i] = curve1[i + 1].subtract(curve1[i]).multiply(2);
+		}
+		var pt = this.evaluate(3, curve, u),
+			pt1 = this.evaluate(2, curve1, u),
+			pt2 = this.evaluate(1, curve2, u),
+			diff = pt.subtract(point),
+			df = pt1.dot(pt1) + diff.dot(pt2);
+		if (Math.abs(df) < 1e-6)
+			return u;
+		return u - diff.dot(pt1) / df;
+	},
+
+	evaluate: function(degree, curve, t) {
+		var tmp = curve.slice();
+		for (var i = 1; i <= degree; i++) {
+			for (var j = 0; j <= degree - i; j++) {
+				tmp[j] = tmp[j].multiply(1 - t).add(tmp[j + 1].multiply(t));
+			}
+		}
+		return tmp[0];
+	},
+
+	chordLengthParameterize: function(first, last) {
+		var u = [0];
+		for (var i = first + 1; i <= last; i++) {
+			u[i - first] = u[i - first - 1]
+					+ this.points[i].getDistance(this.points[i - 1]);
+		}
+		for (var i = 1, m = last - first; i <= m; i++) {
+			u[i] /= u[m];
+		}
+		return u;
+	},
+
+	findMaxError: function(first, last, curve, u) {
+		var index = Math.floor((last - first + 1) / 2),
+			maxDist = 0;
+		for (var i = first + 1; i < last; i++) {
+			var P = this.evaluate(3, curve, u[i - first]);
+			var v = P.subtract(this.points[i]);
+			var dist = v.x * v.x + v.y * v.y;
+			if (dist >= maxDist) {
+				maxDist = dist;
+				index = i;
+			}
+		}
+		return {
+			error: maxDist,
+			index: index
+		};
+	}
+});
+
+var TextItem = Item.extend({
+	_class: 'TextItem',
+	_boundsSelected: true,
+	_applyMatrix: false,
+	_canApplyMatrix: false,
+	_serializeFields: {
+		content: null
+	},
+	_boundsGetter: 'getBounds',
+
+	initialize: function TextItem(arg) {
+		this._content = '';
+		this._lines = [];
+		var hasProps = arg && Base.isPlainObject(arg)
+				&& arg.x === undefined && arg.y === undefined;
+		this._initialize(hasProps && arg, !hasProps && Point.read(arguments));
+	},
+
+	_equals: function(item) {
+		return this._content === item._content;
+	},
+
+	copyContent: function(source) {
+		this.setContent(source._content);
+	},
+
+	getContent: function() {
+		return this._content;
+	},
+
+	setContent: function(content) {
+		this._content = '' + content;
+		this._lines = this._content.split(/\r\n|\n|\r/mg);
+		this._changed(265);
+	},
+
+	isEmpty: function() {
+		return !this._content;
+	},
+
+	getCharacterStyle: '#getStyle',
+	setCharacterStyle: '#setStyle',
+
+	getParagraphStyle: '#getStyle',
+	setParagraphStyle: '#setStyle'
+});
+
+var PointText = TextItem.extend({
+	_class: 'PointText',
+
+	initialize: function PointText() {
+		TextItem.apply(this, arguments);
+	},
+
+	getPoint: function() {
+		var point = this._matrix.getTranslation();
+		return new LinkedPoint(point.x, point.y, this, 'setPoint');
+	},
+
+	setPoint: function() {
+		var point = Point.read(arguments);
+		this.translate(point.subtract(this._matrix.getTranslation()));
+	},
+
+	_draw: function(ctx) {
+		if (!this._content)
+			return;
+		this._setStyles(ctx);
+		var lines = this._lines,
+			style = this._style,
+			hasFill = style.hasFill(),
+			hasStroke = style.hasStroke(),
+			leading = style.getLeading(),
+			shadowBlur = ctx.shadowBlur;
+		ctx.font = style.getFontStyle();
+		ctx.textAlign = style.getJustification();
+		for (var i = 0, l = lines.length; i < l; i++) {
+			ctx.shadowBlur = shadowBlur;
+			var line = lines[i];
+			if (hasFill) {
+				ctx.fillText(line, 0, 0);
+				ctx.shadowBlur = 0;
+			}
+			if (hasStroke)
+				ctx.strokeText(line, 0, 0);
+			ctx.translate(0, leading);
+		}
+	},
+
+	_getBounds: function(getter, matrix) {
+		var style = this._style,
+			lines = this._lines,
+			numLines = lines.length,
+			justification = style.getJustification(),
+			leading = style.getLeading(),
+			width = this.getView().getTextWidth(style.getFontStyle(), lines),
+			x = 0;
+		if (justification !== 'left')
+			x -= width / (justification === 'center' ? 2: 1);
+		var bounds = new Rectangle(x,
+					numLines ? - 0.75 * leading : 0,
+					width, numLines * leading);
+		return matrix ? matrix._transformBounds(bounds, bounds) : bounds;
+	}
+});
+
+var Color = Base.extend(new function() {
+	var types = {
+		gray: ['gray'],
+		rgb: ['red', 'green', 'blue'],
+		hsb: ['hue', 'saturation', 'brightness'],
+		hsl: ['hue', 'saturation', 'lightness'],
+		gradient: ['gradient', 'origin', 'destination', 'highlight']
+	};
+
+	var componentParsers = {},
+		colorCache = {},
+		colorCtx;
+
+	function fromCSS(string) {
+		var match = string.match(/^#(\w{1,2})(\w{1,2})(\w{1,2})$/),
+			components;
+		if (match) {
+			components = [0, 0, 0];
+			for (var i = 0; i < 3; i++) {
+				var value = match[i + 1];
+				components[i] = parseInt(value.length == 1
+						? value + value : value, 16) / 255;
+			}
+		} else if (match = string.match(/^rgba?\((.*)\)$/)) {
+			components = match[1].split(',');
+			for (var i = 0, l = components.length; i < l; i++) {
+				var value = +components[i];
+				components[i] = i < 3 ? value / 255 : value;
+			}
+		} else {
+			var cached = colorCache[string];
+			if (!cached) {
+				if (!colorCtx) {
+					colorCtx = CanvasProvider.getContext(1, 1);
+					colorCtx.globalCompositeOperation = 'copy';
+				}
+				colorCtx.fillStyle = 'rgba(0,0,0,0)';
+				colorCtx.fillStyle = string;
+				colorCtx.fillRect(0, 0, 1, 1);
+				var data = colorCtx.getImageData(0, 0, 1, 1).data;
+				cached = colorCache[string] = [
+					data[0] / 255,
+					data[1] / 255,
+					data[2] / 255
+				];
+			}
+			components = cached.slice();
+		}
+		return components;
+	}
+
+	var hsbIndices = [
+		[0, 3, 1],
+		[2, 0, 1],
+		[1, 0, 3],
+		[1, 2, 0],
+		[3, 1, 0],
+		[0, 1, 2]
+	];
+
+	var converters = {
+		'rgb-hsb': function(r, g, b) {
+			var max = Math.max(r, g, b),
+				min = Math.min(r, g, b),
+				delta = max - min,
+				h = delta === 0 ? 0
+					:	( max == r ? (g - b) / delta + (g < b ? 6 : 0)
+						: max == g ? (b - r) / delta + 2
+						:			 (r - g) / delta + 4) * 60;
+			return [h, max === 0 ? 0 : delta / max, max];
+		},
+
+		'hsb-rgb': function(h, s, b) {
+			h = (((h / 60) % 6) + 6) % 6;
+			var i = Math.floor(h),
+				f = h - i,
+				i = hsbIndices[i],
+				v = [
+					b,
+					b * (1 - s),
+					b * (1 - s * f),
+					b * (1 - s * (1 - f))
+				];
+			return [v[i[0]], v[i[1]], v[i[2]]];
+		},
+
+		'rgb-hsl': function(r, g, b) {
+			var max = Math.max(r, g, b),
+				min = Math.min(r, g, b),
+				delta = max - min,
+				achromatic = delta === 0,
+				h = achromatic ? 0
+					:	( max == r ? (g - b) / delta + (g < b ? 6 : 0)
+						: max == g ? (b - r) / delta + 2
+						:			 (r - g) / delta + 4) * 60,
+				l = (max + min) / 2,
+				s = achromatic ? 0 : l < 0.5
+						? delta / (max + min)
+						: delta / (2 - max - min);
+			return [h, s, l];
+		},
+
+		'hsl-rgb': function(h, s, l) {
+			h = (((h / 360) % 1) + 1) % 1;
+			if (s === 0)
+				return [l, l, l];
+			var t3s = [ h + 1 / 3, h, h - 1 / 3 ],
+				t2 = l < 0.5 ? l * (1 + s) : l + s - l * s,
+				t1 = 2 * l - t2,
+				c = [];
+			for (var i = 0; i < 3; i++) {
+				var t3 = t3s[i];
+				if (t3 < 0) t3 += 1;
+				if (t3 > 1) t3 -= 1;
+				c[i] = 6 * t3 < 1
+					? t1 + (t2 - t1) * 6 * t3
+					: 2 * t3 < 1
+						? t2
+						: 3 * t3 < 2
+							? t1 + (t2 - t1) * ((2 / 3) - t3) * 6
+							: t1;
+			}
+			return c;
+		},
+
+		'rgb-gray': function(r, g, b) {
+			return [r * 0.2989 + g * 0.587 + b * 0.114];
+		},
+
+		'gray-rgb': function(g) {
+			return [g, g, g];
+		},
+
+		'gray-hsb': function(g) {
+			return [0, 0, g];
+		},
+
+		'gray-hsl': function(g) {
+			return [0, 0, g];
+		},
+
+		'gradient-rgb': function() {
+			return [];
+		},
+
+		'rgb-gradient': function() {
+			return [];
+		}
+
+	};
+
+	return Base.each(types, function(properties, type) {
+		componentParsers[type] = [];
+		Base.each(properties, function(name, index) {
+			var part = Base.capitalize(name),
+				hasOverlap = /^(hue|saturation)$/.test(name),
+				parser = componentParsers[type][index] = name === 'gradient'
+					? function(value) {
+						var current = this._components[0];
+						value = Gradient.read(Array.isArray(value) ? value
+								: arguments, 0, { readNull: true });
+						if (current !== value) {
+							if (current)
+								current._removeOwner(this);
+							if (value)
+								value._addOwner(this);
+						}
+						return value;
+					}
+					: type === 'gradient'
+						? function() {
+							return Point.read(arguments, 0, {
+									readNull: name === 'highlight',
+									clone: true
+							});
+						}
+						: function(value) {
+							return value == null || isNaN(value) ? 0 : value;
+						};
+
+			this['get' + part] = function() {
+				return this._type === type
+					|| hasOverlap && /^hs[bl]$/.test(this._type)
+						? this._components[index]
+						: this._convert(type)[index];
+			};
+
+			this['set' + part] = function(value) {
+				if (this._type !== type
+						&& !(hasOverlap && /^hs[bl]$/.test(this._type))) {
+					this._components = this._convert(type);
+					this._properties = types[type];
+					this._type = type;
+				}
+				this._components[index] = parser.call(this, value);
+				this._changed();
+			};
+		}, this);
+	}, {
+		_class: 'Color',
+		_readIndex: true,
+
+		initialize: function Color(arg) {
+			var slice = Array.prototype.slice,
+				args = arguments,
+				read = 0,
+				type,
+				components,
+				alpha,
+				values;
+			if (Array.isArray(arg)) {
+				args = arg;
+				arg = args[0];
+			}
+			var argType = arg != null && typeof arg;
+			if (argType === 'string' && arg in types) {
+				type = arg;
+				arg = args[1];
+				if (Array.isArray(arg)) {
+					components = arg;
+					alpha = args[2];
+				} else {
+					if (this.__read)
+						read = 1;
+					args = slice.call(args, 1);
+					argType = typeof arg;
+				}
+			}
+			if (!components) {
+				values = argType === 'number'
+						? args
+						: argType === 'object' && arg.length != null
+							? arg
+							: null;
+				if (values) {
+					if (!type)
+						type = values.length >= 3
+								? 'rgb'
+								: 'gray';
+					var length = types[type].length;
+					alpha = values[length];
+					if (this.__read)
+						read += values === arguments
+							? length + (alpha != null ? 1 : 0)
+							: 1;
+					if (values.length > length)
+						values = slice.call(values, 0, length);
+				} else if (argType === 'string') {
+					type = 'rgb';
+					components = fromCSS(arg);
+					if (components.length === 4) {
+						alpha = components[3];
+						components.length--;
+					}
+				} else if (argType === 'object') {
+					if (arg.constructor === Color) {
+						type = arg._type;
+						components = arg._components.slice();
+						alpha = arg._alpha;
+						if (type === 'gradient') {
+							for (var i = 1, l = components.length; i < l; i++) {
+								var point = components[i];
+								if (point)
+									components[i] = point.clone();
+							}
+						}
+					} else if (arg.constructor === Gradient) {
+						type = 'gradient';
+						values = args;
+					} else {
+						type = 'hue' in arg
+							? 'lightness' in arg
+								? 'hsl'
+								: 'hsb'
+							: 'gradient' in arg || 'stops' in arg
+									|| 'radial' in arg
+								? 'gradient'
+								: 'gray' in arg
+									? 'gray'
+									: 'rgb';
+						var properties = types[type],
+							parsers = componentParsers[type];
+						this._components = components = [];
+						for (var i = 0, l = properties.length; i < l; i++) {
+							var value = arg[properties[i]];
+							if (value == null && i === 0 && type === 'gradient'
+									&& 'stops' in arg) {
+								value = {
+									stops: arg.stops,
+									radial: arg.radial
+								};
+							}
+							value = parsers[i].call(this, value);
+							if (value != null)
+								components[i] = value;
+						}
+						alpha = arg.alpha;
+					}
+				}
+				if (this.__read && type)
+					read = 1;
+			}
+			this._type = type || 'rgb';
+			this._id = UID.get(Color);
+			if (!components) {
+				this._components = components = [];
+				var parsers = componentParsers[this._type];
+				for (var i = 0, l = parsers.length; i < l; i++) {
+					var value = parsers[i].call(this, values && values[i]);
+					if (value != null)
+						components[i] = value;
+				}
+			}
+			this._components = components;
+			this._properties = types[this._type];
+			this._alpha = alpha;
+			if (this.__read)
+				this.__read = read;
+		},
+
+		_serialize: function(options, dictionary) {
+			var components = this.getComponents();
+			return Base.serialize(
+					/^(gray|rgb)$/.test(this._type)
+						? components
+						: [this._type].concat(components),
+					options, true, dictionary);
+		},
+
+		_changed: function() {
+			this._canvasStyle = null;
+			if (this._owner)
+				this._owner._changed(65);
+		},
+
+		_convert: function(type) {
+			var converter;
+			return this._type === type
+					? this._components.slice()
+					: (converter = converters[this._type + '-' + type])
+						? converter.apply(this, this._components)
+						: converters['rgb-' + type].apply(this,
+							converters[this._type + '-rgb'].apply(this,
+								this._components));
+		},
+
+		convert: function(type) {
+			return new Color(type, this._convert(type), this._alpha);
+		},
+
+		getType: function() {
+			return this._type;
+		},
+
+		setType: function(type) {
+			this._components = this._convert(type);
+			this._properties = types[type];
+			this._type = type;
+		},
+
+		getComponents: function() {
+			var components = this._components.slice();
+			if (this._alpha != null)
+				components.push(this._alpha);
+			return components;
+		},
+
+		getAlpha: function() {
+			return this._alpha != null ? this._alpha : 1;
+		},
+
+		setAlpha: function(alpha) {
+			this._alpha = alpha == null ? null : Math.min(Math.max(alpha, 0), 1);
+			this._changed();
+		},
+
+		hasAlpha: function() {
+			return this._alpha != null;
+		},
+
+		equals: function(color) {
+			var col = Base.isPlainValue(color, true)
+					? Color.read(arguments)
+					: color;
+			return col === this || col && this._class === col._class
+					&& this._type === col._type
+					&& this._alpha === col._alpha
+					&& Base.equals(this._components, col._components)
+					|| false;
+		},
+
+		toString: function() {
+			var properties = this._properties,
+				parts = [],
+				isGradient = this._type === 'gradient',
+				f = Formatter.instance;
+			for (var i = 0, l = properties.length; i < l; i++) {
+				var value = this._components[i];
+				if (value != null)
+					parts.push(properties[i] + ': '
+							+ (isGradient ? value : f.number(value)));
+			}
+			if (this._alpha != null)
+				parts.push('alpha: ' + f.number(this._alpha));
+			return '{ ' + parts.join(', ') + ' }';
+		},
+
+		toCSS: function(hex) {
+			var components = this._convert('rgb'),
+				alpha = hex || this._alpha == null ? 1 : this._alpha;
+			function convert(val) {
+				return Math.round((val < 0 ? 0 : val > 1 ? 1 : val) * 255);
+			}
+			components = [
+				convert(components[0]),
+				convert(components[1]),
+				convert(components[2])
+			];
+			if (alpha < 1)
+				components.push(alpha < 0 ? 0 : alpha);
+			return hex
+					? '#' + ((1 << 24) + (components[0] << 16)
+						+ (components[1] << 8)
+						+ components[2]).toString(16).slice(1)
+					: (components.length == 4 ? 'rgba(' : 'rgb(')
+						+ components.join(',') + ')';
+		},
+
+		toCanvasStyle: function(ctx) {
+			if (this._canvasStyle)
+				return this._canvasStyle;
+			if (this._type !== 'gradient')
+				return this._canvasStyle = this.toCSS();
+			var components = this._components,
+				gradient = components[0],
+				stops = gradient._stops,
+				origin = components[1],
+				destination = components[2],
+				canvasGradient;
+			if (gradient._radial) {
+				var radius = destination.getDistance(origin),
+					highlight = components[3];
+				if (highlight) {
+					var vector = highlight.subtract(origin);
+					if (vector.getLength() > radius)
+						highlight = origin.add(vector.normalize(radius - 0.1));
+				}
+				var start = highlight || origin;
+				canvasGradient = ctx.createRadialGradient(start.x, start.y,
+						0, origin.x, origin.y, radius);
+			} else {
+				canvasGradient = ctx.createLinearGradient(origin.x, origin.y,
+						destination.x, destination.y);
+			}
+			for (var i = 0, l = stops.length; i < l; i++) {
+				var stop = stops[i];
+				canvasGradient.addColorStop(stop._rampPoint,
+						stop._color.toCanvasStyle());
+			}
+			return this._canvasStyle = canvasGradient;
+		},
+
+		transform: function(matrix) {
+			if (this._type === 'gradient') {
+				var components = this._components;
+				for (var i = 1, l = components.length; i < l; i++) {
+					var point = components[i];
+					matrix._transformPoint(point, point, true);
+				}
+				this._changed();
+			}
+		},
+
+		statics: {
+			_types: types,
+
+			random: function() {
+				var random = Math.random;
+				return new Color(random(), random(), random());
+			}
+		}
+	});
+},
+new function() {
+	var operators = {
+		add: function(a, b) {
+			return a + b;
+		},
+
+		subtract: function(a, b) {
+			return a - b;
+		},
+
+		multiply: function(a, b) {
+			return a * b;
+		},
+
+		divide: function(a, b) {
+			return a / b;
+		}
+	};
+
+	return Base.each(operators, function(operator, name) {
+		this[name] = function(color) {
+			color = Color.read(arguments);
+			var type = this._type,
+				components1 = this._components,
+				components2 = color._convert(type);
+			for (var i = 0, l = components1.length; i < l; i++)
+				components2[i] = operator(components1[i], components2[i]);
+			return new Color(type, components2,
+					this._alpha != null
+							? operator(this._alpha, color.getAlpha())
+							: null);
+		};
+	}, {
+	});
+});
+
+var Gradient = Base.extend({
+	_class: 'Gradient',
+
+	initialize: function Gradient(stops, radial) {
+		this._id = UID.get();
+		if (stops && this._set(stops))
+			stops = radial = null;
+		if (!this._stops)
+			this.setStops(stops || ['white', 'black']);
+		if (this._radial == null)
+			this.setRadial(typeof radial === 'string' && radial === 'radial'
+					|| radial || false);
+	},
+
+	_serialize: function(options, dictionary) {
+		return dictionary.add(this, function() {
+			return Base.serialize([this._stops, this._radial],
+					options, true, dictionary);
+		});
+	},
+
+	_changed: function() {
+		for (var i = 0, l = this._owners && this._owners.length; i < l; i++)
+			this._owners[i]._changed();
+	},
+
+	_addOwner: function(color) {
+		if (!this._owners)
+			this._owners = [];
+		this._owners.push(color);
+	},
+
+	_removeOwner: function(color) {
+		var index = this._owners ? this._owners.indexOf(color) : -1;
+		if (index != -1) {
+			this._owners.splice(index, 1);
+			if (this._owners.length === 0)
+				this._owners = undefined;
+		}
+	},
+
+	clone: function() {
+		var stops = [];
+		for (var i = 0, l = this._stops.length; i < l; i++)
+			stops[i] = this._stops[i].clone();
+		return new Gradient(stops, this._radial);
+	},
+
+	getStops: function() {
+		return this._stops;
+	},
+
+	setStops: function(stops) {
+		if (this.stops) {
+			for (var i = 0, l = this._stops.length; i < l; i++)
+				this._stops[i]._owner = undefined;
+		}
+		if (stops.length < 2)
+			throw new Error(
+					'Gradient stop list needs to contain at least two stops.');
+		this._stops = GradientStop.readAll(stops, 0, { clone: true });
+		for (var i = 0, l = this._stops.length; i < l; i++) {
+			var stop = this._stops[i];
+			stop._owner = this;
+			if (stop._defaultRamp)
+				stop.setRampPoint(i / (l - 1));
+		}
+		this._changed();
+	},
+
+	getRadial: function() {
+		return this._radial;
+	},
+
+	setRadial: function(radial) {
+		this._radial = radial;
+		this._changed();
+	},
+
+	equals: function(gradient) {
+		if (gradient === this)
+			return true;
+		if (gradient && this._class === gradient._class
+				&& this._stops.length === gradient._stops.length) {
+			for (var i = 0, l = this._stops.length; i < l; i++) {
+				if (!this._stops[i].equals(gradient._stops[i]))
+					return false;
+			}
+			return true;
+		}
+		return false;
+	}
+});
+
+var GradientStop = Base.extend({
+	_class: 'GradientStop',
+
+	initialize: function GradientStop(arg0, arg1) {
+		if (arg0) {
+			var color, rampPoint;
+			if (arg1 === undefined && Array.isArray(arg0)) {
+				color = arg0[0];
+				rampPoint = arg0[1];
+			} else if (arg0.color) {
+				color = arg0.color;
+				rampPoint = arg0.rampPoint;
+			} else {
+				color = arg0;
+				rampPoint = arg1;
+			}
+			this.setColor(color);
+			this.setRampPoint(rampPoint);
+		}
+	},
+
+	clone: function() {
+		return new GradientStop(this._color.clone(), this._rampPoint);
+	},
+
+	_serialize: function(options, dictionary) {
+		return Base.serialize([this._color, this._rampPoint], options, true,
+				dictionary);
+	},
+
+	_changed: function() {
+		if (this._owner)
+			this._owner._changed(65);
+	},
+
+	getRampPoint: function() {
+		return this._rampPoint;
+	},
+
+	setRampPoint: function(rampPoint) {
+		this._defaultRamp = rampPoint == null;
+		this._rampPoint = rampPoint || 0;
+		this._changed();
+	},
+
+	getColor: function() {
+		return this._color;
+	},
+
+	setColor: function(color) {
+		this._color = Color.read(arguments);
+		if (this._color === color)
+			this._color = color.clone();
+		this._color._owner = this;
+		this._changed();
+	},
+
+	equals: function(stop) {
+		return stop === this || stop && this._class === stop._class
+				&& this._color.equals(stop._color)
+				&& this._rampPoint == stop._rampPoint
+				|| false;
+	}
+});
+
+var Style = Base.extend(new function() {
+	var defaults = {
+		fillColor: undefined,
+		fillRule: 'nonzero',
+		strokeColor: undefined,
+		strokeWidth: 1,
+		strokeCap: 'butt',
+		strokeJoin: 'miter',
+		strokeScaling: true,
+		miterLimit: 10,
+		dashOffset: 0,
+		dashArray: [],
+		shadowColor: undefined,
+		shadowBlur: 0,
+		shadowOffset: new Point(),
+		selectedColor: undefined,
+		fontFamily: 'sans-serif',
+		fontWeight: 'normal',
+		fontSize: 12,
+		font: 'sans-serif',
+		leading: null,
+		justification: 'left'
+	},
+	flags = {
+		strokeWidth: 97,
+		strokeCap: 97,
+		strokeJoin: 97,
+		strokeScaling: 105,
+		miterLimit: 97,
+		fontFamily: 9,
+		fontWeight: 9,
+		fontSize: 9,
+		font: 9,
+		leading: 9,
+		justification: 9
+	},
+	item = {
+		beans: true
+	},
+	fields = {
+		_defaults: defaults,
+		_textDefaults: new Base(defaults, {
+			fillColor: new Color()
+		}),
+		beans: true
+	};
+
+	Base.each(defaults, function(value, key) {
+		var isColor = /Color$/.test(key),
+			isPoint = key === 'shadowOffset',
+			part = Base.capitalize(key),
+			flag = flags[key],
+			set = 'set' + part,
+			get = 'get' + part;
+
+		fields[set] = function(value) {
+			var owner = this._owner,
+				children = owner && owner._children;
+			if (children && children.length > 0
+					&& !(owner instanceof CompoundPath)) {
+				for (var i = 0, l = children.length; i < l; i++)
+					children[i]._style[set](value);
+			} else {
+				var old = this._values[key];
+				if (old !== value) {
+					if (isColor) {
+						if (old)
+							old._owner = undefined;
+						if (value && value.constructor === Color) {
+							if (value._owner)
+								value = value.clone();
+							value._owner = owner;
+						}
+					}
+					this._values[key] = value;
+					if (owner)
+						owner._changed(flag || 65);
+				}
+			}
+		};
+
+		fields[get] = function(_dontMerge) {
+			var owner = this._owner,
+				children = owner && owner._children,
+				value;
+			if (!children || children.length === 0 || _dontMerge
+					|| owner instanceof CompoundPath) {
+				var value = this._values[key];
+				if (value === undefined) {
+					value = this._defaults[key];
+					if (value && value.clone)
+						value = value.clone();
+				} else {
+					var ctor = isColor ? Color : isPoint ? Point : null;
+					if (ctor && !(value && value.constructor === ctor)) {
+						this._values[key] = value = ctor.read([value], 0,
+								{ readNull: true, clone: true });
+						if (value && isColor)
+							value._owner = owner;
+					}
+				}
+				return value;
+			}
+			for (var i = 0, l = children.length; i < l; i++) {
+				var childValue = children[i]._style[get]();
+				if (i === 0) {
+					value = childValue;
+				} else if (!Base.equals(value, childValue)) {
+					return undefined;
+				}
+			}
+			return value;
+		};
+
+		item[get] = function(_dontMerge) {
+			return this._style[get](_dontMerge);
+		};
+
+		item[set] = function(value) {
+			this._style[set](value);
+		};
+	});
+
+	Base.each({
+		Font: 'FontFamily',
+		WindingRule: 'FillRule'
+	}, function(value, key) {
+		var get = 'get' + key,
+			set = 'set' + key;
+		fields[get] = item[get] = '#get' + value;
+		fields[set] = item[set] = '#set' + value;
+	});
+
+	Item.inject(item);
+	return fields;
+}, {
+	_class: 'Style',
+
+	initialize: function Style(style, _owner, _project) {
+		this._values = {};
+		this._owner = _owner;
+		this._project = _owner && _owner._project || _project || paper.project;
+		if (_owner instanceof TextItem)
+			this._defaults = this._textDefaults;
+		if (style)
+			this.set(style);
+	},
+
+	set: function(style) {
+		var isStyle = style instanceof Style,
+			values = isStyle ? style._values : style;
+		if (values) {
+			for (var key in values) {
+				if (key in this._defaults) {
+					var value = values[key];
+					this[key] = value && isStyle && value.clone
+							? value.clone() : value;
+				}
+			}
+		}
+	},
+
+	equals: function(style) {
+		return style === this || style && this._class === style._class
+				&& Base.equals(this._values, style._values)
+				|| false;
+	},
+
+	hasFill: function() {
+		return !!this.getFillColor();
+	},
+
+	hasStroke: function() {
+		return !!this.getStrokeColor() && this.getStrokeWidth() > 0;
+	},
+
+	hasShadow: function() {
+		return !!this.getShadowColor() && this.getShadowBlur() > 0;
+	},
+
+	getView: function() {
+		return this._project._view;
+	},
+
+	getFontStyle: function() {
+		var fontSize = this.getFontSize();
+		return this.getFontWeight()
+				+ ' ' + fontSize + (/[a-z]/i.test(fontSize + '') ? ' ' : 'px ')
+				+ this.getFontFamily();
+	},
+
+	getFont: '#getFontFamily',
+	setFont: '#setFontFamily',
+
+	getLeading: function getLeading() {
+		var leading = getLeading.base.call(this),
+			fontSize = this.getFontSize();
+		if (/pt|em|%|px/.test(fontSize))
+			fontSize = this.getView().getPixelSize(fontSize);
+		return leading != null ? leading : fontSize * 1.2;
+	}
+
+});
+
+var DomElement = new function() {
+	function handlePrefix(el, name, set, value) {
+		var prefixes = ['', 'webkit', 'moz', 'Moz', 'ms', 'o'],
+			suffix = name[0].toUpperCase() + name.substring(1);
+		for (var i = 0; i < 6; i++) {
+			var prefix = prefixes[i],
+				key = prefix ? prefix + suffix : name;
+			if (key in el) {
+				if (set) {
+					el[key] = value;
+				} else {
+					return el[key];
+				}
+				break;
+			}
+		}
+	}
+
+	return {
+		getStyles: function(el) {
+			var doc = el && el.nodeType !== 9 ? el.ownerDocument : el,
+				view = doc && doc.defaultView;
+			return view && view.getComputedStyle(el, '');
+		},
+
+		getBounds: function(el, viewport) {
+			var doc = el.ownerDocument,
+				body = doc.body,
+				html = doc.documentElement,
+				rect;
+			try {
+				rect = el.getBoundingClientRect();
+			} catch (e) {
+				rect = { left: 0, top: 0, width: 0, height: 0 };
+			}
+			var x = rect.left - (html.clientLeft || body.clientLeft || 0),
+				y = rect.top - (html.clientTop || body.clientTop || 0);
+			if (!viewport) {
+				var view = doc.defaultView;
+				x += view.pageXOffset || html.scrollLeft || body.scrollLeft;
+				y += view.pageYOffset || html.scrollTop || body.scrollTop;
+			}
+			return new Rectangle(x, y, rect.width, rect.height);
+		},
+
+		getViewportBounds: function(el) {
+			var doc = el.ownerDocument,
+				view = doc.defaultView,
+				html = doc.documentElement;
+			return new Rectangle(0, 0,
+				view.innerWidth || html.clientWidth,
+				view.innerHeight || html.clientHeight
+			);
+		},
+
+		getOffset: function(el, viewport) {
+			return DomElement.getBounds(el, viewport).getPoint();
+		},
+
+		getSize: function(el) {
+			return DomElement.getBounds(el, true).getSize();
+		},
+
+		isInvisible: function(el) {
+			return DomElement.getSize(el).equals(new Size(0, 0));
+		},
+
+		isInView: function(el) {
+			return !DomElement.isInvisible(el)
+					&& DomElement.getViewportBounds(el).intersects(
+						DomElement.getBounds(el, true));
+		},
+
+		isInserted: function(el) {
+			return document.body.contains(el);
+		},
+
+		getPrefixed: function(el, name) {
+			return handlePrefix(el, name);
+		},
+
+		setPrefixed: function(el, name, value) {
+			if (typeof name === 'object') {
+				for (var key in name)
+					handlePrefix(el, key, true, name[key]);
+			} else {
+				handlePrefix(el, name, true, value);
+			}
+		}
+	};
+};
+
+var DomEvent = {
+	add: function(el, events) {
+		for (var type in events) {
+			var func = events[type],
+				parts = type.split(/[\s,]+/g);
+			for (var i = 0, l = parts.length; i < l; i++)
+				el.addEventListener(parts[i], func, false);
+		}
+	},
+
+	remove: function(el, events) {
+		for (var type in events) {
+			var func = events[type],
+				parts = type.split(/[\s,]+/g);
+			for (var i = 0, l = parts.length; i < l; i++)
+				el.removeEventListener(parts[i], func, false);
+		}
+	},
+
+	getPoint: function(event) {
+		var pos = event.targetTouches
+				? event.targetTouches.length
+					? event.targetTouches[0]
+					: event.changedTouches[0]
+				: event;
+		return new Point(
+			pos.pageX || pos.clientX + document.documentElement.scrollLeft,
+			pos.pageY || pos.clientY + document.documentElement.scrollTop
+		);
+	},
+
+	getTarget: function(event) {
+		return event.target || event.srcElement;
+	},
+
+	getRelatedTarget: function(event) {
+		return event.relatedTarget || event.toElement;
+	},
+
+	getOffset: function(event, target) {
+		return DomEvent.getPoint(event).subtract(DomElement.getOffset(
+				target || DomEvent.getTarget(event)));
+	}
+};
+
+DomEvent.requestAnimationFrame = new function() {
+	var nativeRequest = DomElement.getPrefixed(window, 'requestAnimationFrame'),
+		requested = false,
+		callbacks = [],
+		focused = true,
+		timer;
+
+	DomEvent.add(window, {
+		focus: function() {
+			focused = true;
+		},
+		blur: function() {
+			focused = false;
+		}
+	});
+
+	function handleCallbacks() {
+		for (var i = callbacks.length - 1; i >= 0; i--) {
+			var entry = callbacks[i],
+				func = entry[0],
+				el = entry[1];
+			if (!el || (PaperScope.getAttribute(el, 'keepalive') == 'true'
+					|| focused) && DomElement.isInView(el)) {
+				callbacks.splice(i, 1);
+				func();
+			}
+		}
+		if (nativeRequest) {
+			if (callbacks.length) {
+				nativeRequest(handleCallbacks);
+			} else {
+				requested = false;
+			}
+		}
+	}
+
+	return function(callback, element) {
+		callbacks.push([callback, element]);
+		if (nativeRequest) {
+			if (!requested) {
+				nativeRequest(handleCallbacks);
+				requested = true;
+			}
+		} else if (!timer) {
+			timer = setInterval(handleCallbacks, 1000 / 60);
+		}
+	};
+};
+
+var View = Base.extend(Emitter, {
+	_class: 'View',
+
+	initialize: function View(project, element) {
+		this._project = project;
+		this._scope = project._scope;
+		this._element = element;
+		var size;
+		if (!this._pixelRatio)
+			this._pixelRatio = window.devicePixelRatio || 1;
+		this._id = element.getAttribute('id');
+		if (this._id == null)
+			element.setAttribute('id', this._id = 'view-' + View._id++);
+		DomEvent.add(element, this._viewEvents);
+		var none = 'none';
+		DomElement.setPrefixed(element.style, {
+			userDrag: none,
+			userSelect: none,
+			touchCallout: none,
+			contentZooming: none,
+			tapHighlightColor: 'rgba(0,0,0,0)'
+		});
+
+		function getSize(name) {
+			return element[name] || parseInt(element.getAttribute(name), 10);
+		}
+
+		function getCanvasSize() {
+			var size = DomElement.getSize(element);
+			return size.isNaN() || size.isZero()
+					? new Size(getSize('width'), getSize('height'))
+					: size;
+		}
+
+		if (PaperScope.hasAttribute(element, 'resize')) {
+			var that = this;
+			DomEvent.add(window, this._windowEvents = {
+				resize: function() {
+					that.setViewSize(getCanvasSize());
+				}
+			});
+		}
+		this._setViewSize(size = getCanvasSize());
+		if (PaperScope.hasAttribute(element, 'stats')
+				&& typeof Stats !== 'undefined') {
+			this._stats = new Stats();
+			var stats = this._stats.domElement,
+				style = stats.style,
+				offset = DomElement.getOffset(element);
+			style.position = 'absolute';
+			style.left = offset.x + 'px';
+			style.top = offset.y + 'px';
+			document.body.appendChild(stats);
+		}
+		View._views.push(this);
+		View._viewsById[this._id] = this;
+		this._viewSize = size;
+		(this._matrix = new Matrix())._owner = this;
+		this._zoom = 1;
+		if (!View._focused)
+			View._focused = this;
+		this._frameItems = {};
+		this._frameItemCount = 0;
+		this._itemEvents = {};
+	},
+
+	remove: function() {
+		if (!this._project)
+			return false;
+		if (View._focused === this)
+			View._focused = null;
+		View._views.splice(View._views.indexOf(this), 1);
+		delete View._viewsById[this._id];
+		var project = this._project;
+		if (project._view === this)
+			project._view = null;
+		DomEvent.remove(this._element, this._viewEvents);
+		DomEvent.remove(window, this._windowEvents);
+		this._element = this._project = null;
+		this.off('frame');
+		this._animate = false;
+		this._frameItems = {};
+		return true;
+	},
+
+	_events: Base.each(['onResize', 'onMouseDown', 'onMouseUp', 'onMouseMove',
+			'onMouseDrag', 'onMouseEnter', 'onMouseLeave'],
+		function(name) {
+			this[name] = {};
+		}, {
+			onFrame: {
+				install: function() {
+					this.play();
+				},
+
+				uninstall: function() {
+					this.pause();
+				}
+			}
+		}
+	),
+
+	_animate: false,
+	_time: 0,
+	_count: 0,
+
+	_requestFrame: function() {
+		var that = this;
+		DomEvent.requestAnimationFrame(function() {
+			that._requested = false;
+			if (!that._animate)
+				return;
+			that._requestFrame();
+			that._handleFrame();
+		}, this._element);
+		this._requested = true;
+	},
+
+	_handleFrame: function() {
+		paper = this._scope;
+		var now = Date.now() / 1000,
+			delta = this._before ? now - this._before : 0;
+		this._before = now;
+		this._handlingFrame = true;
+		this.emit('frame', new Base({
+			delta: delta,
+			time: this._time += delta,
+			count: this._count++
+		}));
+		if (this._stats)
+			this._stats.update();
+		this._handlingFrame = false;
+		this.update();
+	},
+
+	_animateItem: function(item, animate) {
+		var items = this._frameItems;
+		if (animate) {
+			items[item._id] = {
+				item: item,
+				time: 0,
+				count: 0
+			};
+			if (++this._frameItemCount === 1)
+				this.on('frame', this._handleFrameItems);
+		} else {
+			delete items[item._id];
+			if (--this._frameItemCount === 0) {
+				this.off('frame', this._handleFrameItems);
+			}
+		}
+	},
+
+	_handleFrameItems: function(event) {
+		for (var i in this._frameItems) {
+			var entry = this._frameItems[i];
+			entry.item.emit('frame', new Base(event, {
+				time: entry.time += event.delta,
+				count: entry.count++
+			}));
+		}
+	},
+
+	_update: function() {
+		this._project._needsUpdate = true;
+		if (this._handlingFrame)
+			return;
+		if (this._animate) {
+			this._handleFrame();
+		} else {
+			this.update();
+		}
+	},
+
+	_changed: function() {
+		this._project._changed(2049);
+		this._bounds = null;
+	},
+
+	getElement: function() {
+		return this._element;
+	},
+
+	getPixelRatio: function() {
+		return this._pixelRatio;
+	},
+
+	getResolution: function() {
+		return this._pixelRatio * 72;
+	},
+
+	getViewSize: function() {
+		var size = this._viewSize;
+		return new LinkedSize(size.width, size.height, this, 'setViewSize');
+	},
+
+	setViewSize: function() {
+		var size = Size.read(arguments),
+			delta = size.subtract(this._viewSize);
+		if (delta.isZero())
+			return;
+		this._viewSize.set(size.width, size.height);
+		this._setViewSize(size);
+		this.emit('resize', {
+			size: size,
+			delta: delta
+		});
+		this._changed();
+		this.update();
+	},
+
+	_setViewSize: function(size) {
+		var element = this._element;
+		element.width = size.width;
+		element.height = size.height;
+	},
+
+	getBounds: function() {
+		if (!this._bounds)
+			this._bounds = this._matrix.inverted()._transformBounds(
+					new Rectangle(new Point(), this._viewSize));
+		return this._bounds;
+	},
+
+	getSize: function() {
+		return this.getBounds().getSize();
+	},
+
+	getCenter: function() {
+		return this.getBounds().getCenter();
+	},
+
+	setCenter: function() {
+		var center = Point.read(arguments);
+		this.translate(this.getCenter().subtract(center));
+	},
+
+	getZoom: function() {
+		return this._zoom;
+	},
+
+	setZoom: function(zoom) {
+		this.transform(new Matrix().scale(zoom / this._zoom,
+			this.getCenter()));
+		this._zoom = zoom;
+	},
+
+	getMatrix: function() {
+		return this._matrix;
+	},
+
+	setMatrix: function() {
+		var matrix = this._matrix;
+		matrix.initialize.apply(matrix, arguments);
+	},
+
+	isVisible: function() {
+		return DomElement.isInView(this._element);
+	},
+
+	isInserted: function() {
+		return DomElement.isInserted(this._element);
+	}
+}, Base.each(['rotate', 'scale', 'shear', 'skew'], function(key) {
+	var rotate = key === 'rotate';
+	this[key] = function() {
+		var value = (rotate ? Base : Point).read(arguments),
+			center = Point.read(arguments, 0, { readNull: true });
+		return this.transform(new Matrix()[key](value,
+				center || this.getCenter(true)));
+	};
+}, {
+	translate: function() {
+		var mx = new Matrix();
+		return this.transform(mx.translate.apply(mx, arguments));
+	},
+
+	transform: function(matrix) {
+		this._matrix.concatenate(matrix);
+	},
+
+	scrollBy: function() {
+		this.translate(Point.read(arguments).negate());
+	}
+}), {
+	play: function() {
+		this._animate = true;
+		if (!this._requested)
+			this._requestFrame();
+	},
+
+	pause: function() {
+		this._animate = false;
+	},
+
+	draw: function() {
+		this.update();
+	},
+
+	projectToView: function() {
+		return this._matrix._transformPoint(Point.read(arguments));
+	},
+
+	viewToProject: function() {
+		return this._matrix._inverseTransform(Point.read(arguments));
+	},
+
+	getEventPoint: function(event) {
+		return this.viewToProject(DomEvent.getOffset(event, this._element));
+	},
+
+}, {
+	statics: {
+		_views: [],
+		_viewsById: {},
+		_id: 0,
+
+		create: function(project, element) {
+			if (typeof element === 'string')
+				element = document.getElementById(element);
+			return new CanvasView(project, element);
+		}
+	}
+},
+new function() {
+
+	var prevFocus,
+		tempFocus,
+		dragging = false,
+		mouseDown = false;
+
+	function getView(event) {
+		var target = DomEvent.getTarget(event);
+		return target.getAttribute && View._viewsById[
+				target.getAttribute('id')];
+	}
+
+	function updateFocus() {
+		var view = View._focused;
+		if (!view || !view.isVisible()) {
+			for (var i = 0, l = View._views.length; i < l; i++) {
+				if ((view = View._views[i]).isVisible()) {
+					View._focused = tempFocus = view;
+					break;
+				}
+			}
+		}
+	}
+
+	function handleMouseMove(view, event, point) {
+		view._handleEvent('mousemove', event, point);
+	}
+
+	var navigator = window.navigator,
+		mousedown, mousemove, mouseup;
+	if (navigator.pointerEnabled || navigator.msPointerEnabled) {
+		mousedown = 'pointerdown MSPointerDown';
+		mousemove = 'pointermove MSPointerMove';
+		mouseup = 'pointerup pointercancel MSPointerUp MSPointerCancel';
+	} else {
+		mousedown = 'touchstart';
+		mousemove = 'touchmove';
+		mouseup = 'touchend touchcancel';
+		if (!('ontouchstart' in window && navigator.userAgent.match(
+				/mobile|tablet|ip(ad|hone|od)|android|silk/i))) {
+			mousedown += ' mousedown';
+			mousemove += ' mousemove';
+			mouseup += ' mouseup';
+		}
+	}
+
+	var viewEvents = {},
+		docEvents = {
+			mouseout: function(event) {
+				var view = View._focused,
+					target = DomEvent.getRelatedTarget(event);
+				if (view && (!target || target.nodeName === 'HTML')) {
+					var offset = DomEvent.getOffset(event, view._element),
+						x = offset.x,
+						abs = Math.abs,
+						ax = abs(x),
+						max = 1 << 25,
+						diff = ax - max;
+					offset.x = abs(diff) < ax ? diff * (x < 0 ? -1 : 1) : x;
+					handleMouseMove(view, event, view.viewToProject(offset));
+				}
+			},
+
+			scroll: updateFocus
+		};
+
+	viewEvents[mousedown] = function(event) {
+		var view = View._focused = getView(event);
+		dragging = true;
+		view._handleEvent('mousedown', event);
+	};
+
+	docEvents[mousemove] = function(event) {
+		var view = View._focused;
+		if (!mouseDown) {
+			var target = getView(event);
+			if (target) {
+				if (view !== target) {
+					if (view)
+						handleMouseMove(view, event);
+					if (!prevFocus)
+						prevFocus = view;
+					view = View._focused = tempFocus = target;
+				}
+			} else if (tempFocus && tempFocus === view) {
+				if (prevFocus && !prevFocus.isInserted())
+					prevFocus = null;
+				view = View._focused = prevFocus;
+				prevFocus = null;
+				updateFocus();
+			}
+		}
+		if (view)
+			handleMouseMove(view, event);
+	};
+
+	docEvents[mousedown] = function() {
+		mouseDown = true;
+	};
+
+	docEvents[mouseup] = function(event) {
+		var view = View._focused;
+		if (view && dragging)
+			view._handleEvent('mouseup', event);
+		mouseDown = dragging = false;
+	};
+
+	DomEvent.add(document, docEvents);
+
+	DomEvent.add(window, {
+		load: updateFocus
+	});
+
+	var called = false,
+		fallbacks = {
+			doubleclick: 'click',
+			mousedrag: 'mousemove'
+		};
+
+	function emitEvent(obj, type, event, point, prevPoint, stopItem) {
+		var target = obj,
+			mouseEvent;
+
+		function emit(obj, type) {
+			if (obj.responds(type)) {
+				if (!mouseEvent) {
+					mouseEvent = new MouseEvent(
+							type, event, point, target,
+							prevPoint ? point.subtract(prevPoint) : null);
+				}
+				if (obj.emit(type, mouseEvent)) {
+					called = true;
+					if (mouseEvent.stopped)
+						return true;
+				}
+			} else {
+				var fallback = fallbacks[type];
+				if (fallback)
+					return emit(obj, fallback);
+			}
+		}
+
+		while (obj && obj !== stopItem) {
+			if (emit(obj, type))
+				return true;
+			obj = obj._parent;
+		}
+		return false;
+	}
+
+	function emitEvents(view, item, type, event, point, prevPoint) {
+		called = false;
+		return (dragItem && emitEvent(dragItem, type, event, point,
+					prevPoint)
+			|| item && item !== dragItem && !item.isDescendant(dragItem)
+				&& emitEvent(item, fallbacks[type] || type, event, point,
+					prevPoint, dragItem)
+			|| emitEvent(view, type, event, point, prevPoint));
+	}
+
+	var itemEvents = {
+		mousedown: {
+			mousedown: 1,
+			mousedrag: 1,
+			click: 1,
+			doubleclick: 1
+		},
+		mouseup: {
+			mouseup: 1,
+			mousedrag: 1,
+			click: 1,
+			doubleclick: 1
+		},
+		mousemove: {
+			mousedrag: 1,
+			mousemove: 1,
+			mouseenter: 1,
+			mouseleave: 1
+		}
+	};
+
+	var downPoint,
+		lastPoint,
+		downItem,
+		overItem,
+		dragItem,
+		clickItem,
+		clickTime,
+		dblClick,
+		overView,
+		wasInView = false;
+
+	return {
+		_viewEvents: viewEvents,
+
+		_handleEvent: function(type, event, point) {
+			var handleItems = this._itemEvents[type],
+				project = paper.project,
+				tool = this._scope.tool,
+				view = this;
+			if (type === 'mousemove' && dragging)
+				type = 'mousedrag';
+			if (project)
+				project.removeOn(type);
+			if (!point)
+				point = this.getEventPoint(event);
+			var inView = this.getBounds().contains(point),
+				hit = inView && handleItems && this._project.hitTest(point, {
+					tolerance: 0,
+					fill: true,
+					stroke: true
+				}),
+				item = hit && hit.item || undefined,
+				handle = false,
+				stopped = false,
+				mouse = {};
+			mouse[type.substr(5)] = true;
+			var nativeMove = mouse.move || mouse.drag,
+				moveType = nativeMove && type || 'mousemove';
+			if (moveType) {
+				if (item !== overItem) {
+					if (overItem)
+						emitEvent(overItem, 'mouseleave', event, point);
+					if (item)
+						emitEvent(item, 'mouseenter', event, point);
+				}
+				overItem = item;
+				if (nativeMove && (wasInView ^ inView)) {
+					emitEvent(this, inView ? 'mouseenter' : 'mouseleave', event,
+							point);
+					overView = inView ? this : null;
+					handle = true;
+				}
+				if (inView || mouse.drag && !lastPoint.equals(point)) {
+					stopped = emitEvents(this, item, moveType, event, point,
+							lastPoint);
+					handle = true;
+				}
+				wasInView = inView;
+			}
+			if (!nativeMove &&
+					(handle = mouse.down && inView || mouse.up && downPoint)) {
+				stopped = emitEvents(this, item, type, event, point, downPoint);
+				if (mouse.down) {
+					if (item) {
+						dblClick = item === clickItem
+							&& (Date.now() - clickTime < 300);
+						downItem = clickItem = item;
+						dragItem = !stopped && item;
+					}
+					downPoint = lastPoint = point;
+				} else if (mouse.up) {
+					if (!stopped && item && item === downItem) {
+						clickTime = Date.now();
+						emitEvent(item, dblClick ? 'doubleclick' : 'click',
+								event, point, downPoint);
+						dblClick = false;
+					}
+					downItem = dragItem = null;
+				}
+				wasInView = false;
+			}
+			lastPoint = point;
+			if (handle && tool)
+				called = tool._handleEvent(type, event, point, mouse) || called;
+
+			function responds(type) {
+				return view._itemEvents[type] || view.responds(type)
+						|| tool && tool.responds(type);
+			}
+
+			if (called && (!nativeMove || responds('mousedrag'))
+					|| mouse.down && responds('mouseup'))
+				event.preventDefault();
+
+			this.update();
+		},
+
+		_countItemEvent: function(type, sign) {
+			var events = this._itemEvents;
+			for (var key in itemEvents) {
+				events[key] = (events[key] || 0)
+						+ (itemEvents[key][type] || 0) * sign;
+			}
+		},
+
+		statics: {
+			updateFocus: updateFocus
+		}
+	};
+});
+
+var CanvasView = View.extend({
+	_class: 'CanvasView',
+
+	initialize: function CanvasView(project, canvas) {
+		if (!(canvas instanceof HTMLCanvasElement)) {
+			var size = Size.read(arguments, 1);
+			if (size.isZero())
+				throw new Error(
+						'Cannot create CanvasView with the provided argument: '
+						+ [].slice.call(arguments, 1));
+			canvas = CanvasProvider.getCanvas(size);
+		}
+		this._context = canvas.getContext('2d');
+		this._pixelRatio = 1;
+		if (!/^off|false$/.test(PaperScope.getAttribute(canvas, 'hidpi'))) {
+			var deviceRatio = window.devicePixelRatio || 1,
+				backingStoreRatio = DomElement.getPrefixed(this._context,
+						'backingStorePixelRatio') || 1;
+			this._pixelRatio = deviceRatio / backingStoreRatio;
+		}
+		View.call(this, project, canvas);
+	},
+
+	_setViewSize: function(size) {
+		var element = this._element,
+			pixelRatio = this._pixelRatio,
+			width = size.width,
+			height = size.height;
+		element.width = width * pixelRatio;
+		element.height = height * pixelRatio;
+		if (pixelRatio !== 1) {
+			if (!PaperScope.hasAttribute(element, 'resize')) {
+				var style = element.style;
+				style.width = width + 'px';
+				style.height = height + 'px';
+			}
+			this._context.scale(pixelRatio, pixelRatio);
+		}
+	},
+
+	getPixelSize: function(size) {
+		var browser = paper.browser,
+			pixels;
+		if (browser && browser.firefox) {
+			var parent = this._element.parentNode,
+				temp = document.createElement('div');
+			temp.style.fontSize = size;
+			parent.appendChild(temp);
+			pixels = parseFloat(DomElement.getStyles(temp).fontSize);
+			parent.removeChild(temp);
+		} else {
+			var ctx = this._context,
+				prevFont = ctx.font;
+			ctx.font = size + ' serif';
+			pixels = parseFloat(ctx.font);
+			ctx.font = prevFont;
+		}
+		return pixels;
+	},
+
+	getTextWidth: function(font, lines) {
+		var ctx = this._context,
+			prevFont = ctx.font,
+			width = 0;
+		ctx.font = font;
+		for (var i = 0, l = lines.length; i < l; i++)
+			width = Math.max(width, ctx.measureText(lines[i]).width);
+		ctx.font = prevFont;
+		return width;
+	},
+
+	update: function(force) {
+		var project = this._project;
+		if (!project || !force && !project._needsUpdate)
+			return false;
+		var ctx = this._context,
+			size = this._viewSize;
+		ctx.clearRect(0, 0, size.width + 1, size.height + 1);
+		project.draw(ctx, this._matrix, this._pixelRatio);
+		project._needsUpdate = false;
+		return true;
+	}
+});
+
+var Event = Base.extend({
+	_class: 'Event',
+
+	initialize: function Event(event) {
+		this.event = event;
+	},
+
+	prevented: false,
+	stopped: false,
+
+	preventDefault: function() {
+		this.prevented = true;
+		this.event.preventDefault();
+	},
+
+	stopPropagation: function() {
+		this.stopped = true;
+		this.event.stopPropagation();
+	},
+
+	stop: function() {
+		this.stopPropagation();
+		this.preventDefault();
+	},
+
+	getTimeStamp: function() {
+		return this.event.timeStamp;
+	},
+
+	getModifiers: function() {
+		return Key.modifiers;
+	}
+});
+
+var KeyEvent = Event.extend({
+	_class: 'KeyEvent',
+
+	initialize: function KeyEvent(down, key, character, event) {
+		Event.call(this, event);
+		this.type = down ? 'keydown' : 'keyup';
+		this.key = key;
+		this.character = character;
+	},
+
+	toString: function() {
+		return "{ type: '" + this.type
+				+ "', key: '" + this.key
+				+ "', character: '" + this.character
+				+ "', modifiers: " + this.getModifiers()
+				+ " }";
+	}
+});
+
+var Key = new function() {
+	var keyLookup = {
+			'\t': 'tab',
+			' ': 'space',
+			'\b': 'backspace',
+			'\x7f': 'delete',
+			'Spacebar': 'space',
+			'Del': 'delete',
+			'Win': 'meta',
+			'Esc': 'escape'
+		},
+
+		charLookup = {
+			'tab': '\t',
+			'space': ' ',
+			'enter': '\r'
+		},
+
+		keyMap = {},
+		charMap = {},
+		metaFixMap,
+		downKey;
+
+		modifiers = new Base({
+			shift: false,
+			control: false,
+			alt: false,
+			meta: false,
+			capsLock: false,
+			space: false
+		}).inject({
+			option: {
+				get: function() {
+					return this.alt;
+				}
+			},
+
+			command: {
+				get: function() {
+				var browser = paper.browser;
+					return browser && browser.mac ? this.meta : this.control;
+				}
+			}
+		});
+
+	function getKey(event) {
+		var key = event.key || event.keyIdentifier;
+		key = /^U\+/.test(key)
+				? String.fromCharCode(parseInt(key.substr(2), 16))
+				: /^Arrow[A-Z]/.test(key) ? key.substr(5)
+				: key === 'Unidentified' ? String.fromCharCode(event.keyCode)
+				: key;
+		return keyLookup[key] ||
+				(key.length > 1 ? Base.hyphenate(key) : key.toLowerCase());
+	}
+
+	function handleKey(down, key, character, event) {
+		var type = down ? 'keydown' : 'keyup',
+			view = View._focused,
+			scope = view && view.isVisible() && view._scope,
+			tool = scope && scope.tool,
+			name;
+		keyMap[key] = down;
+		if (down) {
+			charMap[key] = character;
+		} else {
+			delete charMap[key];
+		}
+		if (key.length > 1 && (name = Base.camelize(key)) in modifiers) {
+			modifiers[name] = down;
+			var browser = paper.browser;
+			if (name === 'meta' && browser && browser.mac) {
+				if (down) {
+					metaFixMap = {};
+				} else {
+					for (var k in metaFixMap) {
+						if (k in charMap)
+							handleKey(false, k, metaFixMap[k], event);
+					}
+					metaFixMap = null;
+				}
+			}
+		} else if (down && metaFixMap) {
+			metaFixMap[key] = character;
+		}
+		if (tool && tool.responds(type)) {
+			paper = scope;
+			tool.emit(type, new KeyEvent(down, key, character, event));
+			if (view)
+				view.update();
+		}
+	}
+
+	DomEvent.add(document, {
+		keydown: function(event) {
+			var key = getKey(event),
+				browser = paper.browser;
+			if (key.length > 1 || browser && (browser.chrome && (event.altKey
+						|| browser.mac && event.metaKey
+						|| !browser.mac && event.ctrlKey))) {
+				handleKey(true, key,
+						charLookup[key] || (key.length > 1 ? '' : key), event);
+			} else {
+				downKey = key;
+			}
+		},
+
+		keypress: function(event) {
+			if (downKey) {
+				var key = getKey(event),
+					code = event.charCode,
+					character = code >= 32 ? String.fromCharCode(code)
+						: key.length > 1 ? '' : key;
+				if (key !== downKey) {
+					key = character.toLowerCase();
+				}
+				handleKey(true, key, character, event);
+				downKey = null;
+			}
+		},
+
+		keyup: function(event) {
+			var key = getKey(event);
+			if (key in charMap)
+				handleKey(false, key, charMap[key], event);
+		}
+	});
+
+	DomEvent.add(window, {
+		blur: function(event) {
+			for (var key in charMap)
+				handleKey(false, key, charMap[key], event);
+		}
+	});
+
+	return {
+		modifiers: modifiers,
+
+		isDown: function(key) {
+			return !!keyMap[key];
+		}
+	};
+};
+
+var MouseEvent = Event.extend({
+	_class: 'MouseEvent',
+
+	initialize: function MouseEvent(type, event, point, target, delta) {
+		Event.call(this, event);
+		this.type = type;
+		this.point = point;
+		this.target = target;
+		this.delta = delta;
+	},
+
+	toString: function() {
+		return "{ type: '" + this.type
+				+ "', point: " + this.point
+				+ ', target: ' + this.target
+				+ (this.delta ? ', delta: ' + this.delta : '')
+				+ ', modifiers: ' + this.getModifiers()
+				+ ' }';
+	}
+});
+
+var ToolEvent = Event.extend({
+	_class: 'ToolEvent',
+	_item: null,
+
+	initialize: function ToolEvent(tool, type, event) {
+		this.tool = tool;
+		this.type = type;
+		this.event = event;
+	},
+
+	_choosePoint: function(point, toolPoint) {
+		return point ? point : toolPoint ? toolPoint.clone() : null;
+	},
+
+	getPoint: function() {
+		return this._choosePoint(this._point, this.tool._point);
+	},
+
+	setPoint: function(point) {
+		this._point = point;
+	},
+
+	getLastPoint: function() {
+		return this._choosePoint(this._lastPoint, this.tool._lastPoint);
+	},
+
+	setLastPoint: function(lastPoint) {
+		this._lastPoint = lastPoint;
+	},
+
+	getDownPoint: function() {
+		return this._choosePoint(this._downPoint, this.tool._downPoint);
+	},
+
+	setDownPoint: function(downPoint) {
+		this._downPoint = downPoint;
+	},
+
+	getMiddlePoint: function() {
+		if (!this._middlePoint && this.tool._lastPoint) {
+			return this.tool._point.add(this.tool._lastPoint).divide(2);
+		}
+		return this._middlePoint;
+	},
+
+	setMiddlePoint: function(middlePoint) {
+		this._middlePoint = middlePoint;
+	},
+
+	getDelta: function() {
+		return !this._delta && this.tool._lastPoint
+				? this.tool._point.subtract(this.tool._lastPoint)
+				: this._delta;
+	},
+
+	setDelta: function(delta) {
+		this._delta = delta;
+	},
+
+	getCount: function() {
+		return /^mouse(down|up)$/.test(this.type)
+				? this.tool._downCount
+				: this.tool._count;
+	},
+
+	setCount: function(count) {
+		this.tool[/^mouse(down|up)$/.test(this.type) ? 'downCount' : 'count']
+			= count;
+	},
+
+	getItem: function() {
+		if (!this._item) {
+			var result = this.tool._scope.project.hitTest(this.getPoint());
+			if (result) {
+				var item = result.item,
+					parent = item._parent;
+				while (/^(Group|CompoundPath)$/.test(parent._class)) {
+					item = parent;
+					parent = parent._parent;
+				}
+				this._item = item;
+			}
+		}
+		return this._item;
+	},
+
+	setItem: function(item) {
+		this._item = item;
+	},
+
+	toString: function() {
+		return '{ type: ' + this.type
+				+ ', point: ' + this.getPoint()
+				+ ', count: ' + this.getCount()
+				+ ', modifiers: ' + this.getModifiers()
+				+ ' }';
+	}
+});
+
+var Tool = PaperScopeItem.extend({
+	_class: 'Tool',
+	_list: 'tools',
+	_reference: 'tool',
+	_events: ['onMouseDown', 'onMouseUp', 'onMouseDrag', 'onMouseMove',
+			'onActivate', 'onDeactivate', 'onEditOptions', 'onKeyDown',
+			'onKeyUp'],
+
+	initialize: function Tool(props) {
+		PaperScopeItem.call(this);
+		this._firstMove = true;
+		this._count = 0;
+		this._downCount = -1;
+		this._set(props);
+	},
+
+	getMinDistance: function() {
+		return this._minDistance;
+	},
+
+	setMinDistance: function(minDistance) {
+		this._minDistance = minDistance;
+		if (minDistance != null && this._maxDistance != null
+				&& minDistance > this._maxDistance) {
+			this._maxDistance = minDistance;
+		}
+	},
+
+	getMaxDistance: function() {
+		return this._maxDistance;
+	},
+
+	setMaxDistance: function(maxDistance) {
+		this._maxDistance = maxDistance;
+		if (this._minDistance != null && maxDistance != null
+				&& maxDistance < this._minDistance) {
+			this._minDistance = maxDistance;
+		}
+	},
+
+	getFixedDistance: function() {
+		return this._minDistance == this._maxDistance
+			? this._minDistance : null;
+	},
+
+	setFixedDistance: function(distance) {
+		this._minDistance = this._maxDistance = distance;
+	},
+
+	_handleEvent: function(type, event, point, mouse) {
+		paper = this._scope;
+		var move = mouse.move || mouse.drag && !this.responds(type);
+		if (move)
+			type = 'mousemove';
+		var responds = this.responds(type),
+			minDistance = this.minDistance,
+			maxDistance = this.maxDistance,
+			called = false,
+			tool = this;
+		function update(start, minDistance, maxDistance) {
+			var toolPoint = tool._point,
+				pt = point;
+			if (start) {
+				tool._count = 0;
+			} else {
+				if (pt.equals(toolPoint))
+					return false;
+				if (minDistance != null || maxDistance != null) {
+					var vector = pt.subtract(toolPoint),
+						distance = vector.getLength();
+					if (distance < (minDistance || 0))
+						return false;
+					if (maxDistance) {
+						pt = toolPoint.add(vector.normalize(
+								Math.min(distance, maxDistance)));
+					}
+				}
+				tool._count++;
+			}
+			if (responds) {
+				tool._point = pt;
+				tool._lastPoint = move || mouse.drag
+					? start && move ? pt : toolPoint
+					: tool._downPoint || pt;
+			}
+			if (mouse.down) {
+				tool._downPoint = pt;
+				tool._downCount++;
+			}
+			return true;
+		}
+
+		function emit(firstMove) {
+			if (responds) {
+				called = tool.emit(type, new ToolEvent(tool, type, event))
+						|| called;
+				tool._firstMove = firstMove;
+			}
+		}
+
+		if (mouse.down) {
+			update(responds);
+			emit(false);
+		} else if (mouse.up) {
+			update(false, null, maxDistance);
+			emit(true);
+		} else if (responds) {
+			while (update(this._firstMove, minDistance, maxDistance))
+				emit(false);
+		}
+		return called;
+	}
+
+});
+
+var Http = {
+	request: function(method, url, callback, async) {
+		async = (async === undefined) ? true : async;
+		var ctor = window.ActiveXObject || XMLHttpRequest,
+			xhr = new ctor('Microsoft.XMLHTTP');
+		xhr.open(method.toUpperCase(), url, async);
+		if ('overrideMimeType' in xhr)
+			xhr.overrideMimeType('text/plain');
+		xhr.onreadystatechange = function() {
+			if (xhr.readyState === 4) {
+				var status = xhr.status;
+				if (status === 0 || status === 200) {
+					callback.call(xhr, xhr.responseText);
+				} else {
+					throw new Error('Could not load ' + url + ' (Error '
+							+ status + ')');
+				}
+			}
+		};
+		return xhr.send(null);
+	}
+};
+
+var CanvasProvider = {
+	canvases: [],
+
+	getCanvas: function(width, height) {
+		var canvas,
+			clear = true;
+		if (typeof width === 'object') {
+			height = width.height;
+			width = width.width;
+		}
+		if (this.canvases.length) {
+			canvas = this.canvases.pop();
+		} else {
+			canvas = document.createElement('canvas');
+		}
+		var ctx = canvas.getContext('2d');
+		if (canvas.width === width && canvas.height === height) {
+			if (clear)
+				ctx.clearRect(0, 0, width + 1, height + 1);
+		} else {
+			canvas.width = width;
+			canvas.height = height;
+		}
+		ctx.save();
+		return canvas;
+	},
+
+	getContext: function(width, height) {
+		return this.getCanvas(width, height).getContext('2d');
+	},
+
+	release: function(obj) {
+		var canvas = obj.canvas ? obj.canvas : obj;
+		canvas.getContext('2d').restore();
+		this.canvases.push(canvas);
+	}
+};
+
+var BlendMode = new function() {
+	var min = Math.min,
+		max = Math.max,
+		abs = Math.abs,
+		sr, sg, sb, sa,
+		br, bg, bb, ba,
+		dr, dg, db;
+
+	function getLum(r, g, b) {
+		return 0.2989 * r + 0.587 * g + 0.114 * b;
+	}
+
+	function setLum(r, g, b, l) {
+		var d = l - getLum(r, g, b);
+		dr = r + d;
+		dg = g + d;
+		db = b + d;
+		var l = getLum(dr, dg, db),
+			mn = min(dr, dg, db),
+			mx = max(dr, dg, db);
+		if (mn < 0) {
+			var lmn = l - mn;
+			dr = l + (dr - l) * l / lmn;
+			dg = l + (dg - l) * l / lmn;
+			db = l + (db - l) * l / lmn;
+		}
+		if (mx > 255) {
+			var ln = 255 - l,
+				mxl = mx - l;
+			dr = l + (dr - l) * ln / mxl;
+			dg = l + (dg - l) * ln / mxl;
+			db = l + (db - l) * ln / mxl;
+		}
+	}
+
+	function getSat(r, g, b) {
+		return max(r, g, b) - min(r, g, b);
+	}
+
+	function setSat(r, g, b, s) {
+		var col = [r, g, b],
+			mx = max(r, g, b),
+			mn = min(r, g, b),
+			md;
+		mn = mn === r ? 0 : mn === g ? 1 : 2;
+		mx = mx === r ? 0 : mx === g ? 1 : 2;
+		md = min(mn, mx) === 0 ? max(mn, mx) === 1 ? 2 : 1 : 0;
+		if (col[mx] > col[mn]) {
+			col[md] = (col[md] - col[mn]) * s / (col[mx] - col[mn]);
+			col[mx] = s;
+		} else {
+			col[md] = col[mx] = 0;
+		}
+		col[mn] = 0;
+		dr = col[0];
+		dg = col[1];
+		db = col[2];
+	}
+
+	var modes = {
+		multiply: function() {
+			dr = br * sr / 255;
+			dg = bg * sg / 255;
+			db = bb * sb / 255;
+		},
+
+		screen: function() {
+			dr = br + sr - (br * sr / 255);
+			dg = bg + sg - (bg * sg / 255);
+			db = bb + sb - (bb * sb / 255);
+		},
+
+		overlay: function() {
+			dr = br < 128 ? 2 * br * sr / 255 : 255 - 2 * (255 - br) * (255 - sr) / 255;
+			dg = bg < 128 ? 2 * bg * sg / 255 : 255 - 2 * (255 - bg) * (255 - sg) / 255;
+			db = bb < 128 ? 2 * bb * sb / 255 : 255 - 2 * (255 - bb) * (255 - sb) / 255;
+		},
+
+		'soft-light': function() {
+			var t = sr * br / 255;
+			dr = t + br * (255 - (255 - br) * (255 - sr) / 255 - t) / 255;
+			t = sg * bg / 255;
+			dg = t + bg * (255 - (255 - bg) * (255 - sg) / 255 - t) / 255;
+			t = sb * bb / 255;
+			db = t + bb * (255 - (255 - bb) * (255 - sb) / 255 - t) / 255;
+		},
+
+		'hard-light': function() {
+			dr = sr < 128 ? 2 * sr * br / 255 : 255 - 2 * (255 - sr) * (255 - br) / 255;
+			dg = sg < 128 ? 2 * sg * bg / 255 : 255 - 2 * (255 - sg) * (255 - bg) / 255;
+			db = sb < 128 ? 2 * sb * bb / 255 : 255 - 2 * (255 - sb) * (255 - bb) / 255;
+		},
+
+		'color-dodge': function() {
+			dr = br === 0 ? 0 : sr === 255 ? 255 : min(255, 255 * br / (255 - sr));
+			dg = bg === 0 ? 0 : sg === 255 ? 255 : min(255, 255 * bg / (255 - sg));
+			db = bb === 0 ? 0 : sb === 255 ? 255 : min(255, 255 * bb / (255 - sb));
+		},
+
+		'color-burn': function() {
+			dr = br === 255 ? 255 : sr === 0 ? 0 : max(0, 255 - (255 - br) * 255 / sr);
+			dg = bg === 255 ? 255 : sg === 0 ? 0 : max(0, 255 - (255 - bg) * 255 / sg);
+			db = bb === 255 ? 255 : sb === 0 ? 0 : max(0, 255 - (255 - bb) * 255 / sb);
+		},
+
+		darken: function() {
+			dr = br < sr ? br : sr;
+			dg = bg < sg ? bg : sg;
+			db = bb < sb ? bb : sb;
+		},
+
+		lighten: function() {
+			dr = br > sr ? br : sr;
+			dg = bg > sg ? bg : sg;
+			db = bb > sb ? bb : sb;
+		},
+
+		difference: function() {
+			dr = br - sr;
+			if (dr < 0)
+				dr = -dr;
+			dg = bg - sg;
+			if (dg < 0)
+				dg = -dg;
+			db = bb - sb;
+			if (db < 0)
+				db = -db;
+		},
+
+		exclusion: function() {
+			dr = br + sr * (255 - br - br) / 255;
+			dg = bg + sg * (255 - bg - bg) / 255;
+			db = bb + sb * (255 - bb - bb) / 255;
+		},
+
+		hue: function() {
+			setSat(sr, sg, sb, getSat(br, bg, bb));
+			setLum(dr, dg, db, getLum(br, bg, bb));
+		},
+
+		saturation: function() {
+			setSat(br, bg, bb, getSat(sr, sg, sb));
+			setLum(dr, dg, db, getLum(br, bg, bb));
+		},
+
+		luminosity: function() {
+			setLum(br, bg, bb, getLum(sr, sg, sb));
+		},
+
+		color: function() {
+			setLum(sr, sg, sb, getLum(br, bg, bb));
+		},
+
+		add: function() {
+			dr = min(br + sr, 255);
+			dg = min(bg + sg, 255);
+			db = min(bb + sb, 255);
+		},
+
+		subtract: function() {
+			dr = max(br - sr, 0);
+			dg = max(bg - sg, 0);
+			db = max(bb - sb, 0);
+		},
+
+		average: function() {
+			dr = (br + sr) / 2;
+			dg = (bg + sg) / 2;
+			db = (bb + sb) / 2;
+		},
+
+		negation: function() {
+			dr = 255 - abs(255 - sr - br);
+			dg = 255 - abs(255 - sg - bg);
+			db = 255 - abs(255 - sb - bb);
+		}
+	};
+
+	var nativeModes = this.nativeModes = Base.each([
+		'source-over', 'source-in', 'source-out', 'source-atop',
+		'destination-over', 'destination-in', 'destination-out',
+		'destination-atop', 'lighter', 'darker', 'copy', 'xor'
+	], function(mode) {
+		this[mode] = true;
+	}, {});
+
+	var ctx = CanvasProvider.getContext(1, 1);
+	Base.each(modes, function(func, mode) {
+		var darken = mode === 'darken',
+			ok = false;
+		ctx.save();
+		try {
+			ctx.fillStyle = darken ? '#300' : '#a00';
+			ctx.fillRect(0, 0, 1, 1);
+			ctx.globalCompositeOperation = mode;
+			if (ctx.globalCompositeOperation === mode) {
+				ctx.fillStyle = darken ? '#a00' : '#300';
+				ctx.fillRect(0, 0, 1, 1);
+				ok = ctx.getImageData(0, 0, 1, 1).data[0] !== darken ? 170 : 51;
+			}
+		} catch (e) {}
+		ctx.restore();
+		nativeModes[mode] = ok;
+	});
+	CanvasProvider.release(ctx);
+
+	this.process = function(mode, srcContext, dstContext, alpha, offset) {
+		var srcCanvas = srcContext.canvas,
+			normal = mode === 'normal';
+		if (normal || nativeModes[mode]) {
+			dstContext.save();
+			dstContext.setTransform(1, 0, 0, 1, 0, 0);
+			dstContext.globalAlpha = alpha;
+			if (!normal)
+				dstContext.globalCompositeOperation = mode;
+			dstContext.drawImage(srcCanvas, offset.x, offset.y);
+			dstContext.restore();
+		} else {
+			var process = modes[mode];
+			if (!process)
+				return;
+			var dstData = dstContext.getImageData(offset.x, offset.y,
+					srcCanvas.width, srcCanvas.height),
+				dst = dstData.data,
+				src = srcContext.getImageData(0, 0,
+					srcCanvas.width, srcCanvas.height).data;
+			for (var i = 0, l = dst.length; i < l; i += 4) {
+				sr = src[i];
+				br = dst[i];
+				sg = src[i + 1];
+				bg = dst[i + 1];
+				sb = src[i + 2];
+				bb = dst[i + 2];
+				sa = src[i + 3];
+				ba = dst[i + 3];
+				process();
+				var a1 = sa * alpha / 255,
+					a2 = 1 - a1;
+				dst[i] = a1 * dr + a2 * br;
+				dst[i + 1] = a1 * dg + a2 * bg;
+				dst[i + 2] = a1 * db + a2 * bb;
+				dst[i + 3] = sa * alpha + a2 * ba;
+			}
+			dstContext.putImageData(dstData, offset.x, offset.y);
+		}
+	};
+};
+
+var SVGStyles = Base.each({
+	fillColor: ['fill', 'color'],
+	fillRule: ['fill-rule', 'string'],
+	strokeColor: ['stroke', 'color'],
+	strokeWidth: ['stroke-width', 'number'],
+	strokeCap: ['stroke-linecap', 'string'],
+	strokeJoin: ['stroke-linejoin', 'string'],
+	strokeScaling: ['vector-effect', 'lookup', {
+		true: 'none',
+		false: 'non-scaling-stroke'
+	}, function(item, value) {
+		return !value
+				&& (item instanceof PathItem
+					|| item instanceof Shape
+					|| item instanceof TextItem);
+	}],
+	miterLimit: ['stroke-miterlimit', 'number'],
+	dashArray: ['stroke-dasharray', 'array'],
+	dashOffset: ['stroke-dashoffset', 'number'],
+	fontFamily: ['font-family', 'string'],
+	fontWeight: ['font-weight', 'string'],
+	fontSize: ['font-size', 'number'],
+	justification: ['text-anchor', 'lookup', {
+		left: 'start',
+		center: 'middle',
+		right: 'end'
+	}],
+	opacity: ['opacity', 'number'],
+	blendMode: ['mix-blend-mode', 'style']
+}, function(entry, key) {
+	var part = Base.capitalize(key),
+		lookup = entry[2];
+	this[key] = {
+		type: entry[1],
+		property: key,
+		attribute: entry[0],
+		toSVG: lookup,
+		fromSVG: lookup && Base.each(lookup, function(value, name) {
+			this[value] = name;
+		}, {}),
+		exportFilter: entry[3],
+		get: 'get' + part,
+		set: 'set' + part
+	};
+}, {});
+
+var SVGNamespaces = {
+	href: 'http://www.w3.org/1999/xlink',
+	xlink: 'http://www.w3.org/2000/xmlns'
+};
+
+new function() {
+	var formatter;
+
+	function setAttributes(node, attrs) {
+		for (var key in attrs) {
+			var val = attrs[key],
+				namespace = SVGNamespaces[key];
+			if (typeof val === 'number')
+				val = formatter.number(val);
+			if (namespace) {
+				node.setAttributeNS(namespace, key, val);
+			} else {
+				node.setAttribute(key, val);
+			}
+		}
+		return node;
+	}
+
+	function createElement(tag, attrs) {
+		return setAttributes(
+			document.createElementNS('http://www.w3.org/2000/svg', tag), attrs);
+	}
+
+	function getTransform(matrix, coordinates, center) {
+		var attrs = new Base(),
+			trans = matrix.getTranslation();
+		if (coordinates) {
+			matrix = matrix.shiftless();
+			var point = matrix._inverseTransform(trans);
+			attrs[center ? 'cx' : 'x'] = point.x;
+			attrs[center ? 'cy' : 'y'] = point.y;
+			trans = null;
+		}
+		if (!matrix.isIdentity()) {
+			var decomposed = matrix.decompose();
+			if (decomposed && !decomposed.shearing) {
+				var parts = [],
+					angle = decomposed.rotation,
+					scale = decomposed.scaling;
+				if (trans && !trans.isZero())
+					parts.push('translate(' + formatter.point(trans) + ')');
+				if (!Numerical.isZero(scale.x - 1)
+						|| !Numerical.isZero(scale.y - 1))
+					parts.push('scale(' + formatter.point(scale) +')');
+				if (angle)
+					parts.push('rotate(' + formatter.number(angle) + ')');
+				attrs.transform = parts.join(' ');
+			} else {
+				attrs.transform = 'matrix(' + matrix.getValues().join(',') + ')';
+			}
+		}
+		return attrs;
+	}
+
+	function exportGroup(item, options) {
+		var attrs = getTransform(item._matrix),
+			children = item._children;
+		var node = createElement('g', attrs);
+		for (var i = 0, l = children.length; i < l; i++) {
+			var child = children[i];
+			var childNode = exportSVG(child, options);
+			if (childNode) {
+				if (child.isClipMask()) {
+					var clip = createElement('clipPath');
+					clip.appendChild(childNode);
+					setDefinition(child, clip, 'clip');
+					setAttributes(node, {
+						'clip-path': 'url(#' + clip.id + ')'
+					});
+				} else {
+					node.appendChild(childNode);
+				}
+			}
+		}
+		return node;
+	}
+
+	function exportRaster(item, options) {
+		var attrs = getTransform(item._matrix, true),
+			size = item.getSize(),
+			image = item.getImage();
+		attrs.x -= size.width / 2;
+		attrs.y -= size.height / 2;
+		attrs.width = size.width;
+		attrs.height = size.height;
+		attrs.href = options.embedImages === false && image && image.src
+				|| item.toDataURL();
+		return createElement('image', attrs);
+	}
+
+	function exportPath(item, options) {
+		var matchShapes = options.matchShapes;
+		if (matchShapes) {
+			var shape = item.toShape(false);
+			if (shape)
+				return exportShape(shape, options);
+		}
+		var segments = item._segments,
+			type,
+			attrs = getTransform(item._matrix);
+		if (segments.length === 0)
+			return null;
+		if (matchShapes && !item.hasHandles()) {
+			if (segments.length >= 3) {
+				type = item._closed ? 'polygon' : 'polyline';
+				var parts = [];
+				for(var i = 0, l = segments.length; i < l; i++)
+					parts.push(formatter.point(segments[i]._point));
+				attrs.points = parts.join(' ');
+			} else {
+				type = 'line';
+				var first = segments[0]._point,
+					last = segments[segments.length - 1]._point;
+				attrs.set({
+					x1: first.x,
+					y1: first.y,
+					x2: last.x,
+					y2: last.y
+				});
+			}
+		} else {
+			type = 'path';
+			attrs.d = item.getPathData(null, options.precision);
+		}
+		return createElement(type, attrs);
+	}
+
+	function exportShape(item) {
+		var type = item._type,
+			radius = item._radius,
+			attrs = getTransform(item._matrix, true, type !== 'rectangle');
+		if (type === 'rectangle') {
+			type = 'rect';
+			var size = item._size,
+				width = size.width,
+				height = size.height;
+			attrs.x -= width / 2;
+			attrs.y -= height / 2;
+			attrs.width = width;
+			attrs.height = height;
+			if (radius.isZero())
+				radius = null;
+		}
+		if (radius) {
+			if (type === 'circle') {
+				attrs.r = radius;
+			} else {
+				attrs.rx = radius.width;
+				attrs.ry = radius.height;
+			}
+		}
+		return createElement(type, attrs);
+	}
+
+	function exportCompoundPath(item, options) {
+		var attrs = getTransform(item._matrix);
+		var data = item.getPathData(null, options.precision);
+		if (data)
+			attrs.d = data;
+		return createElement('path', attrs);
+	}
+
+	function exportPlacedSymbol(item, options) {
+		var attrs = getTransform(item._matrix, true),
+			symbol = item.getSymbol(),
+			symbolNode = getDefinition(symbol, 'symbol'),
+			definition = symbol.getDefinition(),
+			bounds = definition.getBounds();
+		if (!symbolNode) {
+			symbolNode = createElement('symbol', {
+				viewBox: formatter.rectangle(bounds)
+			});
+			symbolNode.appendChild(exportSVG(definition, options));
+			setDefinition(symbol, symbolNode, 'symbol');
+		}
+		attrs.href = '#' + symbolNode.id;
+		attrs.x += bounds.x;
+		attrs.y += bounds.y;
+		attrs.width = formatter.number(bounds.width);
+		attrs.height = formatter.number(bounds.height);
+		attrs.overflow = 'visible';
+		return createElement('use', attrs);
+	}
+
+	function exportGradient(color) {
+		var gradientNode = getDefinition(color, 'color');
+		if (!gradientNode) {
+			var gradient = color.getGradient(),
+				radial = gradient._radial,
+				origin = color.getOrigin().transform(),
+				destination = color.getDestination().transform(),
+				attrs;
+			if (radial) {
+				attrs = {
+					cx: origin.x,
+					cy: origin.y,
+					r: origin.getDistance(destination)
+				};
+				var highlight = color.getHighlight();
+				if (highlight) {
+					highlight = highlight.transform();
+					attrs.fx = highlight.x;
+					attrs.fy = highlight.y;
+				}
+			} else {
+				attrs = {
+					x1: origin.x,
+					y1: origin.y,
+					x2: destination.x,
+					y2: destination.y
+				};
+			}
+			attrs.gradientUnits = 'userSpaceOnUse';
+			gradientNode = createElement(
+					(radial ? 'radial' : 'linear') + 'Gradient', attrs);
+			var stops = gradient._stops;
+			for (var i = 0, l = stops.length; i < l; i++) {
+				var stop = stops[i],
+					stopColor = stop._color,
+					alpha = stopColor.getAlpha();
+				attrs = {
+					offset: stop._rampPoint,
+					'stop-color': stopColor.toCSS(true)
+				};
+				if (alpha < 1)
+					attrs['stop-opacity'] = alpha;
+				gradientNode.appendChild(createElement('stop', attrs));
+			}
+			setDefinition(color, gradientNode, 'color');
+		}
+		return 'url(#' + gradientNode.id + ')';
+	}
+
+	function exportText(item) {
+		var node = createElement('text', getTransform(item._matrix, true));
+		node.textContent = item._content;
+		return node;
+	}
+
+	var exporters = {
+		Group: exportGroup,
+		Layer: exportGroup,
+		Raster: exportRaster,
+		Path: exportPath,
+		Shape: exportShape,
+		CompoundPath: exportCompoundPath,
+		PlacedSymbol: exportPlacedSymbol,
+		PointText: exportText
+	};
+
+	function applyStyle(item, node, isRoot) {
+		var attrs = {},
+			parent = !isRoot && item.getParent(),
+			style = [];
+
+		if (item._name != null)
+			attrs.id = item._name;
+
+		Base.each(SVGStyles, function(entry) {
+			var get = entry.get,
+				type = entry.type,
+				value = item[get]();
+			if (entry.exportFilter
+					? entry.exportFilter(item, value)
+					: !parent || !Base.equals(parent[get](), value)) {
+				if (type === 'color' && value != null) {
+					var alpha = value.getAlpha();
+					if (alpha < 1)
+						attrs[entry.attribute + '-opacity'] = alpha;
+				}
+				if (type === 'style') {
+					style.push(entry.attribute + ': ' + value);
+				} else {
+					attrs[entry.attribute] = value == null ? 'none'
+							: type === 'number' ? formatter.number(value)
+							: type === 'color' ? value.gradient
+								? exportGradient(value, item)
+								: value.toCSS(true)
+							: type === 'array' ? value.join(',')
+							: type === 'lookup' ? entry.toSVG[value]
+							: value;
+				}
+			}
+		});
+
+		if (style.length)
+			attrs.style = style.join(';');
+
+		if (attrs.opacity === 1)
+			delete attrs.opacity;
+
+		if (!item._visible)
+			attrs.visibility = 'hidden';
+
+		return setAttributes(node, attrs);
+	}
+
+	var definitions;
+	function getDefinition(item, type) {
+		if (!definitions)
+			definitions = { ids: {}, svgs: {} };
+		return item && definitions.svgs[type + '-' + item._id];
+	}
+
+	function setDefinition(item, node, type) {
+		if (!definitions)
+			getDefinition();
+		var id = definitions.ids[type] = (definitions.ids[type] || 0) + 1;
+		node.id = type + '-' + id;
+		definitions.svgs[type + '-' + item._id] = node;
+	}
+
+	function exportDefinitions(node, options) {
+		var svg = node,
+			defs = null;
+		if (definitions) {
+			svg = node.nodeName.toLowerCase() === 'svg' && node;
+			for (var i in definitions.svgs) {
+				if (!defs) {
+					if (!svg) {
+						svg = createElement('svg');
+						svg.appendChild(node);
+					}
+					defs = svg.insertBefore(createElement('defs'),
+							svg.firstChild);
+				}
+				defs.appendChild(definitions.svgs[i]);
+			}
+			definitions = null;
+		}
+		return options.asString
+				? new XMLSerializer().serializeToString(svg)
+				: svg;
+	}
+
+	function exportSVG(item, options, isRoot) {
+		var exporter = exporters[item._class],
+			node = exporter && exporter(item, options);
+		if (node) {
+			var onExport = options.onExport;
+			if (onExport)
+				node = onExport(item, node, options) || node;
+			var data = JSON.stringify(item._data);
+			if (data && data !== '{}' && data !== 'null')
+				node.setAttribute('data-paper-data', data);
+		}
+		return node && applyStyle(item, node, isRoot);
+	}
+
+	function setOptions(options) {
+		if (!options)
+			options = {};
+		formatter = new Formatter(options.precision);
+		return options;
+	}
+
+	Item.inject({
+		exportSVG: function(options) {
+			options = setOptions(options);
+			return exportDefinitions(exportSVG(this, options, true), options);
+		}
+	});
+
+	Project.inject({
+		exportSVG: function(options) {
+			options = setOptions(options);
+			var children = this._children,
+				view = this.getView(),
+				size = view.getViewSize(),
+				node = createElement('svg', {
+					x: 0,
+					y: 0,
+					width: size.width,
+					height: size.height,
+					version: '1.1',
+					xmlns: 'http://www.w3.org/2000/svg',
+					'xmlns:xlink': 'http://www.w3.org/1999/xlink'
+				}),
+				parent = node,
+				matrix = view._matrix;
+			if (!matrix.isIdentity())
+				parent = node.appendChild(
+						createElement('g', getTransform(matrix)));
+			for (var i = 0, l = children.length; i < l; i++)
+				parent.appendChild(exportSVG(children[i], options, true));
+			return exportDefinitions(node, options);
+		}
+	});
+};
+
+new function() {
+
+	function getValue(node, name, isString, allowNull) {
+		var namespace = SVGNamespaces[name],
+			value = namespace
+				? node.getAttributeNS(namespace, name)
+				: node.getAttribute(name);
+		if (value === 'null')
+			value = null;
+		return value == null
+				? allowNull
+					? null
+					: isString
+						? ''
+						: 0
+				: isString
+					? value
+					: parseFloat(value);
+	}
+
+	function getPoint(node, x, y, allowNull) {
+		x = getValue(node, x, false, allowNull);
+		y = getValue(node, y, false, allowNull);
+		return allowNull && (x == null || y == null) ? null
+				: new Point(x, y);
+	}
+
+	function getSize(node, w, h, allowNull) {
+		w = getValue(node, w, false, allowNull);
+		h = getValue(node, h, false, allowNull);
+		return allowNull && (w == null || h == null) ? null
+				: new Size(w, h);
+	}
+
+	function convertValue(value, type, lookup) {
+		return value === 'none'
+				? null
+				: type === 'number'
+					? parseFloat(value)
+					: type === 'array'
+						? value ? value.split(/[\s,]+/g).map(parseFloat) : []
+						: type === 'color'
+							? getDefinition(value) || value
+							: type === 'lookup'
+								? lookup[value]
+								: value;
+	}
+
+	function importGroup(node, type, options, isRoot) {
+		var nodes = node.childNodes,
+			isClip = type === 'clippath',
+			item = new Group(),
+			project = item._project,
+			currentStyle = project._currentStyle,
+			children = [];
+		if (!isClip) {
+			item = applyAttributes(item, node, isRoot);
+			project._currentStyle = item._style.clone();
+		}
+		if (isRoot) {
+			var defs = node.querySelectorAll('defs');
+			for (var i = 0, l = defs.length; i < l; i++) {
+				importSVG(defs[i], options, false);
+			}
+		}
+		for (var i = 0, l = nodes.length; i < l; i++) {
+			var childNode = nodes[i],
+				child;
+			if (childNode.nodeType === 1
+					&& childNode.nodeName.toLowerCase() !== 'defs'
+					&& (child = importSVG(childNode, options, false))
+					&& !(child instanceof Symbol))
+				children.push(child);
+		}
+		item.addChildren(children);
+		if (isClip)
+			item = applyAttributes(item.reduce(), node, isRoot);
+		project._currentStyle = currentStyle;
+		if (isClip || type === 'defs') {
+			item.remove();
+			item = null;
+		}
+		return item;
+	}
+
+	function importPoly(node, type) {
+		var coords = node.getAttribute('points').match(
+					/[+-]?(?:\d*\.\d+|\d+\.?)(?:[eE][+-]?\d+)?/g),
+			points = [];
+		for (var i = 0, l = coords.length; i < l; i += 2)
+			points.push(new Point(
+					parseFloat(coords[i]),
+					parseFloat(coords[i + 1])));
+		var path = new Path(points);
+		if (type === 'polygon')
+			path.closePath();
+		return path;
+	}
+
+	function importPath(node) {
+		var data = node.getAttribute('d'),
+			param = { pathData: data };
+		return (data.match(/m/gi) || []).length > 1 || /z\S+/i.test(data)
+				? new CompoundPath(param)
+				: new Path(param);
+	}
+
+	function importGradient(node, type) {
+		var id = (getValue(node, 'href', true) || '').substring(1),
+			isRadial = type === 'radialgradient',
+			gradient;
+		if (id) {
+			gradient = definitions[id].getGradient();
+		} else {
+			var nodes = node.childNodes,
+				stops = [];
+			for (var i = 0, l = nodes.length; i < l; i++) {
+				var child = nodes[i];
+				if (child.nodeType === 1)
+					stops.push(applyAttributes(new GradientStop(), child));
+			}
+			gradient = new Gradient(stops, isRadial);
+		}
+		var origin, destination, highlight;
+		if (isRadial) {
+			origin = getPoint(node, 'cx', 'cy');
+			destination = origin.add(getValue(node, 'r'), 0);
+			highlight = getPoint(node, 'fx', 'fy', true);
+		} else {
+			origin = getPoint(node, 'x1', 'y1');
+			destination = getPoint(node, 'x2', 'y2');
+		}
+		applyAttributes(
+			new Color(gradient, origin, destination, highlight), node);
+		return null;
+	}
+
+	var importers = {
+		'#document': function (node, type, options, isRoot) {
+			var nodes = node.childNodes;
+			for (var i = 0, l = nodes.length; i < l; i++) {
+				var child = nodes[i];
+				if (child.nodeType === 1) {
+					var next = child.nextSibling;
+					document.body.appendChild(child);
+					var item = importSVG(child, options, isRoot);
+					if (next) {
+						node.insertBefore(child, next);
+					} else {
+						node.appendChild(child);
+					}
+					return item;
+				}
+			}
+		},
+		g: importGroup,
+		svg: importGroup,
+		clippath: importGroup,
+		polygon: importPoly,
+		polyline: importPoly,
+		path: importPath,
+		lineargradient: importGradient,
+		radialgradient: importGradient,
+
+		image: function (node) {
+			var raster = new Raster(getValue(node, 'href', true));
+			raster.on('load', function() {
+				var size = getSize(node, 'width', 'height');
+				this.setSize(size);
+				var center = this._matrix._transformPoint(
+						getPoint(node, 'x', 'y').add(size.divide(2)));
+				this.translate(center);
+			});
+			return raster;
+		},
+
+		symbol: function(node, type, options, isRoot) {
+			return new Symbol(importGroup(node, type, options, isRoot), true);
+		},
+
+		defs: importGroup,
+
+		use: function(node) {
+			var id = (getValue(node, 'href', true) || '').substring(1),
+				definition = definitions[id],
+				point = getPoint(node, 'x', 'y');
+			return definition
+					? definition instanceof Symbol
+						? definition.place(point)
+						: definition.clone().translate(point)
+					: null;
+		},
+
+		circle: function(node) {
+			return new Shape.Circle(getPoint(node, 'cx', 'cy'),
+					getValue(node, 'r'));
+		},
+
+		ellipse: function(node) {
+			return new Shape.Ellipse({
+				center: getPoint(node, 'cx', 'cy'),
+				radius: getSize(node, 'rx', 'ry')
+			});
+		},
+
+		rect: function(node) {
+			var point = getPoint(node, 'x', 'y'),
+				size = getSize(node, 'width', 'height'),
+				radius = getSize(node, 'rx', 'ry');
+			return new Shape.Rectangle(new Rectangle(point, size), radius);
+		},
+
+		line: function(node) {
+			return new Path.Line(getPoint(node, 'x1', 'y1'),
+					getPoint(node, 'x2', 'y2'));
+		},
+
+		text: function(node) {
+			var text = new PointText(getPoint(node, 'x', 'y')
+					.add(getPoint(node, 'dx', 'dy')));
+			text.setContent(node.textContent.trim() || '');
+			return text;
+		}
+	};
+
+	function applyTransform(item, value, name, node) {
+		var transforms = (node.getAttribute(name) || '').split(/\)\s*/g),
+			matrix = new Matrix();
+		for (var i = 0, l = transforms.length; i < l; i++) {
+			var transform = transforms[i];
+			if (!transform)
+				break;
+			var parts = transform.split(/\(\s*/),
+				command = parts[0],
+				v = parts[1].split(/[\s,]+/g);
+			for (var j = 0, m = v.length; j < m; j++)
+				v[j] = parseFloat(v[j]);
+			switch (command) {
+			case 'matrix':
+				matrix.concatenate(
+						new Matrix(v[0], v[1], v[2], v[3], v[4], v[5]));
+				break;
+			case 'rotate':
+				matrix.rotate(v[0], v[1], v[2]);
+				break;
+			case 'translate':
+				matrix.translate(v[0], v[1]);
+				break;
+			case 'scale':
+				matrix.scale(v);
+				break;
+			case 'skewX':
+				matrix.skew(v[0], 0);
+				break;
+			case 'skewY':
+				matrix.skew(0, v[0]);
+				break;
+			}
+		}
+		item.transform(matrix);
+	}
+
+	function applyOpacity(item, value, name) {
+		var color = item[name === 'fill-opacity' ? 'getFillColor'
+				: 'getStrokeColor']();
+		if (color)
+			color.setAlpha(parseFloat(value));
+	}
+
+	var attributes = Base.set(Base.each(SVGStyles, function(entry) {
+		this[entry.attribute] = function(item, value) {
+			item[entry.set](convertValue(value, entry.type, entry.fromSVG));
+			if (entry.type === 'color' && item instanceof Shape) {
+				var color = item[entry.get]();
+				if (color)
+					color.transform(new Matrix().translate(
+							item.getPosition(true).negate()));
+			}
+		};
+	}, {}), {
+		id: function(item, value) {
+			definitions[value] = item;
+			if (item.setName)
+				item.setName(value);
+		},
+
+		'clip-path': function(item, value) {
+			var clip = getDefinition(value);
+			if (clip) {
+				clip = clip.clone();
+				clip.setClipMask(true);
+				if (item instanceof Group) {
+					item.insertChild(0, clip);
+				} else {
+					return new Group(clip, item);
+				}
+			}
+		},
+
+		gradientTransform: applyTransform,
+		transform: applyTransform,
+
+		'fill-opacity': applyOpacity,
+		'stroke-opacity': applyOpacity,
+
+		visibility: function(item, value) {
+			item.setVisible(value === 'visible');
+		},
+
+		display: function(item, value) {
+			item.setVisible(value !== null);
+		},
+
+		'stop-color': function(item, value) {
+			if (item.setColor)
+				item.setColor(value);
+		},
+
+		'stop-opacity': function(item, value) {
+			if (item._color)
+				item._color.setAlpha(parseFloat(value));
+		},
+
+		offset: function(item, value) {
+			var percentage = value.match(/(.*)%$/);
+			item.setRampPoint(percentage
+					? percentage[1] / 100
+					: parseFloat(value));
+		},
+
+		viewBox: function(item, value, name, node, styles) {
+			var rect = new Rectangle(convertValue(value, 'array')),
+				size = getSize(node, 'width', 'height', true);
+			if (item instanceof Group) {
+				var scale = size ? rect.getSize().divide(size) : 1,
+					matrix = new Matrix().translate(rect.getPoint()).scale(scale);
+				item.transform(matrix.inverted());
+			} else if (item instanceof Symbol) {
+				if (size)
+					rect.setSize(size);
+				var clip = getAttribute(node, 'overflow', styles) != 'visible',
+					group = item._definition;
+				if (clip && !rect.contains(group.getBounds())) {
+					clip = new Shape.Rectangle(rect).transform(group._matrix);
+					clip.setClipMask(true);
+					group.addChild(clip);
+				}
+			}
+		}
+	});
+
+	function getAttribute(node, name, styles) {
+		var attr = node.attributes[name],
+			value = attr && attr.value;
+		if (!value) {
+			var style = Base.camelize(name);
+			value = node.style[style];
+			if (!value && styles.node[style] !== styles.parent[style])
+				value = styles.node[style];
+		}
+		return !value
+				? undefined
+				: value === 'none'
+					? null
+					: value;
+	}
+
+	function applyAttributes(item, node, isRoot) {
+		var styles = {
+			node: DomElement.getStyles(node) || {},
+			parent: !isRoot && DomElement.getStyles(node.parentNode) || {}
+		};
+		Base.each(attributes, function(apply, name) {
+			var value = getAttribute(node, name, styles);
+			if (value !== undefined)
+				item = Base.pick(apply(item, value, name, node, styles), item);
+		});
+		return item;
+	}
+
+	var definitions = {};
+	function getDefinition(value) {
+		var match = value && value.match(/\((?:["'#]*)([^"')]+)/);
+		return match && definitions[match[1]];
+	}
+
+	function importSVG(source, options, isRoot) {
+		if (!source)
+			return null;
+		if (!options) {
+			options = {};
+		} else if (typeof options === 'function') {
+			options = { onLoad: options };
+		}
+
+		var node = source,
+			scope = paper;
+
+		function onLoadCallback(svg) {
+			paper = scope;
+			var item = importSVG(svg, options, isRoot),
+				onLoad = options.onLoad,
+				view = scope.project && scope.getView();
+			if (onLoad)
+				onLoad.call(this, item);
+			view.update();
+		}
+
+		if (isRoot) {
+			if (typeof source === 'string' && !/^.*</.test(source)) {
+				node = document.getElementById(source);
+				if (node) {
+					source = null;
+				} else {
+					return Http.request('get', source, onLoadCallback);
+				}
+			} else if (typeof File !== 'undefined' && source instanceof File) {
+				var reader = new FileReader();
+				reader.onload = function() {
+					onLoadCallback(reader.result);
+				};
+				return reader.readAsText(source);
+			}
+		}
+
+		if (typeof source === 'string')
+			node = new DOMParser().parseFromString(source, 'image/svg+xml');
+		if (!node.nodeName)
+			throw new Error('Unsupported SVG source: ' + source);
+		var type = node.nodeName.toLowerCase(),
+			importer = importers[type],
+			item,
+			data = node.getAttribute && node.getAttribute('data-paper-data'),
+			settings = scope.settings,
+			applyMatrix = settings.applyMatrix;
+		settings.applyMatrix = false;
+		item = importer && importer(node, type, options, isRoot) || null;
+		settings.applyMatrix = applyMatrix;
+		if (item) {
+			if (type !== '#document' && !(item instanceof Group))
+				item = applyAttributes(item, node, isRoot);
+			var onImport = options.onImport;
+			if (onImport)
+				item = onImport(node, item, options) || item;
+			if (options.expandShapes && item instanceof Shape) {
+				item.remove();
+				item = item.toPath();
+			}
+			if (data)
+				item._data = JSON.parse(data);
+		}
+		if (isRoot) {
+			definitions = {};
+			if (item && Base.pick(options.applyMatrix, applyMatrix))
+				item.matrix.apply(true, true);
+		}
+		return item;
+	}
+
+	Item.inject({
+		importSVG: function(node, options) {
+			return this.addChild(importSVG(node, options, true));
+		}
+	});
+
+	Project.inject({
+		importSVG: function(node, options) {
+			this.activate();
+			return importSVG(node, options, true);
+		}
+	});
+};
+
+Base.exports.PaperScript = (function() {
+	var exports, define,
+		scope = this;
+!function(e,r){return"object"==typeof exports&&"object"==typeof module?r(exports):"function"==typeof define&&define.amd?define(["exports"],r):void r(e.acorn||(e.acorn={}))}(this,function(e){"use strict";function r(e){fe=e||{};for(var r in he)Object.prototype.hasOwnProperty.call(fe,r)||(fe[r]=he[r]);me=fe.sourceFile||null}function t(e,r){var t=ve(de,e);r+=" ("+t.line+":"+t.column+")";var n=new SyntaxError(r);throw n.pos=e,n.loc=t,n.raisedAt=be,n}function n(e){function r(e){if(1==e.length)return t+="return str === "+JSON.stringify(e[0])+";";t+="switch(str){";for(var r=0;r<e.length;++r)t+="case "+JSON.stringify(e[r])+":";t+="return true}return false;"}e=e.split(" ");var t="",n=[];e:for(var a=0;a<e.length;++a){for(var o=0;o<n.length;++o)if(n[o][0].length==e[a].length){n[o].push(e[a]);continue e}n.push([e[a]])}if(n.length>3){n.sort(function(e,r){return r.length-e.length}),t+="switch(str.length){";for(var a=0;a<n.length;++a){var i=n[a];t+="case "+i[0].length+":",r(i)}t+="}"}else r(e);return new Function("str",t)}function a(){this.line=Ae,this.column=be-Se}function o(){Ae=1,be=Se=0,Ee=!0,u()}function i(e,r){ge=be,fe.locations&&(ke=new a),we=e,u(),Ce=r,Ee=e.beforeExpr}function s(){var e=fe.onComment&&fe.locations&&new a,r=be,n=de.indexOf("*/",be+=2);if(-1===n&&t(be-2,"Unterminated comment"),be=n+2,fe.locations){Kr.lastIndex=r;for(var o;(o=Kr.exec(de))&&o.index<be;)++Ae,Se=o.index+o[0].length}fe.onComment&&fe.onComment(!0,de.slice(r+2,n),r,be,e,fe.locations&&new a)}function c(){for(var e=be,r=fe.onComment&&fe.locations&&new a,t=de.charCodeAt(be+=2);pe>be&&10!==t&&13!==t&&8232!==t&&8233!==t;)++be,t=de.charCodeAt(be);fe.onComment&&fe.onComment(!1,de.slice(e+2,be),e,be,r,fe.locations&&new a)}function u(){for(;pe>be;){var e=de.charCodeAt(be);if(32===e)++be;else if(13===e){++be;var r=de.charCodeAt(be);10===r&&++be,fe.locations&&(++Ae,Se=be)}else if(10===e||8232===e||8233===e)++be,fe.locations&&(++Ae,Se=be);else if(e>8&&14>e)++be;else if(47===e){var r=de.charCodeAt(be+1);if(42===r)s();else{if(47!==r)break;c()}}else if(160===e)++be;else{if(!(e>=5760&&Jr.test(String.fromCharCode(e))))break;++be}}}function l(){var e=de.charCodeAt(be+1);return e>=48&&57>=e?E(!0):(++be,i(xr))}function f(){var e=de.charCodeAt(be+1);return Ee?(++be,k()):61===e?x(Er,2):x(wr,1)}function d(){var e=de.charCodeAt(be+1);return 61===e?x(Er,2):x(jr,1)}function p(e){var r=de.charCodeAt(be+1);return r===e?x(124===e?Ir:Lr,2):61===r?x(Er,2):x(124===e?Ur:Rr,1)}function m(){var e=de.charCodeAt(be+1);return 61===e?x(Er,2):x(Fr,1)}function h(e){var r=de.charCodeAt(be+1);return r===e?45==r&&62==de.charCodeAt(be+2)&&Gr.test(de.slice(Le,be))?(be+=3,c(),u(),g()):x(Ar,2):61===r?x(Er,2):x(qr,1)}function v(e){var r=de.charCodeAt(be+1),t=1;return r===e?(t=62===e&&62===de.charCodeAt(be+2)?3:2,61===de.charCodeAt(be+t)?x(Er,t+1):x(Tr,t)):33==r&&60==e&&45==de.charCodeAt(be+2)&&45==de.charCodeAt(be+3)?(be+=4,c(),u(),g()):(61===r&&(t=61===de.charCodeAt(be+2)?3:2),x(Vr,t))}function b(e){var r=de.charCodeAt(be+1);return 61===r?x(Or,61===de.charCodeAt(be+2)?3:2):x(61===e?Cr:Sr,1)}function y(e){switch(e){case 46:return l();case 40:return++be,i(hr);case 41:return++be,i(vr);case 59:return++be,i(yr);case 44:return++be,i(br);case 91:return++be,i(fr);case 93:return++be,i(dr);case 123:return++be,i(pr);case 125:return++be,i(mr);case 58:return++be,i(gr);case 63:return++be,i(kr);case 48:var r=de.charCodeAt(be+1);if(120===r||88===r)return C();case 49:case 50:case 51:case 52:case 53:case 54:case 55:case 56:case 57:return E(!1);case 34:case 39:return A(e);case 47:return f(e);case 37:case 42:return d();case 124:case 38:return p(e);case 94:return m();case 43:case 45:return h(e);case 60:case 62:return v(e);case 61:case 33:return b(e);case 126:return x(Sr,1)}return!1}function g(e){if(e?be=ye+1:ye=be,fe.locations&&(xe=new a),e)return k();if(be>=pe)return i(Be);var r=de.charCodeAt(be);if(Qr(r)||92===r)return L();var n=y(r);if(n===!1){var o=String.fromCharCode(r);if("\\"===o||$r.test(o))return L();t(be,"Unexpected character '"+o+"'")}return n}function x(e,r){var t=de.slice(be,be+r);be+=r,i(e,t)}function k(){for(var e,r,n="",a=be;;){be>=pe&&t(a,"Unterminated regular expression");var o=de.charAt(be);if(Gr.test(o)&&t(a,"Unterminated regular expression"),e)e=!1;else{if("["===o)r=!0;else if("]"===o&&r)r=!1;else if("/"===o&&!r)break;e="\\"===o}++be}var n=de.slice(a,be);++be;var s=I();s&&!/^[gmsiy]*$/.test(s)&&t(a,"Invalid regexp flag");try{var c=new RegExp(n,s)}catch(u){u instanceof SyntaxError&&t(a,u.message),t(u)}return i(qe,c)}function w(e,r){for(var t=be,n=0,a=0,o=null==r?1/0:r;o>a;++a){var i,s=de.charCodeAt(be);if(i=s>=97?s-97+10:s>=65?s-65+10:s>=48&&57>=s?s-48:1/0,i>=e)break;++be,n=n*e+i}return be===t||null!=r&&be-t!==r?null:n}function C(){be+=2;var e=w(16);return null==e&&t(ye+2,"Expected hexadecimal number"),Qr(de.charCodeAt(be))&&t(be,"Identifier directly after number"),i(Te,e)}function E(e){var r=be,n=!1,a=48===de.charCodeAt(be);e||null!==w(10)||t(r,"Invalid number"),46===de.charCodeAt(be)&&(++be,w(10),n=!0);var o=de.charCodeAt(be);(69===o||101===o)&&(o=de.charCodeAt(++be),(43===o||45===o)&&++be,null===w(10)&&t(r,"Invalid number"),n=!0),Qr(de.charCodeAt(be))&&t(be,"Identifier directly after number");var s,c=de.slice(r,be);return n?s=parseFloat(c):a&&1!==c.length?/[89]/.test(c)||Oe?t(r,"Invalid number"):s=parseInt(c,8):s=parseInt(c,10),i(Te,s)}function A(e){be++;for(var r="";;){be>=pe&&t(ye,"Unterminated string constant");var n=de.charCodeAt(be);if(n===e)return++be,i(je,r);if(92===n){n=de.charCodeAt(++be);var a=/^[0-7]+/.exec(de.slice(be,be+3));for(a&&(a=a[0]);a&&parseInt(a,8)>255;)a=a.slice(0,-1);if("0"===a&&(a=null),++be,a)Oe&&t(be-2,"Octal literal in strict mode"),r+=String.fromCharCode(parseInt(a,8)),be+=a.length-1;else switch(n){case 110:r+="\n";break;case 114:r+="\r";break;case 120:r+=String.fromCharCode(S(2));break;case 117:r+=String.fromCharCode(S(4));break;case 85:r+=String.fromCharCode(S(8));break;case 116:r+="	";break;case 98:r+="\b";break;case 118:r+="";break;case 102:r+="\f";break;case 48:r+="\x00";break;case 13:10===de.charCodeAt(be)&&++be;case 10:fe.locations&&(Se=be,++Ae);break;default:r+=String.fromCharCode(n)}}else(13===n||10===n||8232===n||8233===n)&&t(ye,"Unterminated string constant"),r+=String.fromCharCode(n),++be}}function S(e){var r=w(16,e);return null===r&&t(ye,"Bad character escape sequence"),r}function I(){Br=!1;for(var e,r=!0,n=be;;){var a=de.charCodeAt(be);if(Yr(a))Br&&(e+=de.charAt(be)),++be;else{if(92!==a)break;Br||(e=de.slice(n,be)),Br=!0,117!=de.charCodeAt(++be)&&t(be,"Expecting Unicode escape sequence \\uXXXX"),++be;var o=S(4),i=String.fromCharCode(o);i||t(be-1,"Invalid Unicode escape"),(r?Qr(o):Yr(o))||t(be-4,"Invalid Unicode escape"),e+=i}r=!1}return Br?e:de.slice(n,be)}function L(){var e=I(),r=De;return!Br&&Wr(e)&&(r=lr[e]),i(r,e)}function U(){Ie=ye,Le=ge,Ue=ke,g()}function F(e){if(Oe=e,be=ye,fe.locations)for(;Se>be;)Se=de.lastIndexOf("\n",Se-2)+1,--Ae;u(),g()}function R(){this.type=null,this.start=ye,this.end=null}function O(){this.start=xe,this.end=null,null!==me&&(this.source=me)}function V(){var e=new R;return fe.locations&&(e.loc=new O),fe.directSourceFile&&(e.sourceFile=fe.directSourceFile),fe.ranges&&(e.range=[ye,0]),e}function T(e){var r=new R;return r.start=e.start,fe.locations&&(r.loc=new O,r.loc.start=e.loc.start),fe.ranges&&(r.range=[e.range[0],0]),r}function q(e,r){return e.type=r,e.end=Le,fe.locations&&(e.loc.end=Ue),fe.ranges&&(e.range[1]=Le),e}function j(e){return fe.ecmaVersion>=5&&"ExpressionStatement"===e.type&&"Literal"===e.expression.type&&"use strict"===e.expression.value}function D(e){return we===e?(U(),!0):void 0}function B(){return!fe.strictSemicolons&&(we===Be||we===mr||Gr.test(de.slice(Le,ye)))}function M(){D(yr)||B()||X()}function z(e){we===e?U():X()}function X(){t(ye,"Unexpected token")}function N(e){"Identifier"!==e.type&&"MemberExpression"!==e.type&&t(e.start,"Assigning to rvalue"),Oe&&"Identifier"===e.type&&Nr(e.name)&&t(e.start,"Assigning to "+e.name+" in strict mode")}function W(e){Ie=Le=be,fe.locations&&(Ue=new a),Fe=Oe=null,Re=[],g();var r=e||V(),t=!0;for(e||(r.body=[]);we!==Be;){var n=J();r.body.push(n),t&&j(n)&&F(!0),t=!1}return q(r,"Program")}function J(){(we===wr||we===Er&&"/="==Ce)&&g(!0);var e=we,r=V();switch(e){case Me:case Ne:U();var n=e===Me;D(yr)||B()?r.label=null:we!==De?X():(r.label=le(),M());for(var a=0;a<Re.length;++a){var o=Re[a];if(null==r.label||o.name===r.label.name){if(null!=o.kind&&(n||"loop"===o.kind))break;if(r.label&&n)break}}return a===Re.length&&t(r.start,"Unsyntactic "+e.keyword),q(r,n?"BreakStatement":"ContinueStatement");case We:return U(),M(),q(r,"DebuggerStatement");case Pe:return U(),Re.push(Zr),r.body=J(),Re.pop(),z(tr),r.test=P(),M(),q(r,"DoWhileStatement");case _e:if(U(),Re.push(Zr),z(hr),we===yr)return $(r,null);if(we===rr){var i=V();return U(),G(i,!0),q(i,"VariableDeclaration"),1===i.declarations.length&&D(ur)?_(r,i):$(r,i)}var i=K(!1,!0);return D(ur)?(N(i),_(r,i)):$(r,i);case Ge:return U(),ce(r,!0);case Ke:return U(),r.test=P(),r.consequent=J(),r.alternate=D(He)?J():null,q(r,"IfStatement");case Qe:return Fe||fe.allowReturnOutsideFunction||t(ye,"'return' outside of function"),U(),D(yr)||B()?r.argument=null:(r.argument=K(),M()),q(r,"ReturnStatement");case Ye:U(),r.discriminant=P(),r.cases=[],z(pr),Re.push(et);for(var s,c;we!=mr;)if(we===ze||we===Je){var u=we===ze;s&&q(s,"SwitchCase"),r.cases.push(s=V()),s.consequent=[],U(),u?s.test=K():(c&&t(Ie,"Multiple default clauses"),c=!0,s.test=null),z(gr)}else s||X(),s.consequent.push(J());return s&&q(s,"SwitchCase"),U(),Re.pop(),q(r,"SwitchStatement");case Ze:return U(),Gr.test(de.slice(Le,ye))&&t(Le,"Illegal newline after throw"),r.argument=K(),M(),q(r,"ThrowStatement");case er:if(U(),r.block=H(),r.handler=null,we===Xe){var l=V();U(),z(hr),l.param=le(),Oe&&Nr(l.param.name)&&t(l.param.start,"Binding "+l.param.name+" in strict mode"),z(vr),l.guard=null,l.body=H(),r.handler=q(l,"CatchClause")}return r.guardedHandlers=Ve,r.finalizer=D($e)?H():null,r.handler||r.finalizer||t(r.start,"Missing catch or finally clause"),q(r,"TryStatement");case rr:return U(),G(r),M(),q(r,"VariableDeclaration");case tr:return U(),r.test=P(),Re.push(Zr),r.body=J(),Re.pop(),q(r,"WhileStatement");case nr:return Oe&&t(ye,"'with' in strict mode"),U(),r.object=P(),r.body=J(),q(r,"WithStatement");case pr:return H();case yr:return U(),q(r,"EmptyStatement");default:var f=Ce,d=K();if(e===De&&"Identifier"===d.type&&D(gr)){for(var a=0;a<Re.length;++a)Re[a].name===f&&t(d.start,"Label '"+f+"' is already declared");var p=we.isLoop?"loop":we===Ye?"switch":null;return Re.push({name:f,kind:p}),r.body=J(),Re.pop(),r.label=d,q(r,"LabeledStatement")}return r.expression=d,M(),q(r,"ExpressionStatement")}}function P(){z(hr);var e=K();return z(vr),e}function H(e){var r,t=V(),n=!0,a=!1;for(t.body=[],z(pr);!D(mr);){var o=J();t.body.push(o),n&&e&&j(o)&&(r=a,F(a=!0)),n=!1}return a&&!r&&F(!1),q(t,"BlockStatement")}function $(e,r){return e.init=r,z(yr),e.test=we===yr?null:K(),z(yr),e.update=we===vr?null:K(),z(vr),e.body=J(),Re.pop(),q(e,"ForStatement")}function _(e,r){return e.left=r,e.right=K(),z(vr),e.body=J(),Re.pop(),q(e,"ForInStatement")}function G(e,r){for(e.declarations=[],e.kind="var";;){var n=V();if(n.id=le(),Oe&&Nr(n.id.name)&&t(n.id.start,"Binding "+n.id.name+" in strict mode"),n.init=D(Cr)?K(!0,r):null,e.declarations.push(q(n,"VariableDeclarator")),!D(br))break}return e}function K(e,r){var t=Q(r);if(!e&&we===br){var n=T(t);for(n.expressions=[t];D(br);)n.expressions.push(Q(r));return q(n,"SequenceExpression")}return t}function Q(e){var r=Y(e);if(we.isAssign){var t=T(r);return t.operator=Ce,t.left=r,U(),t.right=Q(e),N(r),q(t,"AssignmentExpression")}return r}function Y(e){var r=Z(e);if(D(kr)){var t=T(r);return t.test=r,t.consequent=K(!0),z(gr),t.alternate=K(!0,e),q(t,"ConditionalExpression")}return r}function Z(e){return ee(re(),-1,e)}function ee(e,r,t){var n=we.binop;if(null!=n&&(!t||we!==ur)&&n>r){var a=T(e);a.left=e,a.operator=Ce;var o=we;U(),a.right=ee(re(),n,t);var i=q(a,o===Ir||o===Lr?"LogicalExpression":"BinaryExpression");return ee(i,r,t)}return e}function re(){if(we.prefix){var e=V(),r=we.isUpdate;return e.operator=Ce,e.prefix=!0,Ee=!0,U(),e.argument=re(),r?N(e.argument):Oe&&"delete"===e.operator&&"Identifier"===e.argument.type&&t(e.start,"Deleting local variable in strict mode"),q(e,r?"UpdateExpression":"UnaryExpression")}for(var n=te();we.postfix&&!B();){var e=T(n);e.operator=Ce,e.prefix=!1,e.argument=n,N(n),U(),n=q(e,"UpdateExpression")}return n}function te(){return ne(ae())}function ne(e,r){if(D(xr)){var t=T(e);return t.object=e,t.property=le(!0),t.computed=!1,ne(q(t,"MemberExpression"),r)}if(D(fr)){var t=T(e);return t.object=e,t.property=K(),t.computed=!0,z(dr),ne(q(t,"MemberExpression"),r)}if(!r&&D(hr)){var t=T(e);return t.callee=e,t.arguments=ue(vr,!1),ne(q(t,"CallExpression"),r)}return e}function ae(){switch(we){case or:var e=V();return U(),q(e,"ThisExpression");case De:return le();case Te:case je:case qe:var e=V();return e.value=Ce,e.raw=de.slice(ye,ge),U(),q(e,"Literal");case ir:case sr:case cr:var e=V();return e.value=we.atomValue,e.raw=we.keyword,U(),q(e,"Literal");case hr:var r=xe,t=ye;U();var n=K();return n.start=t,n.end=ge,fe.locations&&(n.loc.start=r,n.loc.end=ke),fe.ranges&&(n.range=[t,ge]),z(vr),n;case fr:var e=V();return U(),e.elements=ue(dr,!0,!0),q(e,"ArrayExpression");case pr:return ie();case Ge:var e=V();return U(),ce(e,!1);case ar:return oe();default:X()}}function oe(){var e=V();return U(),e.callee=ne(ae(),!0),D(hr)?e.arguments=ue(vr,!1):e.arguments=Ve,q(e,"NewExpression")}function ie(){var e=V(),r=!0,n=!1;for(e.properties=[],U();!D(mr);){if(r)r=!1;else if(z(br),fe.allowTrailingCommas&&D(mr))break;var a,o={key:se()},i=!1;if(D(gr)?(o.value=K(!0),a=o.kind="init"):fe.ecmaVersion>=5&&"Identifier"===o.key.type&&("get"===o.key.name||"set"===o.key.name)?(i=n=!0,a=o.kind=o.key.name,o.key=se(),we!==hr&&X(),o.value=ce(V(),!1)):X(),"Identifier"===o.key.type&&(Oe||n))for(var s=0;s<e.properties.length;++s){var c=e.properties[s];if(c.key.name===o.key.name){var u=a==c.kind||i&&"init"===c.kind||"init"===a&&("get"===c.kind||"set"===c.kind);u&&!Oe&&"init"===a&&"init"===c.kind&&(u=!1),u&&t(o.key.start,"Redefinition of property")}}e.properties.push(o)}return q(e,"ObjectExpression")}function se(){return we===Te||we===je?ae():le(!0)}function ce(e,r){we===De?e.id=le():r?X():e.id=null,e.params=[];var n=!0;for(z(hr);!D(vr);)n?n=!1:z(br),e.params.push(le());var a=Fe,o=Re;if(Fe=!0,Re=[],e.body=H(!0),Fe=a,Re=o,Oe||e.body.body.length&&j(e.body.body[0]))for(var i=e.id?-1:0;i<e.params.length;++i){var s=0>i?e.id:e.params[i];if((Xr(s.name)||Nr(s.name))&&t(s.start,"Defining '"+s.name+"' in strict mode"),i>=0)for(var c=0;i>c;++c)s.name===e.params[c].name&&t(s.start,"Argument name clash in strict mode")}return q(e,r?"FunctionDeclaration":"FunctionExpression")}function ue(e,r,t){for(var n=[],a=!0;!D(e);){if(a)a=!1;else if(z(br),r&&fe.allowTrailingCommas&&D(e))break;t&&we===br?n.push(null):n.push(K(!0))}return n}function le(e){var r=V();return e&&"everywhere"==fe.forbidReserved&&(e=!1),we===De?(!e&&(fe.forbidReserved&&(3===fe.ecmaVersion?Mr:zr)(Ce)||Oe&&Xr(Ce))&&-1==de.slice(ye,ge).indexOf("\\")&&t(ye,"The keyword '"+Ce+"' is reserved"),r.name=Ce):e&&we.keyword?r.name=we.keyword:X(),Ee=!1,U(),q(r,"Identifier")}e.version="0.5.0";var fe,de,pe,me;e.parse=function(e,t){return de=String(e),pe=de.length,r(t),o(),W(fe.program)};var he=e.defaultOptions={ecmaVersion:5,strictSemicolons:!1,allowTrailingCommas:!0,forbidReserved:!1,allowReturnOutsideFunction:!1,locations:!1,onComment:null,ranges:!1,program:null,sourceFile:null,directSourceFile:null},ve=e.getLineInfo=function(e,r){for(var t=1,n=0;;){Kr.lastIndex=n;var a=Kr.exec(e);if(!(a&&a.index<r))break;++t,n=a.index+a[0].length}return{line:t,column:r-n}};e.tokenize=function(e,t){function n(e){return Le=ge,g(e),a.start=ye,a.end=ge,a.startLoc=xe,a.endLoc=ke,a.type=we,a.value=Ce,a}de=String(e),pe=de.length,r(t),o();var a={};return n.jumpTo=function(e,r){if(be=e,fe.locations){Ae=1,Se=Kr.lastIndex=0;for(var t;(t=Kr.exec(de))&&t.index<e;)++Ae,Se=t.index+t[0].length}Ee=r,u()},n};var be,ye,ge,xe,ke,we,Ce,Ee,Ae,Se,Ie,Le,Ue,Fe,Re,Oe,Ve=[],Te={type:"num"},qe={type:"regexp"},je={type:"string"},De={type:"name"},Be={type:"eof"},Me={keyword:"break"},ze={keyword:"case",beforeExpr:!0},Xe={keyword:"catch"},Ne={keyword:"continue"},We={keyword:"debugger"},Je={keyword:"default"},Pe={keyword:"do",isLoop:!0},He={keyword:"else",beforeExpr:!0},$e={keyword:"finally"},_e={keyword:"for",isLoop:!0},Ge={keyword:"function"},Ke={keyword:"if"},Qe={keyword:"return",beforeExpr:!0},Ye={keyword:"switch"},Ze={keyword:"throw",beforeExpr:!0},er={keyword:"try"},rr={keyword:"var"},tr={keyword:"while",isLoop:!0},nr={keyword:"with"},ar={keyword:"new",beforeExpr:!0},or={keyword:"this"},ir={keyword:"null",atomValue:null},sr={keyword:"true",atomValue:!0},cr={keyword:"false",atomValue:!1},ur={keyword:"in",binop:7,beforeExpr:!0},lr={"break":Me,"case":ze,"catch":Xe,"continue":Ne,"debugger":We,"default":Je,"do":Pe,"else":He,"finally":$e,"for":_e,"function":Ge,"if":Ke,"return":Qe,"switch":Ye,"throw":Ze,"try":er,"var":rr,"while":tr,"with":nr,"null":ir,"true":sr,"false":cr,"new":ar,"in":ur,"instanceof":{keyword:"instanceof",binop:7,beforeExpr:!0},"this":or,"typeof":{keyword:"typeof",prefix:!0,beforeExpr:!0},"void":{keyword:"void",prefix:!0,beforeExpr:!0},"delete":{keyword:"delete",prefix:!0,beforeExpr:!0}},fr={type:"[",beforeExpr:!0},dr={type:"]"},pr={type:"{",beforeExpr:!0},mr={type:"}"},hr={type:"(",beforeExpr:!0},vr={type:")"},br={type:",",beforeExpr:!0},yr={type:";",beforeExpr:!0},gr={type:":",beforeExpr:!0},xr={type:"."},kr={type:"?",beforeExpr:!0},wr={binop:10,beforeExpr:!0},Cr={isAssign:!0,beforeExpr:!0},Er={isAssign:!0,beforeExpr:!0},Ar={postfix:!0,prefix:!0,isUpdate:!0},Sr={prefix:!0,beforeExpr:!0},Ir={binop:1,beforeExpr:!0},Lr={binop:2,beforeExpr:!0},Ur={binop:3,beforeExpr:!0},Fr={binop:4,beforeExpr:!0},Rr={binop:5,beforeExpr:!0},Or={binop:6,beforeExpr:!0},Vr={binop:7,beforeExpr:!0},Tr={binop:8,beforeExpr:!0},qr={binop:9,prefix:!0,beforeExpr:!0},jr={binop:10,beforeExpr:!0};e.tokTypes={bracketL:fr,bracketR:dr,braceL:pr,braceR:mr,parenL:hr,parenR:vr,comma:br,semi:yr,colon:gr,dot:xr,question:kr,slash:wr,eq:Cr,name:De,eof:Be,num:Te,regexp:qe,string:je};for(var Dr in lr)e.tokTypes["_"+Dr]=lr[Dr];var Br,Mr=n("abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile"),zr=n("class enum extends super const export import"),Xr=n("implements interface let package private protected public static yield"),Nr=n("eval arguments"),Wr=n("break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this"),Jr=/[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]/,Pr="\xaa\xb5\xba\xc0-\xd6\xd8-\xf6\xf8-\u02c1\u02c6-\u02d1\u02e0-\u02e4\u02ec\u02ee\u0370-\u0374\u0376\u0377\u037a-\u037d\u0386\u0388-\u038a\u038c\u038e-\u03a1\u03a3-\u03f5\u03f7-\u0481\u048a-\u0527\u0531-\u0556\u0559\u0561-\u0587\u05d0-\u05ea\u05f0-\u05f2\u0620-\u064a\u066e\u066f\u0671-\u06d3\u06d5\u06e5\u06e6\u06ee\u06ef\u06fa-\u06fc\u06ff\u0710\u0712-\u072f\u074d-\u07a5\u07b1\u07ca-\u07ea\u07f4\u07f5\u07fa\u0800-\u0815\u081a\u0824\u0828\u0840-\u0858\u08a0\u08a2-\u08ac\u0904-\u0939\u093d\u0950\u0958-\u0961\u0971-\u0977\u0979-\u097f\u0985-\u098c\u098f\u0990\u0993-\u09a8\u09aa-\u09b0\u09b2\u09b6-\u09b9\u09bd\u09ce\u09dc\u09dd\u09df-\u09e1\u09f0\u09f1\u0a05-\u0a0a\u0a0f\u0a10\u0a13-\u0a28\u0a2a-\u0a30\u0a32\u0a33\u0a35\u0a36\u0a38\u0a39\u0a59-\u0a5c\u0a5e\u0a72-\u0a74\u0a85-\u0a8d\u0a8f-\u0a91\u0a93-\u0aa8\u0aaa-\u0ab0\u0ab2\u0ab3\u0ab5-\u0ab9\u0abd\u0ad0\u0ae0\u0ae1\u0b05-\u0b0c\u0b0f\u0b10\u0b13-\u0b28\u0b2a-\u0b30\u0b32\u0b33\u0b35-\u0b39\u0b3d\u0b5c\u0b5d\u0b5f-\u0b61\u0b71\u0b83\u0b85-\u0b8a\u0b8e-\u0b90\u0b92-\u0b95\u0b99\u0b9a\u0b9c\u0b9e\u0b9f\u0ba3\u0ba4\u0ba8-\u0baa\u0bae-\u0bb9\u0bd0\u0c05-\u0c0c\u0c0e-\u0c10\u0c12-\u0c28\u0c2a-\u0c33\u0c35-\u0c39\u0c3d\u0c58\u0c59\u0c60\u0c61\u0c85-\u0c8c\u0c8e-\u0c90\u0c92-\u0ca8\u0caa-\u0cb3\u0cb5-\u0cb9\u0cbd\u0cde\u0ce0\u0ce1\u0cf1\u0cf2\u0d05-\u0d0c\u0d0e-\u0d10\u0d12-\u0d3a\u0d3d\u0d4e\u0d60\u0d61\u0d7a-\u0d7f\u0d85-\u0d96\u0d9a-\u0db1\u0db3-\u0dbb\u0dbd\u0dc0-\u0dc6\u0e01-\u0e30\u0e32\u0e33\u0e40-\u0e46\u0e81\u0e82\u0e84\u0e87\u0e88\u0e8a\u0e8d\u0e94-\u0e97\u0e99-\u0e9f\u0ea1-\u0ea3\u0ea5\u0ea7\u0eaa\u0eab\u0ead-\u0eb0\u0eb2\u0eb3\u0ebd\u0ec0-\u0ec4\u0ec6\u0edc-\u0edf\u0f00\u0f40-\u0f47\u0f49-\u0f6c\u0f88-\u0f8c\u1000-\u102a\u103f\u1050-\u1055\u105a-\u105d\u1061\u1065\u1066\u106e-\u1070\u1075-\u1081\u108e\u10a0-\u10c5\u10c7\u10cd\u10d0-\u10fa\u10fc-\u1248\u124a-\u124d\u1250-\u1256\u1258\u125a-\u125d\u1260-\u1288\u128a-\u128d\u1290-\u12b0\u12b2-\u12b5\u12b8-\u12be\u12c0\u12c2-\u12c5\u12c8-\u12d6\u12d8-\u1310\u1312-\u1315\u1318-\u135a\u1380-\u138f\u13a0-\u13f4\u1401-\u166c\u166f-\u167f\u1681-\u169a\u16a0-\u16ea\u16ee-\u16f0\u1700-\u170c\u170e-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176c\u176e-\u1770\u1780-\u17b3\u17d7\u17dc\u1820-\u1877\u1880-\u18a8\u18aa\u18b0-\u18f5\u1900-\u191c\u1950-\u196d\u1970-\u1974\u1980-\u19ab\u19c1-\u19c7\u1a00-\u1a16\u1a20-\u1a54\u1aa7\u1b05-\u1b33\u1b45-\u1b4b\u1b83-\u1ba0\u1bae\u1baf\u1bba-\u1be5\u1c00-\u1c23\u1c4d-\u1c4f\u1c5a-\u1c7d\u1ce9-\u1cec\u1cee-\u1cf1\u1cf5\u1cf6\u1d00-\u1dbf\u1e00-\u1f15\u1f18-\u1f1d\u1f20-\u1f45\u1f48-\u1f4d\u1f50-\u1f57\u1f59\u1f5b\u1f5d\u1f5f-\u1f7d\u1f80-\u1fb4\u1fb6-\u1fbc\u1fbe\u1fc2-\u1fc4\u1fc6-\u1fcc\u1fd0-\u1fd3\u1fd6-\u1fdb\u1fe0-\u1fec\u1ff2-\u1ff4\u1ff6-\u1ffc\u2071\u207f\u2090-\u209c\u2102\u2107\u210a-\u2113\u2115\u2119-\u211d\u2124\u2126\u2128\u212a-\u212d\u212f-\u2139\u213c-\u213f\u2145-\u2149\u214e\u2160-\u2188\u2c00-\u2c2e\u2c30-\u2c5e\u2c60-\u2ce4\u2ceb-\u2cee\u2cf2\u2cf3\u2d00-\u2d25\u2d27\u2d2d\u2d30-\u2d67\u2d6f\u2d80-\u2d96\u2da0-\u2da6\u2da8-\u2dae\u2db0-\u2db6\u2db8-\u2dbe\u2dc0-\u2dc6\u2dc8-\u2dce\u2dd0-\u2dd6\u2dd8-\u2dde\u2e2f\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303c\u3041-\u3096\u309d-\u309f\u30a1-\u30fa\u30fc-\u30ff\u3105-\u312d\u3131-\u318e\u31a0-\u31ba\u31f0-\u31ff\u3400-\u4db5\u4e00-\u9fcc\ua000-\ua48c\ua4d0-\ua4fd\ua500-\ua60c\ua610-\ua61f\ua62a\ua62b\ua640-\ua66e\ua67f-\ua697\ua6a0-\ua6ef\ua717-\ua71f\ua722-\ua788\ua78b-\ua78e\ua790-\ua793\ua7a0-\ua7aa\ua7f8-\ua801\ua803-\ua805\ua807-\ua80a\ua80c-\ua822\ua840-\ua873\ua882-\ua8b3\ua8f2-\ua8f7\ua8fb\ua90a-\ua925\ua930-\ua946\ua960-\ua97c\ua984-\ua9b2\ua9cf\uaa00-\uaa28\uaa40-\uaa42\uaa44-\uaa4b\uaa60-\uaa76\uaa7a\uaa80-\uaaaf\uaab1\uaab5\uaab6\uaab9-\uaabd\uaac0\uaac2\uaadb-\uaadd\uaae0-\uaaea\uaaf2-\uaaf4\uab01-\uab06\uab09-\uab0e\uab11-\uab16\uab20-\uab26\uab28-\uab2e\uabc0-\uabe2\uac00-\ud7a3\ud7b0-\ud7c6\ud7cb-\ud7fb\uf900-\ufa6d\ufa70-\ufad9\ufb00-\ufb06\ufb13-\ufb17\ufb1d\ufb1f-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb3e\ufb40\ufb41\ufb43\ufb44\ufb46-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\uff21-\uff3a\uff41-\uff5a\uff66-\uffbe\uffc2-\uffc7\uffca-\uffcf\uffd2-\uffd7\uffda-\uffdc",Hr="\u0300-\u036f\u0483-\u0487\u0591-\u05bd\u05bf\u05c1\u05c2\u05c4\u05c5\u05c7\u0610-\u061a\u0620-\u0649\u0672-\u06d3\u06e7-\u06e8\u06fb-\u06fc\u0730-\u074a\u0800-\u0814\u081b-\u0823\u0825-\u0827\u0829-\u082d\u0840-\u0857\u08e4-\u08fe\u0900-\u0903\u093a-\u093c\u093e-\u094f\u0951-\u0957\u0962-\u0963\u0966-\u096f\u0981-\u0983\u09bc\u09be-\u09c4\u09c7\u09c8\u09d7\u09df-\u09e0\u0a01-\u0a03\u0a3c\u0a3e-\u0a42\u0a47\u0a48\u0a4b-\u0a4d\u0a51\u0a66-\u0a71\u0a75\u0a81-\u0a83\u0abc\u0abe-\u0ac5\u0ac7-\u0ac9\u0acb-\u0acd\u0ae2-\u0ae3\u0ae6-\u0aef\u0b01-\u0b03\u0b3c\u0b3e-\u0b44\u0b47\u0b48\u0b4b-\u0b4d\u0b56\u0b57\u0b5f-\u0b60\u0b66-\u0b6f\u0b82\u0bbe-\u0bc2\u0bc6-\u0bc8\u0bca-\u0bcd\u0bd7\u0be6-\u0bef\u0c01-\u0c03\u0c46-\u0c48\u0c4a-\u0c4d\u0c55\u0c56\u0c62-\u0c63\u0c66-\u0c6f\u0c82\u0c83\u0cbc\u0cbe-\u0cc4\u0cc6-\u0cc8\u0cca-\u0ccd\u0cd5\u0cd6\u0ce2-\u0ce3\u0ce6-\u0cef\u0d02\u0d03\u0d46-\u0d48\u0d57\u0d62-\u0d63\u0d66-\u0d6f\u0d82\u0d83\u0dca\u0dcf-\u0dd4\u0dd6\u0dd8-\u0ddf\u0df2\u0df3\u0e34-\u0e3a\u0e40-\u0e45\u0e50-\u0e59\u0eb4-\u0eb9\u0ec8-\u0ecd\u0ed0-\u0ed9\u0f18\u0f19\u0f20-\u0f29\u0f35\u0f37\u0f39\u0f41-\u0f47\u0f71-\u0f84\u0f86-\u0f87\u0f8d-\u0f97\u0f99-\u0fbc\u0fc6\u1000-\u1029\u1040-\u1049\u1067-\u106d\u1071-\u1074\u1082-\u108d\u108f-\u109d\u135d-\u135f\u170e-\u1710\u1720-\u1730\u1740-\u1750\u1772\u1773\u1780-\u17b2\u17dd\u17e0-\u17e9\u180b-\u180d\u1810-\u1819\u1920-\u192b\u1930-\u193b\u1951-\u196d\u19b0-\u19c0\u19c8-\u19c9\u19d0-\u19d9\u1a00-\u1a15\u1a20-\u1a53\u1a60-\u1a7c\u1a7f-\u1a89\u1a90-\u1a99\u1b46-\u1b4b\u1b50-\u1b59\u1b6b-\u1b73\u1bb0-\u1bb9\u1be6-\u1bf3\u1c00-\u1c22\u1c40-\u1c49\u1c5b-\u1c7d\u1cd0-\u1cd2\u1d00-\u1dbe\u1e01-\u1f15\u200c\u200d\u203f\u2040\u2054\u20d0-\u20dc\u20e1\u20e5-\u20f0\u2d81-\u2d96\u2de0-\u2dff\u3021-\u3028\u3099\u309a\ua640-\ua66d\ua674-\ua67d\ua69f\ua6f0-\ua6f1\ua7f8-\ua800\ua806\ua80b\ua823-\ua827\ua880-\ua881\ua8b4-\ua8c4\ua8d0-\ua8d9\ua8f3-\ua8f7\ua900-\ua909\ua926-\ua92d\ua930-\ua945\ua980-\ua983\ua9b3-\ua9c0\uaa00-\uaa27\uaa40-\uaa41\uaa4c-\uaa4d\uaa50-\uaa59\uaa7b\uaae0-\uaae9\uaaf2-\uaaf3\uabc0-\uabe1\uabec\uabed\uabf0-\uabf9\ufb20-\ufb28\ufe00-\ufe0f\ufe20-\ufe26\ufe33\ufe34\ufe4d-\ufe4f\uff10-\uff19\uff3f",$r=new RegExp("["+Pr+"]"),_r=new RegExp("["+Pr+Hr+"]"),Gr=/[\n\r\u2028\u2029]/,Kr=/\r\n|[\n\r\u2028\u2029]/g,Qr=e.isIdentifierStart=function(e){return 65>e?36===e:91>e?!0:97>e?95===e:123>e?!0:e>=170&&$r.test(String.fromCharCode(e))},Yr=e.isIdentifierChar=function(e){return 48>e?36===e:58>e?!0:65>e?!1:91>e?!0:97>e?95===e:123>e?!0:e>=170&&_r.test(String.fromCharCode(e))},Zr={kind:"loop"},et={kind:"switch"}});
+
+	var binaryOperators = {
+		'+': '__add',
+		'-': '__subtract',
+		'*': '__multiply',
+		'/': '__divide',
+		'%': '__modulo',
+		'==': 'equals',
+		'!=': 'equals'
+	};
+
+	var unaryOperators = {
+		'-': '__negate',
+		'+': null
+	};
+
+	var fields = Base.each(
+		['add', 'subtract', 'multiply', 'divide', 'modulo', 'negate'],
+		function(name) {
+			this['__' + name] = '#' + name;
+		},
+		{}
+	);
+	Point.inject(fields);
+	Size.inject(fields);
+	Color.inject(fields);
+
+	function __$__(left, operator, right) {
+		var handler = binaryOperators[operator];
+		if (left && left[handler]) {
+			var res = left[handler](right);
+			return operator === '!=' ? !res : res;
+		}
+		switch (operator) {
+		case '+': return left + right;
+		case '-': return left - right;
+		case '*': return left * right;
+		case '/': return left / right;
+		case '%': return left % right;
+		case '==': return left == right;
+		case '!=': return left != right;
+		}
+	}
+
+	function $__(operator, value) {
+		var handler = unaryOperators[operator];
+		if (handler && value && value[handler])
+			return value[handler]();
+		switch (operator) {
+		case '+': return +value;
+		case '-': return -value;
+		}
+	}
+
+	function parse(code, options) {
+		return scope.acorn.parse(code, options);
+	}
+
+	function compile(code, url, options) {
+		if (!code)
+			return '';
+		options = options || {};
+		url = url || '';
+
+		var insertions = [];
+
+		function getOffset(offset) {
+			for (var i = 0, l = insertions.length; i < l; i++) {
+				var insertion = insertions[i];
+				if (insertion[0] >= offset)
+					break;
+				offset += insertion[1];
+			}
+			return offset;
+		}
+
+		function getCode(node) {
+			return code.substring(getOffset(node.range[0]),
+					getOffset(node.range[1]));
+		}
+
+		function getBetween(left, right) {
+			return code.substring(getOffset(left.range[1]),
+					getOffset(right.range[0]));
+		}
+
+		function replaceCode(node, str) {
+			var start = getOffset(node.range[0]),
+				end = getOffset(node.range[1]),
+				insert = 0;
+			for (var i = insertions.length - 1; i >= 0; i--) {
+				if (start > insertions[i][0]) {
+					insert = i + 1;
+					break;
+				}
+			}
+			insertions.splice(insert, 0, [start, str.length - end + start]);
+			code = code.substring(0, start) + str + code.substring(end);
+		}
+
+		function walkAST(node, parent) {
+			if (!node)
+				return;
+			for (var key in node) {
+				if (key === 'range' || key === 'loc')
+					continue;
+				var value = node[key];
+				if (Array.isArray(value)) {
+					for (var i = 0, l = value.length; i < l; i++)
+						walkAST(value[i], node);
+				} else if (value && typeof value === 'object') {
+					walkAST(value, node);
+				}
+			}
+			switch (node.type) {
+			case 'UnaryExpression':
+				if (node.operator in unaryOperators
+						&& node.argument.type !== 'Literal') {
+					var arg = getCode(node.argument);
+					replaceCode(node, '$__("' + node.operator + '", '
+							+ arg + ')');
+				}
+				break;
+			case 'BinaryExpression':
+				if (node.operator in binaryOperators
+						&& node.left.type !== 'Literal') {
+					var left = getCode(node.left),
+						right = getCode(node.right),
+						between = getBetween(node.left, node.right),
+						operator = node.operator;
+					replaceCode(node, '__$__(' + left + ','
+							+ between.replace(new RegExp('\\' + operator),
+								'"' + operator + '"')
+							+ ', ' + right + ')');
+				}
+				break;
+			case 'UpdateExpression':
+			case 'AssignmentExpression':
+				var parentType = parent && parent.type;
+				if (!(
+						parentType === 'ForStatement'
+						|| parentType === 'BinaryExpression'
+							&& /^[=!<>]/.test(parent.operator)
+						|| parentType === 'MemberExpression' && parent.computed
+				)) {
+					if (node.type === 'UpdateExpression') {
+						var arg = getCode(node.argument),
+							exp = '__$__(' + arg + ', "' + node.operator[0]
+									+ '", 1)',
+							str = arg + ' = ' + exp;
+						if (!node.prefix
+								&& (parentType === 'AssignmentExpression'
+									|| parentType === 'VariableDeclarator')) {
+							if (getCode(parent.left || parent.id) === arg)
+								str = exp;
+							str = arg + '; ' + str;
+						}
+						replaceCode(node, str);
+					} else {
+						if (/^.=$/.test(node.operator)
+								&& node.left.type !== 'Literal') {
+							var left = getCode(node.left),
+								right = getCode(node.right);
+							replaceCode(node, left + ' = __$__(' + left + ', "'
+									+ node.operator[0] + '", ' + right + ')');
+						}
+					}
+				}
+				break;
+			}
+		}
+		var sourceMap = null,
+			browser = paper.browser,
+			version = browser.versionNumber,
+			lineBreaks = /\r\n|\n|\r/mg,
+			offset = 0;
+		if (browser.chrome && version >= 30
+				|| browser.webkit && version >= 537.76
+				|| browser.firefox && version >= 23) {
+			if (window.location.href.indexOf(url) === 0) {
+				var html = document.getElementsByTagName('html')[0].innerHTML;
+				offset = html.substr(0, html.indexOf(code) + 1).match(
+						lineBreaks).length + 1;
+			}
+			var mappings = ['AAAA'];
+			mappings.length = (code.match(lineBreaks) || []).length + 1 + offset;
+			sourceMap = {
+				version: 3,
+				file: url,
+				names:[],
+				mappings: mappings.join(';AACA'),
+				sourceRoot: '',
+				sources: [url]
+			};
+			var source = options.source || !url && code;
+			if (source)
+				sourceMap.sourcesContent = [source];
+		}
+		walkAST(parse(code, { ranges: true }));
+		if (sourceMap) {
+			code = new Array(offset + 1).join('\n') + code
+					+ "\n//# sourceMappingURL=data:application/json;base64,"
+					+ (btoa(unescape(encodeURIComponent(
+						JSON.stringify(sourceMap)))))
+					+ "\n//# sourceURL=" + (url || 'paperscript');
+		}
+		return code;
+	}
+
+	function execute(code, scope, url, options) {
+		paper = scope;
+		var view = scope.getView(),
+			tool = /\s+on(?:Key|Mouse)(?:Up|Down|Move|Drag)\b/.test(code)
+					? new Tool()
+					: null,
+			toolHandlers = tool ? tool._events : [],
+			handlers = ['onFrame', 'onResize'].concat(toolHandlers),
+			params = [],
+			args = [],
+			func;
+		code = compile(code, url, options);
+		function expose(scope, hidden) {
+			for (var key in scope) {
+				if ((hidden || !/^_/.test(key)) && new RegExp('([\\b\\s\\W]|^)'
+						+ key.replace(/\$/g, '\\$') + '\\b').test(code)) {
+					params.push(key);
+					args.push(scope[key]);
+				}
+			}
+		}
+		expose({ __$__: __$__, $__: $__, paper: scope, view: view, tool: tool },
+				true);
+		expose(scope);
+		handlers = Base.each(handlers, function(key) {
+			if (new RegExp('\\s+' + key + '\\b').test(code)) {
+				params.push(key);
+				this.push(key + ': ' + key);
+			}
+		}, []).join(', ');
+		if (handlers)
+			code += '\nreturn { ' + handlers + ' };';
+		var browser = paper.browser;
+		if (browser.chrome || browser.firefox) {
+			var script = document.createElement('script'),
+				head = document.head || document.getElementsByTagName('head')[0];
+			if (browser.firefox)
+				code = '\n' + code;
+			script.appendChild(document.createTextNode(
+				'paper._execute = function(' + params + ') {' + code + '\n}'
+			));
+			head.appendChild(script);
+			func = paper._execute;
+			delete paper._execute;
+			head.removeChild(script);
+		} else {
+			func = Function(params, code);
+		}
+		var res = func.apply(scope, args) || {};
+		Base.each(toolHandlers, function(key) {
+			var value = res[key];
+			if (value)
+				tool[key] = value;
+		});
+		if (view) {
+			if (res.onResize)
+				view.setOnResize(res.onResize);
+			view.emit('resize', {
+				size: view.size,
+				delta: new Point()
+			});
+			if (res.onFrame)
+				view.setOnFrame(res.onFrame);
+			view.update();
+		}
+	}
+
+	function loadScript(script) {
+		if (/^text\/(?:x-|)paperscript$/.test(script.type)
+				&& PaperScope.getAttribute(script, 'ignore') !== 'true') {
+			var canvasId = PaperScope.getAttribute(script, 'canvas'),
+				canvas = document.getElementById(canvasId),
+				src = script.src || script.getAttribute('data-src'),
+				async = PaperScope.hasAttribute(script, 'async'),
+				scopeAttribute = 'data-paper-scope';
+			if (!canvas)
+				throw new Error('Unable to find canvas with id "'
+						+ canvasId + '"');
+			var scope = PaperScope.get(canvas.getAttribute(scopeAttribute))
+						|| new PaperScope().setup(canvas);
+			canvas.setAttribute(scopeAttribute, scope._id);
+			if (src) {
+				Http.request('get', src, function(code) {
+					execute(code, scope, src);
+				}, async);
+			} else {
+				execute(script.innerHTML, scope, script.baseURI);
+			}
+			script.setAttribute('data-paper-ignore', 'true');
+			return scope;
+		}
+	}
+
+	function loadAll() {
+		Base.each(document.getElementsByTagName('script'), loadScript);
+	}
+
+	function load(script) {
+		return script ? loadScript(script) : loadAll();
+	}
+
+	if (document.readyState === 'complete') {
+		setTimeout(loadAll);
+	} else {
+		DomEvent.add(window, { load: loadAll });
+	}
+
+	return {
+		compile: compile,
+		execute: execute,
+		load: load,
+		parse: parse
+	};
+
+}).call(this);
+
+paper = new (PaperScope.inject(Base.exports, {
+	enumerable: true,
+	Base: Base,
+	Numerical: Numerical,
+	Key: Key
+}))();
+
+if (typeof define === 'function' && define.amd) {
+	define('paper', paper);
+} else if (typeof module === 'object' && module) {
+	module.exports = paper;
+}
+
+return paper;
+};

--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -98,7 +98,6 @@
                     }
                   };
                 }
-
                 oaAnnos[oaAnnos.length - 1].on.selector.value = _this.svgOverlay.getSVGString(shapeArray);
                 annotationShapesAreEdited = true;
                 break;
@@ -172,18 +171,30 @@
         stroke: true,
         segments: true
       };
+      var hoverColor = this.state.getStateProperty('drawingToolsSettings').hoverColor;
       var annotations = [];
       for (var key in _this.annotationsToShapesMap) {
         if (_this.annotationsToShapesMap.hasOwnProperty(key)) {
           var shapeArray = _this.annotationsToShapesMap[key];
           for (var idx = 0; idx < shapeArray.length; idx++) {
+            var shapeTool = this.svgOverlay.getTool(shapeArray[idx]);
             if (shapeArray[idx].hitTest(location, hitOptions)) {
               annotations.push(shapeArray[idx].data.annotation);
+              if(shapeTool.onHover){
+                for(var k=0;k<shapeArray.length;k++){
+                  shapeTool.onHover(true,shapeArray[k],hoverColor);
+                }
+              }
               break;
+            }else{
+              if(shapeTool.onHover){
+                shapeTool.onHover(false,shapeArray[idx]);
+              }
             }
           }
         }
       }
+      this.svgOverlay.paperScope.view.draw();
       if (_this.svgOverlay.availableExternalCommentsPanel) {
         _this.eventEmitter.publish('annotationMousePosition.' + _this.parent.windowId, [annotations]);
         return;

--- a/js/src/annotations/osd-svg-ellipse.js
+++ b/js/src/annotations/osd-svg-ellipse.js
@@ -17,15 +17,18 @@
       overlay.mode = 'create';
       var segments = [];
       // point indexes
-      //       1      
-      //   0   ─   2  
-      //     /   \    
-      //  7 |     | 3 
-      //     \   /    
-      //   6   ─   4  
-      //       5      
+      //     1&2&3
+      //   0   ─   4
+      //     /   \
+      //  9 |     | 5
+      //     \   /
+      //   8   ─   6
+      //       7
+      // points 1 & 2 & 3 are workaround used to draw rotation handle
       var pixel = 1 / overlay.paperScope.view.zoom;
       segments.push(new overlay.paperScope.Point(initialPoint.x - 2 * pixel, initialPoint.y - 2 * pixel));
+      segments.push(new overlay.paperScope.Point(initialPoint.x - 1 * pixel, initialPoint.y - (Math.sqrt(2) + 1) * pixel));
+      segments.push(new overlay.paperScope.Point(initialPoint.x - 1 * pixel, initialPoint.y - (Math.sqrt(2) + 1) * pixel));
       segments.push(new overlay.paperScope.Point(initialPoint.x - 1 * pixel, initialPoint.y - (Math.sqrt(2) + 1) * pixel));
       segments.push(new overlay.paperScope.Point(initialPoint.x, initialPoint.y - 2 * pixel));
       segments.push(new overlay.paperScope.Point(initialPoint.x + (Math.sqrt(2) - 1) * pixel, initialPoint.y - 1 * pixel));
@@ -44,10 +47,57 @@
       shape.fillColor = overlay.fillColor;
       shape.fillColor.alpha = overlay.fillColorAlpha;
       shape.closed = true;
-      shape.smooth();
       shape.data.rotation = 0;
-      overlay.segment = shape.segments[4];
+      overlay.segment = shape.segments[6];
+      this.updateSelection(true, shape, overlay);
       return shape;
+    },
+
+    updateSelection: function(selected, item, overlay) {
+      if (item._name.toString().indexOf(this.idPrefix) != -1) {
+        if (item.segments.length > 10) {
+          item.removeSegment(10);
+        }
+        item.smooth({from: -7, to: 1});
+        item.selected = selected;
+        item.segments[2].selected = selected;
+        var inHandle = item.segments[7].handleIn.clone();
+        inHandle = inHandle.multiply(-1);
+        var outHandle = item.segments[7].handleOut.clone();
+        outHandle = outHandle.multiply(-1);
+        item.segments[1].handleIn = inHandle;
+        item.segments[1].handleOut = new overlay.paperScope.Point(0, 0);
+        item.segments[2].handleIn = new overlay.paperScope.Point(0, 0);
+        item.segments[2].handleOut = new overlay.paperScope.Point(0, 0);
+        item.segments[3].handleIn = new overlay.paperScope.Point(0, 0);
+        item.segments[3].handleOut = outHandle;
+        if (selected) {
+          item.segments[2].handleOut = new overlay.paperScope.Point(0, -20 / overlay.paperScope.view.zoom);
+          item.segments[2].handleOut = item.segments[2].handleOut.rotate(item.data.rotation, item.segments[2]);
+          var point = item.segments[2].point.clone();
+          point = point.add(item.segments[2].handleOut);
+          if (item.contains(point)) {
+            item.segments[2].handleOut = item.segments[2].handleOut.rotate(180, item.segments[2]);
+          }
+        } else {
+          item.segments[2].handleOut = new overlay.paperScope.Point(0, 0);
+        }
+      }
+    },
+
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
+      }
     },
 
     onMouseUp: function(event, overlay) {
@@ -62,23 +112,7 @@
           overlay.path.segments[i].point.x += event.delta.x;
           overlay.path.segments[i].point.y += event.delta.y;
         }
-      } else if (overlay.mode == 'create') {
-        overlay.path.segments[0].point.x += event.delta.x * (1 - Math.sqrt(1 / 2)) / 2;
-        overlay.path.segments[1].point.x += event.delta.x / 2;
-        overlay.path.segments[2].point.x += event.delta.x * (1 + Math.sqrt(1 / 2)) / 2;
-        overlay.path.segments[3].point.x += event.delta.x;
-        overlay.path.segments[4].point.x += event.delta.x * (1 + Math.sqrt(1 / 2)) / 2;
-        overlay.path.segments[5].point.x += event.delta.x / 2;
-        overlay.path.segments[6].point.x += event.delta.x * (1 - Math.sqrt(1 / 2)) / 2;
-        overlay.path.segments[0].point.y += event.delta.y * (1 - Math.sqrt(1 / 2)) / 2;
-        overlay.path.segments[2].point.y += event.delta.y * (1 - Math.sqrt(1 / 2)) / 2;
-        overlay.path.segments[3].point.y += event.delta.y / 2;
-        overlay.path.segments[4].point.y += event.delta.y * (1 + Math.sqrt(1 / 2)) / 2;
-        overlay.path.segments[5].point.y += event.delta.y;
-        overlay.path.segments[6].point.y += event.delta.y * (1 + Math.sqrt(1 / 2)) / 2;
-        overlay.path.segments[7].point.y += event.delta.y / 2;
-        overlay.path.smooth();
-      } else if (overlay.mode == 'deform') {
+      } else if (overlay.mode == 'create' || overlay.mode == 'deform') {
         var idx = -1;
         for (var l = 0; l < overlay.path.segments.length; l++) {
           if (overlay.path.segments[l] == overlay.segment) {
@@ -86,39 +120,92 @@
             break;
           }
         }
-        if (idx % 2 == 1) {
-          var oldPoint = new overlay.paperScope.Point(overlay.segment.point.x - overlay.path.position.x, overlay.segment.point.y - overlay.path.position.y);
-          var newPoint = new overlay.paperScope.Point(overlay.segment.point.x - overlay.path.position.x + event.delta.x, overlay.segment.point.y - overlay.path.position.y + event.delta.y);
-          var scale = Math.sqrt(newPoint.x * newPoint.x + newPoint.y * newPoint.y) / Math.sqrt(oldPoint.x * oldPoint.x + oldPoint.y * oldPoint.y);
+        if (idx === -1) {
+          var segment = overlay.path.segments[2];
+          var center = overlay.path.position;
+          var oldPoint = new overlay.paperScope.Point(event.point.x - center.x, event.point.y - center.y);
+          var newPoint = new overlay.paperScope.Point(event.point.x - center.x + event.delta.x, event.point.y - center.y + event.delta.y);
           var rotation = Math.atan2(newPoint.y, newPoint.x) - Math.atan2(oldPoint.y, oldPoint.x);
           rotation = rotation * (180 / Math.PI);
-          overlay.path.scale(scale);
           overlay.path.rotate(rotation, overlay.path.position);
           overlay.path.data.rotation += rotation;
         } else {
-          // code switches one of the 4 segments with indexes 0,2,4,6 to prevent scaling with negative value almost equal to 0.
-          // this scenario is chrome bug which paints the whole image with the color of the border and the internal area of the ellipse is transparent.
+          var translation = new overlay.paperScope.Point(event.delta.x, event.delta.y);
           var rot = overlay.path.data.rotation;
-          var rotScale;
-          var updatedSegment;
-          var updatedPosition = {
-            x: event.delta.x + overlay.segment.point.x,
-            y: event.delta.y + overlay.segment.point.y
-          };
-          do {
-            updatedSegment = overlay.path.segments[idx];
-            var oldRotPoint = new overlay.paperScope.Point(updatedSegment.point.x - overlay.path.position.x, updatedSegment.point.y - overlay.path.position.y);
-            var newRotPoint = new overlay.paperScope.Point(updatedPosition.x - overlay.path.position.x, updatedPosition.y - overlay.path.position.y);
-            oldRotPoint = oldRotPoint.rotate(-rot);
-            newRotPoint = newRotPoint.rotate(-rot);
-            rotScale = new overlay.paperScope.Point(newRotPoint.x / oldRotPoint.x, newRotPoint.y / oldRotPoint.y);
-            idx = (idx + 2) % 8;
-          } while (rotScale.x < 0 || rotScale.y < 0);
-          overlay.segment = updatedSegment;
-          overlay.path.rotate(-rot, overlay.path.position);
-          overlay.path.scale(rotScale);
-          overlay.path.rotate(rot, overlay.path.position);
+          translation = translation.rotate(-rot);
+          var translationX = new overlay.paperScope.Point(translation.x, 0);
+          translationX = translationX.rotate(rot);
+          var translationY = new overlay.paperScope.Point(0, translation.y);
+          translationY = translationY.rotate(rot);
+          if (idx === 0 || idx === 4 || idx === 6 || idx === 8) {
+            translationX = translationX.multiply(2 / (1 + Math.sqrt(1 / 2)));
+            translationY = translationY.multiply(2 / (1 + Math.sqrt(1 / 2)));
+          }
+          var moveTopSize = idx === 0 || idx === 1 || idx === 2 || idx === 3 || idx === 4;
+          var moveBottomSize = idx === 6 || idx === 7 || idx === 8;
+          var moveRightSize = idx === 4 || idx === 5 || idx === 6;
+          var moveLeftSize = idx === 0 || idx === 8 || idx === 9;
+          if (moveTopSize) {
+            overlay.path.segments[1].point = overlay.path.segments[1].point.add(translationY);
+            overlay.path.segments[2].point = overlay.path.segments[2].point.add(translationY);
+            overlay.path.segments[3].point = overlay.path.segments[3].point.add(translationY);
+            var trTop = translationY.clone();
+            trTop = trTop.multiply((1 + Math.sqrt(1 / 2)) / 2);
+            overlay.path.segments[0].point = overlay.path.segments[0].point.add(trTop);
+            overlay.path.segments[4].point = overlay.path.segments[4].point.add(trTop);
+            trTop = trTop.multiply((1 - Math.sqrt(1 / 2)) / (1 + Math.sqrt(1 / 2)));
+            overlay.path.segments[6].point = overlay.path.segments[6].point.add(trTop);
+            overlay.path.segments[8].point = overlay.path.segments[8].point.add(trTop);
+          }
+          if (moveBottomSize) {
+            overlay.path.segments[7].point = overlay.path.segments[7].point.add(translationY);
+            var trBottom = translationY.clone();
+            trBottom = trBottom.multiply((1 + Math.sqrt(1 / 2)) / 2);
+            overlay.path.segments[6].point = overlay.path.segments[6].point.add(trBottom);
+            overlay.path.segments[8].point = overlay.path.segments[8].point.add(trBottom);
+            trBottom = trBottom.multiply((1 - Math.sqrt(1 / 2)) / (1 + Math.sqrt(1 / 2)));
+            overlay.path.segments[0].point = overlay.path.segments[0].point.add(trBottom);
+            overlay.path.segments[4].point = overlay.path.segments[4].point.add(trBottom);
+          }
+          if (moveTopSize || moveBottomSize) {
+            translationY = translationY.multiply(0.5);
+            overlay.path.segments[5].point = overlay.path.segments[5].point.add(translationY);
+            overlay.path.segments[9].point = overlay.path.segments[9].point.add(translationY);
+          }
+          if (moveRightSize) {
+            overlay.path.segments[5].point = overlay.path.segments[5].point.add(translationX);
+            var trRight = translationX.clone();
+            trRight = trRight.multiply((1 + Math.sqrt(1 / 2)) / 2);
+            overlay.path.segments[4].point = overlay.path.segments[4].point.add(trRight);
+            overlay.path.segments[6].point = overlay.path.segments[6].point.add(trRight);
+            trRight = trRight.multiply((1 - Math.sqrt(1 / 2)) / (1 + Math.sqrt(1 / 2)));
+            overlay.path.segments[0].point = overlay.path.segments[0].point.add(trRight);
+            overlay.path.segments[8].point = overlay.path.segments[8].point.add(trRight);
+          }
+          if (moveLeftSize) {
+            overlay.path.segments[9].point = overlay.path.segments[9].point.add(translationX);
+            var trLeft = translationX.clone();
+            trLeft = trLeft.multiply((1 + Math.sqrt(1 / 2)) / 2);
+            overlay.path.segments[0].point = overlay.path.segments[0].point.add(trLeft);
+            overlay.path.segments[8].point = overlay.path.segments[8].point.add(trLeft);
+            trLeft = trLeft.multiply((1 - Math.sqrt(1 / 2)) / (1 + Math.sqrt(1 / 2)));
+            overlay.path.segments[4].point = overlay.path.segments[4].point.add(trLeft);
+            overlay.path.segments[6].point = overlay.path.segments[6].point.add(trLeft);
+          }
+          if (moveRightSize || moveLeftSize) {
+            translationX = translationX.multiply(0.5);
+            overlay.path.segments[1].point = overlay.path.segments[1].point.add(translationX);
+            overlay.path.segments[2].point = overlay.path.segments[2].point.add(translationX);
+            overlay.path.segments[3].point = overlay.path.segments[3].point.add(translationX);
+            overlay.path.segments[7].point = overlay.path.segments[7].point.add(translationX);
+          }
+          var point = overlay.path.segments[2].point.clone();
+          point = point.add(overlay.path.segments[2].handleOut);
+          if (overlay.path.contains(point)) {
+            overlay.path.segments[2].handleOut = overlay.path.segments[2].handleOut.rotate(180, overlay.path.segments[2]);
+          }
         }
+        overlay.updateSelection(true, overlay.path, overlay);
       }
     },
 
@@ -130,22 +217,62 @@
       var hitResult = overlay.paperScope.project.hitTest(event.point, overlay.hitOptions);
       if (hitResult && hitResult.item._name.toString().indexOf(this.idPrefix) != -1) {
         if (overlay.mode != 'deform' && overlay.mode != 'translate' && overlay.mode != 'create') {
-          if (hitResult.type == 'segment') {
+          if (hitResult.type == 'segment' || hitResult.type == 'handle-out') {
             overlay.mode = 'deform';
             overlay.segment = null;
             overlay.path = null;
-            var segments = hitResult.item.segments;
-            for (var idx = 0; idx < segments.length; idx++) {
-              if (segments[idx] == hitResult.segment) {
-                if (idx % 2 === 0) {
-                  document.body.style.cursor = "move";
-                } else {
-                  jQuery('body').awesomeCursor('repeat', {
-                    color: 'white',
-                    hotspot: 'center'
-                  });
-                }
+            if (hitResult.type == 'handle-out') {
+              jQuery('body').awesomeCursor('repeat', {
+                color: 'white',
+                hotspot: 'center'
+              });
+            } else {
+              var cursor = '';
+              var rotation = hitResult.item.data.rotation;
+              switch (hitResult.segment) {
+                case hitResult.item.segments[0]:
+                  cursor = 'arrows-v';
+                  rotation -= 45;
+                  break;
+                case hitResult.item.segments[1]:
+                  cursor = 'arrows-v';
+                  break;
+                case hitResult.item.segments[2]:
+                  cursor = 'arrows-v';
+                  break;
+                case hitResult.item.segments[3]:
+                  cursor = 'arrows-v';
+                  break;
+                case hitResult.item.segments[4]:
+                  cursor = 'arrows-v';
+                  rotation += 45;
+                  break;
+                case hitResult.item.segments[5]:
+                  cursor = 'arrows-h';
+                  break;
+                case hitResult.item.segments[6]:
+                  cursor = 'arrows-v';
+                  rotation -= 45;
+                  break;
+                case hitResult.item.segments[7]:
+                  cursor = 'arrows-v';
+                  break;
+                case hitResult.item.segments[8]:
+                  cursor = 'arrows-v';
+                  rotation += 45;
+                  break;
+                case hitResult.item.segments[9]:
+                  cursor = 'arrows-h';
+                  break;
+                default:
+                  cursor = 'default';
+                  break;
               }
+              jQuery('body').awesomeCursor(cursor, {
+                color: 'white',
+                hotspot: 'center',
+                rotate: rotation
+              });
             }
           } else {
             overlay.mode = 'translate';
@@ -172,6 +299,9 @@
           overlay.segment = null;
           overlay.path = null;
           overlay.mode = '';
+        } else if (hitResult.type == 'handle-out') {
+          overlay.path = hitResult.item;
+          overlay.segment = null;
         } else {
           overlay.path = hitResult.item;
           overlay.segment = hitResult.segment;

--- a/js/src/annotations/osd-svg-freehand.js
+++ b/js/src/annotations/osd-svg-freehand.js
@@ -26,6 +26,25 @@
       return shape;
     },
 
+    updateSelection: function(selected, item, overlay) {
+      if (item._name.toString().indexOf(this.idPrefix) != -1) {
+        item.selected = selected;
+      }
+    },
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
+      }
+    },
     onMouseUp: function(event, overlay) {
       if (overlay.path) {
         overlay.path.simplify();

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -31,8 +31,10 @@
       availableAnnotationDrawingTools: availableAnnotationDrawingTools,
       availableExternalCommentsPanel: availableExternalCommentsPanel,
       dashArray: [],
-      fixedShapeSize: 10,
+      fixedShapeSize: drawingToolsSettings.fixedShapeSize,
+      shapeHandleSize:drawingToolsSettings.shapeHandleSize,
       hitOptions: {
+        handles: true,
         stroke: true,
         segments: true,
         tolerance: 5
@@ -66,8 +68,8 @@
     this.viewer.addHandler('resize', _thisResize);
     this.viewer.addHandler('rotate', _thisResize);
     this.viewer.addHandler('constrain', _thisResize);
-    
-    
+
+
     _this.eventEmitter.subscribe('toggleDrawingTool.' + _this.windowId, function(event, tool) {
       jQuery('#' + osdViewerId).parent().find('.hud-container').find('.draw-tool').removeClass('selected');
       if (_this.disabled) {
@@ -135,7 +137,7 @@
       this.paperScope = new paper.PaperScope();
       this.paperScope.setup('draw_canvas_' + _this.windowId);
       this.paperScope.activate();
-      this.paperScope.project.options.handleSize = 10;
+      this.paperScope.project.options.handleSize = _this.shapeHandleSize;
       jQuery(_this.canvas).attr('keepalive', 'true');
       this.paperScope.view.onFrame = function(event) {
         if (_this.paperScope.snapPoint) {
@@ -185,7 +187,6 @@
     },
 
     onMouseDrag: function(event) {
-      var _this = this;
       if (!this.overlay.disabled) {
         event.stopPropagation();
         this.overlay.currentTool.onMouseDrag(event, this.overlay);
@@ -194,15 +195,15 @@
           'x': event.event.clientX,
           'y': event.event.clientY
         };
-        _this.overlay.eventEmitter.publish('updateTooltips.' + this.overlay.windowId, [event.point, absolutePoint]);
+        this.overlay.eventEmitter.publish('updateTooltips.' + this.overlay.windowId, [event.point, absolutePoint]);
       }
       this.overlay.paperScope.view.draw();
     },
 
     onMouseMove: function(event) {
-      var _this = this;
       this.overlay.cursorLocation = event.point;
       if (!this.overlay.disabled) {
+        // We are in drawing mode
         if (this.overlay.paperScope.project.hitTest(event.point, this.overlay.hitOptions)) {
           document.body.style.cursor = "pointer";
         } else {
@@ -215,13 +216,12 @@
           'x': event.event.clientX,
           'y': event.event.clientY
         };
-        _this.overlay.eventEmitter.publish('updateTooltips.' + this.overlay.windowId, [event.point, absolutePoint]);
+        this.overlay.eventEmitter.publish('updateTooltips.' + this.overlay.windowId, [event.point, absolutePoint]);
       }
       this.overlay.paperScope.view.draw();
     },
 
     onMouseDown: function(event) {
-      var _this = this;
       if (this.overlay.disabled) {
         return;
       }
@@ -239,8 +239,8 @@
           prefix = prefix.substring(0, prefix.lastIndexOf('_') + 1);
           for (var j = 0; j < this.overlay.tools.length; j++) {
             if (this.overlay.tools[j].idPrefix == prefix) {
-              _this.overlay.eventEmitter.publish('toggleDrawingTool.' + this.overlay.windowId, this.overlay.tools[j].logoClass);
-              this.overlay.paperScope.project.activeLayer.selected = false;
+              this.overlay.eventEmitter.publish('toggleDrawingTool.' + this.overlay.windowId, this.overlay.tools[j].logoClass);
+              this.overlay.updateSelection(false, this.overlay.paperScope.project.activeLayer);
               this.overlay.hoveredPath = null;
               this.overlay.segment = null;
               this.overlay.path = null;
@@ -287,6 +287,17 @@
       }
     },
 
+    updateSelection: function(selected, item) {
+      if(item && item._name){
+        for (var i = 0; i < this.tools.length; i++) {
+          if (item._name.toString().indexOf(this.tools[i].idPrefix) != -1) {
+            this.tools[i].updateSelection(selected, item, this);
+            break;
+          }
+        }
+      }
+    },
+
     resize: function() {
       var viewportBounds = this.viewer.viewport.getBounds(true);
       /* in viewport coordinates */
@@ -323,34 +334,34 @@
     hover: function() {
       if (!this.currentTool) {
         if (this.hoveredPath) {
-          this.hoveredPath.selected = false;
+          this.updateSelection(false, this.hoveredPath);
           this.hoveredPath = null;
         }
       } else if (this.hoveredPath) {
         if (this.hoveredPath._name.toString().indexOf(this.currentTool.idPrefix) == -1) {
-          this.hoveredPath.selected = false;
+          this.updateSelection(false, this.hoveredPath);
           this.hoveredPath = null;
         }
         if (this.path && this.path._name.toString().indexOf(this.currentTool.idPrefix) != -1) {
           if (this.hoveredPath) {
-            this.hoveredPath.selected = false;
+            this.updateSelection(false, this.hoveredPath);
           }
           this.hoveredPath = this.path;
-          this.hoveredPath.selected = true;
+          this.updateSelection(true, this.hoveredPath);
         }
       } else if (this.path && this.path._name.toString().indexOf(this.currentTool.idPrefix) != -1) {
         this.hoveredPath = this.path;
-        this.hoveredPath.selected = true;
+        this.updateSelection(true, this.hoveredPath);
       }
     },
 
     removeFocus: function() {
       if (this.hoveredPath) {
-        this.hoveredPath.selected = false;
+        this.updateSelection(false, this.hoveredPath);
         this.hoveredPath = null;
       }
       if (this.path) {
-        this.path.selected = false;
+        this.updateSelection(false, this.path);
         this.path = null;
       }
     },
@@ -361,17 +372,34 @@
     },
 
     restoreDraftShapes: function() {
-      this.draftPaths = [];
+      this.clearDraftData();
       this.removeFocus();
+    },
+
+    // get the tool which controls given shape
+    getTool:function(shape){
+      for(var i=0;i<this.tools.length;i++){
+        if(shape.name.toString().indexOf(this.tools[i].idPrefix) !== -1){
+          return this.tools[i];
+        }
+      }
     },
 
     // replaces paper.js objects with the required properties only.
     // 'shapes' coordinates are image coordiantes
     replaceShape: function(shape, annotation) {
+
+      //backward compatibility when changing shapes points
+      var shapeTool = this.getTool(shape);
+      if(shapeTool && shapeTool.SEGMENT_POINTS_COUNT && shapeTool.SEGMENT_POINTS_COUNT !== shape.segments.length){
+        shapeTool.adaptSegments(shape,this);
+      }
+
       var cloned = new this.paperScope.Path({
         segments: shape.segments,
         name: shape.name
       });
+
       cloned.strokeWidth = 1 / this.paperScope.view.zoom;
       cloned.strokeColor = shape.strokeColor;
       cloned.dashArray = shape.dashArray;
@@ -400,8 +428,8 @@
       var rect = new $.Rectangle();
       var newShape = this.viewer.viewport.viewportToImageRectangle(shape);
       var initialPoint = {
-        'x': newShape.x,
-        'y': newShape.y
+        'x': newShape.x * scale,
+        'y': newShape.y * scale
       };
       var currentMode = this.mode;
       var currentPath = this.path;
@@ -415,14 +443,14 @@
       this.path = rect.createShape(initialPoint, this);
       var eventData = {
         'delta': {
-          'x': newShape.width,
-          'y': newShape.height
+          'x': newShape.width * scale,
+          'y': newShape.height * scale
         }
       };
       rect.onMouseDrag(eventData, this);
       paperItems.push(this.path);
       paperItems[0].data.annotation = annotation;
-      paperItems[0].selected = false;
+      this.updateSelection(false, paperItems[0]);
       this.strokeColor = strokeColor;
       this.fillColor = fillColor;
       this.fillColorAlpha = fillColorAlpha;
@@ -506,25 +534,23 @@
     },
 
     disable: function() {
-      var _this = this;
       this.disabled = true;
-      _this.eventEmitter.publish('hideDrawTools.' + this.windowId);
-      _this.eventEmitter.publish('disableBorderColorPicker.' + this.windowId, this.disabled);
-      _this.eventEmitter.publish('disableFillColorPicker.' + this.windowId, this.disabled);
-      _this.eventEmitter.publish('enableTooltips.' + this.windowId);
+      this.eventEmitter.publish('hideDrawTools.' + this.windowId);
+      this.eventEmitter.publish('disableBorderColorPicker.' + this.windowId, this.disabled);
+      this.eventEmitter.publish('disableFillColorPicker.' + this.windowId, this.disabled);
+      this.eventEmitter.publish('enableTooltips.' + this.windowId);
       this.deselectAll();
     },
 
     enable: function() {
-      var _this = this;
       var setDefaultTool = this.disabled;
       this.disabled = false;
-      _this.eventEmitter.publish('showDrawTools.' + this.windowId);
-      _this.eventEmitter.publish('disableBorderColorPicker.' + this.windowId, this.disabled);
-      _this.eventEmitter.publish('disableFillColorPicker.' + this.windowId, this.disabled);
-      _this.eventEmitter.publish('disableTooltips.' + this.windowId);
+      this.eventEmitter.publish('showDrawTools.' + this.windowId);
+      this.eventEmitter.publish('disableBorderColorPicker.' + this.windowId, this.disabled);
+      this.eventEmitter.publish('disableFillColorPicker.' + this.windowId, this.disabled);
+      this.eventEmitter.publish('disableTooltips.' + this.windowId);
       if (setDefaultTool) {
-        _this.eventEmitter.publish('toggleDefaultDrawingTool.' + this.windowId);
+        this.eventEmitter.publish('toggleDefaultDrawingTool.' + this.windowId);
       }
     },
 
@@ -533,8 +559,7 @@
     },
 
     destroyCommentPanel: function() {
-      var _this = this;
-      _this.eventEmitter.publish('removeTooltips.' + this.windowId);
+      this.eventEmitter.publish('removeTooltips.' + this.windowId);
       jQuery(this.canvas).parents('.mirador-osd').qtip('destroy', true);
       this.commentPanel = null;
     },
@@ -548,6 +573,7 @@
       if (shapes.length > 1) {
         svg += "<g>";
         for (var i = 0; i < shapes.length; i++) {
+          this.updateSelection(false,shapes[i]);
           if (shapes[i].data.fixedSize) {
             this.fitFixedSizeShapes(shapes[i]);
           }
@@ -560,6 +586,7 @@
         }
         svg += "</g>";
       } else {
+        this.updateSelection(false,shapes[0]);
         if (shapes[0].data.fixedSize) {
           this.fitFixedSizeShapes(shapes[0]);
         }
@@ -580,10 +607,10 @@
         return;
       }
       if (this.hoveredPath) {
-        this.hoveredPath.selected = false;
+        this.updateSelection(false, this.hoveredPath);
       }
       this.hoveredPath = shape;
-      this.hoveredPath.selected = true;
+      this.updateSelection(true, this.hoveredPath);
       this.segment = null;
       this.path = null;
       this.mode = '';
@@ -594,11 +621,12 @@
         eventEmitter: this.eventEmitter,
         windowId: this.windowId
       });
-      var _this = this;
-      if (_this.availableExternalCommentsPanel) {
-        _this.eventEmitter.publish('annotationShapeCreated.' + _this.windowId, [_this, shape]);
+
+      if (this.availableExternalCommentsPanel) {
+        this.eventEmitter.publish('annotationShapeCreated.' + _this.windowId, [_this, shape]);
         return;
       }
+      var _this = this;
       annoTooltip.showEditor({
         annotation: {},
         onAnnotationCreated: function(oaAnno) {
@@ -611,7 +639,6 @@
               "value": svg
             }
           };
-
           //save to endpoint
           _this.eventEmitter.publish('annotationCreated.' + _this.windowId, [oaAnno, shape]);
         },
@@ -627,6 +654,7 @@
     clearDraftData: function() {
       var _this = this;
       for (var idx = 0; idx < _this.draftPaths.length; idx++) {
+        _this.updateSelection(false, this.draftPaths[idx]);
         _this.draftPaths[idx].remove();
       }
       _this.draftPaths = [];
@@ -634,7 +662,6 @@
         _this.path.remove();
       }
       _this.paperScope.view.update(true);
-      _this.paperScope.project.activeLayer.selected = false;
       _this.hoveredPath = null;
       _this.segment = null;
       _this.path = null;

--- a/js/src/annotations/osd-svg-pin.js
+++ b/js/src/annotations/osd-svg-pin.js
@@ -16,10 +16,15 @@
     createShape: function(initialPoint, overlay) {
       overlay.mode = 'create';
       var _this = this;
-      var pathData = '';
       var size = overlay.fixedShapeSize;
+      var pathData = '';
       pathData += 'M' + initialPoint.x + ',' + initialPoint.y;
-      pathData += 'c' + (size * -2) + ',' + (size * -3) + ' ' + (size * 2) + ',' + (size * -3) + ' 0,0z';
+      pathData += ' Q' + initialPoint.x + ',' + (initialPoint.y - size);
+      pathData += ' ' + (initialPoint.x + size) + ',' + (initialPoint.y - 2 * size);
+      pathData += ' A' + size + ',' + size + ' 0 1 0';
+      pathData += ' ' + (initialPoint.x - size) + ',' + (initialPoint.y - 2 * size);
+      pathData += ' Q' + initialPoint.x + ',' + (initialPoint.y - size);
+      pathData += ' ' + initialPoint.x + ',' + initialPoint.y;
       var shape = new overlay.paperScope.Path(pathData);
       shape.name = overlay.getName(_this);
       shape.dashArray = overlay.dashArray;
@@ -30,6 +35,33 @@
       shape.closed = true;
       overlay.fitFixedSizeShapes(shape);
       return shape;
+    },
+
+    updateSelection: function(selected, item, overlay) {
+      var selectedStrokeColor = 'red';
+      //item.selected = selected;
+      if (item._name.toString().indexOf(this.idPrefix) != -1) {
+        if(selected){
+         item.strokeColor = selectedStrokeColor;
+        }else{
+          item.strokeColor = overlay.strokeColor;
+        }
+      }
+    },
+    
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
+      }
     },
 
     onMouseUp: function(event, overlay) {

--- a/js/src/annotations/osd-svg-polygon.js
+++ b/js/src/annotations/osd-svg-polygon.js
@@ -26,6 +26,27 @@
       return shape;
     },
 
+    updateSelection: function(selected, item, overlay) {
+      if (item._name.toString().indexOf(this.idPrefix) != -1) {
+        item.selected = selected;
+      }
+    },
+
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
+      }
+    },
+
     onMouseUp: function(event, overlay) {
       // Empty block.
     },

--- a/js/src/annotations/osd-svg-rectangle.js
+++ b/js/src/annotations/osd-svg-rectangle.js
@@ -11,31 +11,17 @@
 
   $.Rectangle.prototype = {
     init: function() {
+      this.SEGMENT_POINTS_COUNT = 9;
     },
 
     createShape: function(initialPoint, overlay) {
       overlay.mode = 'create';
-      var segments = [];
-      // point indexes
-      // 0     1     2
-      //   ┌ ─ ─ ─ ┐  
-      // 7 │       │ 3
-      //   └ ─ ─ ─ ┘  
-      // 6     5     4
       var pixel = 1 / overlay.paperScope.view.zoom;
-      segments.push(new overlay.paperScope.Point(initialPoint.x - 2 * pixel, initialPoint.y - 2 * pixel));
-      segments.push(new overlay.paperScope.Point(initialPoint.x - 1 * pixel, initialPoint.y - 2 * pixel));
-      segments.push(new overlay.paperScope.Point(initialPoint.x, initialPoint.y - 2 * pixel));
-      segments.push(new overlay.paperScope.Point(initialPoint.x, initialPoint.y - 1 * pixel));
-      segments.push(new overlay.paperScope.Point(initialPoint.x, initialPoint.y));
-      segments.push(new overlay.paperScope.Point(initialPoint.x - 1 * pixel, initialPoint.y));
-      segments.push(new overlay.paperScope.Point(initialPoint.x - 2 * pixel, initialPoint.y));
-      segments.push(new overlay.paperScope.Point(initialPoint.x - 2 * pixel, initialPoint.y - 1 * pixel));
-      var _this = this;
+      var segments = this._createSegments(initialPoint,pixel,overlay);
       var shape = new overlay.paperScope.Path({
         segments: segments,
         fullySelected: true,
-        name: overlay.getName(_this)
+        name: overlay.getName(this)
       });
       shape.dashArray = overlay.dashArray;
       shape.strokeWidth = 1 / overlay.paperScope.view.zoom;
@@ -44,8 +30,70 @@
       shape.fillColor.alpha = overlay.fillColorAlpha;
       shape.closed = true;
       shape.data.rotation = 0;
-      overlay.segment = shape.segments[4];
+      overlay.segment = shape.segments[5];
+      this.updateSelection(true, shape, overlay);
       return shape;
+    },
+
+    _createSegments:function(initialPoint,pixel, overlay){
+      var segments = [];
+      // point indexes
+      // 0    1&2    3
+      //   ┌ ─ ─ ─ ┐
+      // 8 │       │ 4
+      //   └ ─ ─ ─ ┘
+      // 7     6     5
+      // points 1 & 2 are workaround used to draw rotation handle
+
+      segments.push(new overlay.paperScope.Point(initialPoint.x - 2 * pixel, initialPoint.y - 2 * pixel));
+      segments.push(new overlay.paperScope.Point(initialPoint.x - 1 * pixel, initialPoint.y - 2 * pixel));
+      segments.push(new overlay.paperScope.Point(initialPoint.x - 1 * pixel, initialPoint.y - 2 * pixel));
+      segments.push(new overlay.paperScope.Point(initialPoint.x, initialPoint.y - 2 * pixel));
+      segments.push(new overlay.paperScope.Point(initialPoint.x, initialPoint.y - 1 * pixel));
+      segments.push(new overlay.paperScope.Point(initialPoint.x, initialPoint.y));
+      segments.push(new overlay.paperScope.Point(initialPoint.x - 1 * pixel, initialPoint.y));
+      segments.push(new overlay.paperScope.Point(initialPoint.x - 2 * pixel, initialPoint.y));
+      segments.push(new overlay.paperScope.Point(initialPoint.x - 2 * pixel, initialPoint.y - 1 * pixel));
+      return segments;
+    },
+
+    updateSelection: function(selected, item, overlay) {
+      if (item._name.toString().indexOf(this.idPrefix) != -1) {
+        item.fullySelected = selected;
+        if (selected) {
+          item.segments[1].handleOut = new overlay.paperScope.Point(0, -20 / overlay.paperScope.view.zoom);
+          item.segments[1].handleOut = item.segments[1].handleOut.rotate(item.data.rotation, item.segments[1]);
+          var point = item.segments[1].point.clone();
+          point = point.add(item.segments[1].handleOut);
+          if (item.contains(point)) {
+            item.segments[1].handleOut = item.segments[1].handleOut.rotate(180, item.segments[1]);
+          }
+        } else {
+          item.segments[1].handleOut = new overlay.paperScope.Point(0, 0);
+        }
+      }
+    },
+    //TODO Radoslav unit test
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
+      }
+    },
+
+    // Old rectangle shapes does not have rotation handle point
+    // add it manually for old shapes
+    adaptSegments:function(shape,overlay){
+      var handleSegment = shape.segments[1].clone();
+      shape.segments.splice(1,0,handleSegment);
     },
 
     onMouseUp: function(event, overlay) {
@@ -60,18 +108,7 @@
           overlay.path.segments[i].point.x += event.delta.x;
           overlay.path.segments[i].point.y += event.delta.y;
         }
-      } else if (overlay.mode == 'create') {
-        overlay.path.segments[1].point.x += event.delta.x / 2;
-        overlay.path.segments[2].point.x += event.delta.x;
-        overlay.path.segments[3].point.x += event.delta.x;
-        overlay.path.segments[4].point.x += event.delta.x;
-        overlay.path.segments[5].point.x += event.delta.x / 2;
-        overlay.path.segments[3].point.y += event.delta.y / 2;
-        overlay.path.segments[4].point.y += event.delta.y;
-        overlay.path.segments[5].point.y += event.delta.y;
-        overlay.path.segments[6].point.y += event.delta.y;
-        overlay.path.segments[7].point.y += event.delta.y / 2;
-      } else if (overlay.mode == 'deform') {
+      } else if (overlay.mode == 'create' || overlay.mode == 'deform') {
         var idx = -1;
         for (var l = 0; l < overlay.path.segments.length; l++) {
           if (overlay.path.segments[l] == overlay.segment) {
@@ -79,25 +116,64 @@
             break;
           }
         }
-        if (idx % 2 == 1) {
-          var oldPoint = new overlay.paperScope.Point(overlay.segment.point.x - overlay.path.position.x, overlay.segment.point.y - overlay.path.position.y);
-          var newPoint = new overlay.paperScope.Point(overlay.segment.point.x - overlay.path.position.x + event.delta.x, overlay.segment.point.y - overlay.path.position.y + event.delta.y);
-          var scale = Math.sqrt(newPoint.x * newPoint.x + newPoint.y * newPoint.y) / Math.sqrt(oldPoint.x * oldPoint.x + oldPoint.y * oldPoint.y);
+        if (idx === -1) {
+          var segment = overlay.path.segments[1];
+          var center = overlay.path.position;
+          var oldPoint = new overlay.paperScope.Point(event.point.x - center.x, event.point.y - center.y);
+          var newPoint = new overlay.paperScope.Point(event.point.x - center.x + event.delta.x, event.point.y - center.y + event.delta.y);
           var rotation = Math.atan2(newPoint.y, newPoint.x) - Math.atan2(oldPoint.y, oldPoint.x);
           rotation = rotation * (180 / Math.PI);
-          overlay.path.scale(scale);
           overlay.path.rotate(rotation, overlay.path.position);
           overlay.path.data.rotation += rotation;
         } else {
-          var oldRotPoint = new overlay.paperScope.Point(overlay.segment.point.x - overlay.path.position.x, overlay.segment.point.y - overlay.path.position.y);
-          var newRotPoint = new overlay.paperScope.Point(overlay.segment.point.x - overlay.path.position.x + event.delta.x, overlay.segment.point.y - overlay.path.position.y + event.delta.y);
+          var translation = new overlay.paperScope.Point(event.delta.x, event.delta.y);
           var rot = overlay.path.data.rotation;
-          oldRotPoint = oldRotPoint.rotate(-rot);
-          newRotPoint = newRotPoint.rotate(-rot);
-          var rotScale = new overlay.paperScope.Point(newRotPoint.x / oldRotPoint.x, newRotPoint.y / oldRotPoint.y);
-          overlay.path.rotate(-rot, overlay.path.position);
-          overlay.path.scale(rotScale);
-          overlay.path.rotate(rot, overlay.path.position);
+          translation = translation.rotate(-rot);
+          var translationX = new overlay.paperScope.Point(translation.x, 0);
+          translationX = translationX.rotate(rot);
+          var translationY = new overlay.paperScope.Point(0, translation.y);
+          translationY = translationY.rotate(rot);
+          var moveTopSize = idx === 0 || idx === 1 || idx === 2 || idx === 3;
+          var moveBottomSize = idx === 5 || idx === 6 || idx === 7;
+          var moveRightSize = idx === 3 || idx === 4 || idx === 5;
+          var moveLeftSize = idx === 0 || idx === 7 || idx === 8;
+          if (moveTopSize) {
+            overlay.path.segments[0].point = overlay.path.segments[0].point.add(translationY);
+            overlay.path.segments[1].point = overlay.path.segments[1].point.add(translationY);
+            overlay.path.segments[2].point = overlay.path.segments[2].point.add(translationY);
+            overlay.path.segments[3].point = overlay.path.segments[3].point.add(translationY);
+          }
+          if (moveBottomSize) {
+            overlay.path.segments[5].point = overlay.path.segments[5].point.add(translationY);
+            overlay.path.segments[6].point = overlay.path.segments[6].point.add(translationY);
+            overlay.path.segments[7].point = overlay.path.segments[7].point.add(translationY);
+          }
+          if (moveTopSize || moveBottomSize) {
+            translationY = translationY.multiply(0.5);
+            overlay.path.segments[4].point = overlay.path.segments[4].point.add(translationY);
+            overlay.path.segments[8].point = overlay.path.segments[8].point.add(translationY);
+          }
+          if (moveRightSize) {
+            overlay.path.segments[3].point = overlay.path.segments[3].point.add(translationX);
+            overlay.path.segments[4].point = overlay.path.segments[4].point.add(translationX);
+            overlay.path.segments[5].point = overlay.path.segments[5].point.add(translationX);
+          }
+          if (moveLeftSize) {
+            overlay.path.segments[0].point = overlay.path.segments[0].point.add(translationX);
+            overlay.path.segments[7].point = overlay.path.segments[7].point.add(translationX);
+            overlay.path.segments[8].point = overlay.path.segments[8].point.add(translationX);
+          }
+          if (moveRightSize || moveLeftSize) {
+            translationX = translationX.multiply(0.5);
+            overlay.path.segments[1].point = overlay.path.segments[1].point.add(translationX);
+            overlay.path.segments[2].point = overlay.path.segments[2].point.add(translationX);
+            overlay.path.segments[6].point = overlay.path.segments[6].point.add(translationX);
+          }
+          var point = overlay.path.segments[1].point.clone();
+          point = point.add(overlay.path.segments[1].handleOut);
+          if (overlay.path.contains(point)) {
+            overlay.path.segments[1].handleOut = overlay.path.segments[1].handleOut.rotate(180, overlay.path.segments[1]);
+          }
         }
       }
     },
@@ -110,22 +186,59 @@
       var hitResult = overlay.paperScope.project.hitTest(event.point, overlay.hitOptions);
       if (hitResult && hitResult.item._name.toString().indexOf(this.idPrefix) != -1) {
         if (overlay.mode != 'deform' && overlay.mode != 'translate' && overlay.mode != 'create') {
-          if (hitResult.type == 'segment') {
+          if (hitResult.type == 'segment' || hitResult.type == 'handle-out') {
             overlay.mode = 'deform';
             overlay.segment = null;
             overlay.path = null;
-            var segments = hitResult.item.segments;
-            for (var idx = 0; idx < segments.length; idx++) {
-              if (segments[idx] == hitResult.segment) {
-                if (idx % 2 === 0) {
-                  document.body.style.cursor = "move";
-                } else {
-                  jQuery('body').awesomeCursor('repeat', {
-                    color: 'white',
-                    hotspot: 'center'
-                  });
-                }
+            if (hitResult.type == 'handle-out') {
+              jQuery('body').awesomeCursor('repeat', {
+                color: 'white',
+                hotspot: 'center'
+              });
+            } else {
+              var cursor = '';
+              var rotation = hitResult.item.data.rotation;
+              switch (hitResult.segment) {
+                case hitResult.item.segments[0]:
+                  cursor = 'arrows-v';
+                  rotation -= 45;
+                  break;
+                case hitResult.item.segments[1]:
+                  cursor = 'arrows-v';
+                  break;
+                case hitResult.item.segments[2]:
+                  cursor = 'arrows-v';
+                  break;
+                case hitResult.item.segments[3]:
+                  cursor = 'arrows-v';
+                  rotation += 45;
+                  break;
+                case hitResult.item.segments[4]:
+                  cursor = 'arrows-h';
+                  break;
+                case hitResult.item.segments[5]:
+                  cursor = 'arrows-v';
+                  rotation -= 45;
+                  break;
+                case hitResult.item.segments[6]:
+                  cursor = 'arrows-v';
+                  break;
+                case hitResult.item.segments[7]:
+                  cursor = 'arrows-v';
+                  rotation += 45;
+                  break;
+                case hitResult.item.segments[8]:
+                  cursor = 'arrows-h';
+                  break;
+                default:
+                  cursor = 'default';
+                  break;
               }
+              jQuery('body').awesomeCursor(cursor, {
+                color: 'white',
+                hotspot: 'center',
+                rotate: rotation
+              });
             }
           } else {
             overlay.mode = 'translate';
@@ -152,6 +265,9 @@
           overlay.segment = null;
           overlay.path = null;
           overlay.mode = '';
+        } else if (hitResult.type == 'handle-out') {
+          overlay.path = hitResult.item;
+          overlay.segment = null;
         } else {
           overlay.path = hitResult.item;
           overlay.segment = hitResult.segment;

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -109,10 +109,14 @@
       'doubleClickReactionTime': 300,
       'strokeColor': 'deepSkyBlue',
       'fillColor': 'deepSkyBlue',
-      'fillColorAlpha': 0.0
+      'fillColorAlpha': 0.0,
+      'shapeHandleSize':10,
+      'fixedShapeSize':10,
+      'hoverColor':'yellow'
     },
 
     'availableExternalCommentsPanel': false,
+
 
     'availableCanvasTools': [
 

--- a/js/src/widgets/contextControls.js
+++ b/js/src/widgets/contextControls.js
@@ -17,7 +17,7 @@
 
   $.ContextControls.prototype = {
 
-    init: function() {    
+    init: function() {
       var _this = this;
       this.element = jQuery(this.annotationTemplate({
         tools : _this.availableAnnotationTools,
@@ -98,7 +98,6 @@
           jQuery.data(document.body, 'fillColorPickerPop' + _this.windowId, color);
         },
         hide: function(color) {
-          var _this = this;
           color = jQuery.data(document.body, 'fillColorPickerPop' + _this.windowId);
           if (color) {
             _this.eventEmitter.publish('changeFillColor.' + _this.windowId, [color.toHexString(), color.getAlpha()]);
@@ -139,7 +138,7 @@
     },
 
     bindEvents: function() {
-      var _this = this;      
+      var _this = this;
       this.container.find('.mirador-osd-back').on('click', function() {
         _this.element.remove();
         _this.element = jQuery(_this.template()).appendTo(_this.container);

--- a/spec/annotations/osd-svg-ellipse.test.js
+++ b/spec/annotations/osd-svg-ellipse.test.js
@@ -22,11 +22,13 @@ describe('Ellipse', function() {
       'viewZoom': 1,
       'hitOptions': {
         'fill': true,
-        'stroke': true,
+        'handles': true,
         'segments': true,
         'tolerance': 0
       },
       onDrawFinish: function() {
+      },
+      updateSelection: function() {
       },
       getName: function(tool) {
         return tool.idPrefix + '1';
@@ -56,7 +58,7 @@ describe('Ellipse', function() {
 
     expect(overlay.mode).toBe('create');
 
-    expect(overlay.segment).toBe(shape.segments[4]);
+    expect(overlay.segment).toBe(shape.segments[6]);
 
     expect(shape.strokeColor.red).toBe(1);
     expect(shape.strokeColor.green).toBe(0);
@@ -74,7 +76,7 @@ describe('Ellipse', function() {
 
     expect(shape.name).toBe(this.ellipse.idPrefix + '1');
 
-    expect(shape.segments.length).toBe(8);
+    expect(shape.segments.length).toBe(10);
 
     expect(shape.segments[0].point.x).toBe(initialPoint.x - 2);
     expect(shape.segments[0].point.y).toBe(initialPoint.y - 2);
@@ -82,23 +84,29 @@ describe('Ellipse', function() {
     expect(shape.segments[1].point.x).toBe(initialPoint.x - 1);
     expect(shape.segments[1].point.y).toBe(initialPoint.y - diagonalSize - 1);
 
-    expect(shape.segments[2].point.x).toBe(initialPoint.x);
-    expect(shape.segments[2].point.y).toBe(initialPoint.y - 2);
+    expect(shape.segments[2].point.x).toBe(initialPoint.x - 1);
+    expect(shape.segments[2].point.y).toBe(initialPoint.y - diagonalSize - 1);
 
-    expect(shape.segments[3].point.x).toBe(initialPoint.x + diagonalSize - 1);
-    expect(shape.segments[3].point.y).toBe(initialPoint.y - 1);
+    expect(shape.segments[3].point.x).toBe(initialPoint.x - 1);
+    expect(shape.segments[3].point.y).toBe(initialPoint.y - diagonalSize - 1);
 
     expect(shape.segments[4].point.x).toBe(initialPoint.x);
-    expect(shape.segments[4].point.y).toBe(initialPoint.y);
+    expect(shape.segments[4].point.y).toBe(initialPoint.y - 2);
 
-    expect(shape.segments[5].point.x).toBe(initialPoint.x - 1);
-    expect(shape.segments[5].point.y).toBe(initialPoint.y + diagonalSize - 1);
+    expect(shape.segments[5].point.x).toBe(initialPoint.x + diagonalSize - 1);
+    expect(shape.segments[5].point.y).toBe(initialPoint.y - 1);
 
-    expect(shape.segments[6].point.x).toBe(initialPoint.x - 2);
+    expect(shape.segments[6].point.x).toBe(initialPoint.x);
     expect(shape.segments[6].point.y).toBe(initialPoint.y);
 
-    expect(shape.segments[7].point.x).toBe(initialPoint.x - diagonalSize - 1);
-    expect(shape.segments[7].point.y).toBe(initialPoint.y - 1);
+    expect(shape.segments[7].point.x).toBe(initialPoint.x - 1);
+    expect(shape.segments[7].point.y).toBe(initialPoint.y + diagonalSize - 1);
+
+    expect(shape.segments[8].point.x).toBe(initialPoint.x - 2);
+    expect(shape.segments[8].point.y).toBe(initialPoint.y);
+
+    expect(shape.segments[9].point.x).toBe(initialPoint.x - diagonalSize - 1);
+    expect(shape.segments[9].point.y).toBe(initialPoint.y - 1);
   });
 
   describe('Ellipse Mouse Tool', function() {
@@ -117,6 +125,39 @@ describe('Ellipse', function() {
     afterEach(function() {
       delete this.shape;
       delete this.ellipse;
+    });
+
+    it('should update selection', function() {
+      this.shape.selected = false;
+      var rectTool = new Mirador.Rectangle();
+      var initialPoint = {
+        'x': 987,
+        'y': 654
+      };
+      var rect = rectTool.createShape(initialPoint, overlay);
+      this.ellipse.updateSelection(true, rect, overlay);
+
+      expect(this.shape.selected).toBe(false);
+
+      this.ellipse.updateSelection(true, this.shape, overlay);
+
+      expect(this.shape.selected).toBe(true);
+
+      this.shape.scale(-10);
+
+      this.ellipse.updateSelection(true, this.shape, overlay);
+
+      expect(this.shape.selected).toBe(true);
+
+      this.ellipse.updateSelection(false, this.shape, overlay);
+
+      expect(this.shape.selected).toBe(false);
+
+      this.shape.add(new Segment(0, 0));
+
+      this.ellipse.updateSelection(false, this.shape, overlay);
+
+      expect(this.shape.segments.length).toBe(10);
     });
 
     it('should do nothing', function() {
@@ -156,80 +197,129 @@ describe('Ellipse', function() {
       expect(this.shape.segments[1].point.x - event.delta.x).toBe(this.initialPoint.x - 1);
       expect(this.shape.segments[1].point.y - event.delta.y).toBe(this.initialPoint.y - diagonalSize - 1);
 
-      expect(this.shape.segments[2].point.x - event.delta.x).toBe(this.initialPoint.x);
-      expect(this.shape.segments[2].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
+      expect(this.shape.segments[2].point.x - event.delta.x).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[2].point.y - event.delta.y).toBe(this.initialPoint.y - diagonalSize - 1);
 
-      expect(this.shape.segments[3].point.x - event.delta.x).toBe(this.initialPoint.x + diagonalSize - 1);
-      expect(this.shape.segments[3].point.y - event.delta.y).toBe(this.initialPoint.y - 1);
+      expect(this.shape.segments[3].point.x - event.delta.x).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[3].point.y - event.delta.y).toBe(this.initialPoint.y - diagonalSize - 1);
 
       expect(this.shape.segments[4].point.x - event.delta.x).toBe(this.initialPoint.x);
-      expect(this.shape.segments[4].point.y - event.delta.y).toBe(this.initialPoint.y);
+      expect(this.shape.segments[4].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
-      expect(this.shape.segments[5].point.x - event.delta.x).toBe(this.initialPoint.x - 1);
-      expect(this.shape.segments[5].point.y - event.delta.y).toBe(this.initialPoint.y + diagonalSize - 1);
+      expect(this.shape.segments[5].point.x - event.delta.x).toBe(this.initialPoint.x + diagonalSize - 1);
+      expect(this.shape.segments[5].point.y - event.delta.y).toBe(this.initialPoint.y - 1);
 
-      expect(this.shape.segments[6].point.x - event.delta.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[6].point.x - event.delta.x).toBe(this.initialPoint.x);
       expect(this.shape.segments[6].point.y - event.delta.y).toBe(this.initialPoint.y);
 
-      expect(this.shape.segments[7].point.x - event.delta.x).toBe(this.initialPoint.x - diagonalSize - 1);
-      expect(this.shape.segments[7].point.y - event.delta.y).toBe(this.initialPoint.y - 1);
+      expect(this.shape.segments[7].point.x - event.delta.x).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[7].point.y - event.delta.y).toBe(this.initialPoint.y + diagonalSize - 1);
+
+      expect(this.shape.segments[8].point.x - event.delta.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[8].point.y - event.delta.y).toBe(this.initialPoint.y);
+
+      expect(this.shape.segments[9].point.x - event.delta.x).toBe(this.initialPoint.x - diagonalSize - 1);
+      expect(this.shape.segments[9].point.y - event.delta.y).toBe(this.initialPoint.y - 1);
     });
 
     it('should resize the whole ellipse shape', function() {
       var event = getEvent({
         'x': 10,
-        'y': -100
+        'y': 100
       });
-      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[2]);
+      var diagonalSizeX = event.delta.x * (2 / (1 + Math.sqrt(1 / 2)));
+      var diagonalSizeY = event.delta.y * (2 / (1 + Math.sqrt(1 / 2)));
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[6]);
       this.ellipse.onMouseDrag(event, overlay);
 
-      expect(this.shape.segments[0].point.x + event.delta.x).toBeCloseTo(this.initialPoint.x - 2, 1);
+      expect(this.shape.segments[0].point.x - diagonalSizeX * ((2 - Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.x - 2, 1);
+      expect(this.shape.segments[0].point.y - diagonalSizeY * ((2 - Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.y - 2, 1);
+
+      expect(this.shape.segments[1].point.x - diagonalSizeX / 2).toBeCloseTo(this.initialPoint.x - 1, 1);
+      expect(this.shape.segments[1].point.y).toBeCloseTo(this.initialPoint.y - diagonalSize - 1, 1);
+
+      expect(this.shape.segments[2].point.x - diagonalSizeX / 2).toBeCloseTo(this.initialPoint.x - 1, 1);
+      expect(this.shape.segments[2].point.y).toBeCloseTo(this.initialPoint.y - diagonalSize - 1, 1);
+
+      expect(this.shape.segments[3].point.x - diagonalSizeX / 2).toBeCloseTo(this.initialPoint.x - 1, 1);
+      expect(this.shape.segments[3].point.y).toBeCloseTo(this.initialPoint.y - diagonalSize - 1, 1);
+
+      expect(this.shape.segments[4].point.x - diagonalSizeX * ((2 + Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.x, 1);
+      expect(this.shape.segments[4].point.y - diagonalSizeY * ((2 - Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.y - 2, 1);
+
+      expect(this.shape.segments[5].point.x - diagonalSizeX).toBeCloseTo(this.initialPoint.x + diagonalSize - 1, 1);
+      expect(this.shape.segments[5].point.y - diagonalSizeY / 2).toBeCloseTo(this.initialPoint.y - 1, 1);
+
+      expect(this.shape.segments[6].point.x - event.delta.x).toBeCloseTo(this.initialPoint.x, 1);
+      expect(this.shape.segments[6].point.y - event.delta.y).toBeCloseTo(this.initialPoint.y, 1);
+
+      expect(this.shape.segments[7].point.x - diagonalSizeX / 2).toBeCloseTo(this.initialPoint.x - 1, 1);
+      expect(this.shape.segments[7].point.y - diagonalSizeY).toBeCloseTo(this.initialPoint.y + diagonalSize - 1, 1);
+
+      expect(this.shape.segments[8].point.x - diagonalSizeX * ((2 - Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.x - 2, 1);
+      expect(this.shape.segments[8].point.y - diagonalSizeY * ((2 + Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.y, 1);
+
+      expect(this.shape.segments[9].point.x).toBeCloseTo(this.initialPoint.x - diagonalSize - 1, 1);
+      expect(this.shape.segments[9].point.y - diagonalSizeY / 2).toBeCloseTo(this.initialPoint.y - 1, 1);
+    });
+
+
+    it('should resize the whole ellipse shape 2', function() {
+      var event = getEvent({
+        'x': 10,
+        'y': 100
+      });
+      var diagonalSizeX = event.delta.x * (2 / (1 + Math.sqrt(1 / 2)));
+      var diagonalSizeY = event.delta.y * (2 / (1 + Math.sqrt(1 / 2)));
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[0]);
+      this.ellipse.onMouseDrag(event, overlay);
+
+      expect(this.shape.segments[0].point.x - event.delta.x).toBeCloseTo(this.initialPoint.x - 2, 1);
       expect(this.shape.segments[0].point.y - event.delta.y).toBeCloseTo(this.initialPoint.y - 2, 1);
 
-      expect(this.shape.segments[1].point.x).toBeCloseTo(this.initialPoint.x - 1, 1);
-      expect(this.shape.segments[1].point.y - event.delta.y * diagonalSize).toBeCloseTo(this.initialPoint.y - diagonalSize - 1, 1);
+      expect(this.shape.segments[1].point.x - diagonalSizeX / 2).toBeCloseTo(this.initialPoint.x - 1, 1);
+      expect(this.shape.segments[1].point.y - diagonalSizeY).toBeCloseTo(this.initialPoint.y - diagonalSize - 1, 1);
 
-      expect(this.shape.segments[2].point.x - event.delta.x).toBeCloseTo(this.initialPoint.x, 1);
-      expect(this.shape.segments[2].point.y - event.delta.y).toBeCloseTo(this.initialPoint.y - 2, 1);
+      expect(this.shape.segments[2].point.x - diagonalSizeX / 2).toBeCloseTo(this.initialPoint.x - 1, 1);
+      expect(this.shape.segments[2].point.y - diagonalSizeY).toBeCloseTo(this.initialPoint.y - diagonalSize - 1, 1);
 
-      expect(this.shape.segments[3].point.x - event.delta.x * diagonalSize).toBeCloseTo(this.initialPoint.x + diagonalSize - 1, 1);
-      expect(this.shape.segments[3].point.y).toBeCloseTo(this.initialPoint.y - 1, 1);
+      expect(this.shape.segments[3].point.x - diagonalSizeX / 2).toBeCloseTo(this.initialPoint.x - 1, 1);
+      expect(this.shape.segments[3].point.y - diagonalSizeY).toBeCloseTo(this.initialPoint.y - diagonalSize - 1, 1);
 
-      expect(this.shape.segments[4].point.x - event.delta.x).toBeCloseTo(this.initialPoint.x, 1);
-      expect(this.shape.segments[4].point.y + event.delta.y).toBeCloseTo(this.initialPoint.y, 1);
+      expect(this.shape.segments[4].point.x - diagonalSizeX * ((2 - Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.x, 1);
+      expect(this.shape.segments[4].point.y - event.delta.y).toBeCloseTo(this.initialPoint.y - 2, 1);
 
-      expect(this.shape.segments[5].point.x).toBeCloseTo(this.initialPoint.x - 1, 1);
-      expect(this.shape.segments[5].point.y + event.delta.y * diagonalSize).toBeCloseTo(this.initialPoint.y + diagonalSize - 1, 1);
+      expect(this.shape.segments[5].point.x).toBeCloseTo(this.initialPoint.x + diagonalSize - 1, 1);
+      expect(this.shape.segments[5].point.y - diagonalSizeY / 2).toBeCloseTo(this.initialPoint.y - 1, 1);
 
-      expect(this.shape.segments[6].point.x + event.delta.x).toBeCloseTo(this.initialPoint.x - 2, 1);
-      expect(this.shape.segments[6].point.y + event.delta.y).toBeCloseTo(this.initialPoint.y, 1);
+      expect(this.shape.segments[6].point.x - diagonalSizeX * ((2 - Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.x, 1);
+      expect(this.shape.segments[6].point.y - diagonalSizeY * ((2 - Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.y, 1);
 
-      expect(this.shape.segments[7].point.x + event.delta.x * diagonalSize).toBeCloseTo(this.initialPoint.x - diagonalSize - 1, 1);
-      expect(this.shape.segments[7].point.y).toBeCloseTo(this.initialPoint.y - 1, 1);
+      expect(this.shape.segments[7].point.x - diagonalSizeX / 2).toBeCloseTo(this.initialPoint.x - 1, 1);
+      expect(this.shape.segments[7].point.y).toBeCloseTo(this.initialPoint.y + diagonalSize - 1, 1);
 
-      event = getEvent({
-        'x': -100,
-        'y': 10
-      });
-      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'create', this.shape, null);
-      var expected = [];
-      for (var idx = 0; idx < this.shape.segments.length; idx++) {
-        var point = {
-          'x': this.shape.segments[idx].point.x,
-          'y': this.shape.segments[idx].point.y
-        };
-        point.x += event.delta.x / 2 + Math.cos((3 - idx) * Math.PI / 4) * event.delta.x / 2;
-        point.y += event.delta.y / 2 - Math.sin((3 - idx) * Math.PI / 4) * event.delta.y / 2;
-        expected.push(point);
-      }
+      expect(this.shape.segments[8].point.x - event.delta.x).toBeCloseTo(this.initialPoint.x - 2, 1);
+      expect(this.shape.segments[8].point.y - diagonalSizeY * ((2 - Math.sqrt(2)) / 4)).toBeCloseTo(this.initialPoint.y, 1);
+
+      expect(this.shape.segments[9].point.x - diagonalSizeX).toBeCloseTo(this.initialPoint.x - diagonalSize - 1, 1);
+      expect(this.shape.segments[9].point.y - diagonalSizeY / 2).toBeCloseTo(this.initialPoint.y - 1, 1);
+
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[8]);
       this.ellipse.onMouseDrag(event, overlay);
 
-      expect(this.shape.segments.length).toBe(expected.length);
-      for (var idx = 0; idx < this.shape.segments.length; idx++) {
-        expect(this.shape.segments[idx].point.x).toBeCloseTo(expected[idx].x, 1);
-        expect(this.shape.segments[idx].point.y).toBeCloseTo(expected[idx].y, 1);
-      }
+      expect(overlay.mode).toBe('deform');
+
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[7]);
+      this.ellipse.onMouseDrag(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[5]);
+      this.ellipse.onMouseDrag(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
     });
+
 
     function rotatePoint(point, initialPoint, angle) {
       var angleRad = angle * Math.PI / 180.0;
@@ -239,14 +329,7 @@ describe('Ellipse', function() {
       };
     }
 
-    function scalePoint(point, initialPoint, scale) {
-      return {
-        x: scale * (point.x - initialPoint.x) + initialPoint.x,
-        y: scale * (point.y - initialPoint.y) + initialPoint.y
-      };
-    }
-
-    it('should rotate and scale the whole ellipse shape', function() {
+    it('should rotate the whole ellipse shape', function() {
       var size = {
         'x': 1,
         'y': 1
@@ -255,18 +338,20 @@ describe('Ellipse', function() {
       var rotationAngle = -90;
       // -90 degrees rotation + scale
       var event = getEvent({
-        'x': -size.x * diagonalSize * scale,
-        'y': size.y * diagonalSize
+        'x': -size.x,
+        'y': size.y
+      }, {
+        'x': this.shape.position.x,
+        'y': this.shape.position.y - size.y
       });
       var localCenterPoint = {
-        'x': this.initialPoint.x - size.x,
-        'y': this.initialPoint.y - size.y
+        'x': this.shape.position.x,
+        'y': this.shape.position.y
       };
-      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[1]);
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, null);
       var expected = [];
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
         var point = this.shape.segments[idx].point;
-        point = scalePoint(point, localCenterPoint, scale);
         point = rotatePoint(point, localCenterPoint, rotationAngle);
         expected.push(point);
       }
@@ -274,8 +359,8 @@ describe('Ellipse', function() {
 
       expect(this.shape.segments.length).toBe(expected.length);
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
-        expect(this.shape.segments[idx].point.x).toBeCloseTo(expected[idx].x, 1);
-        expect(this.shape.segments[idx].point.y).toBeCloseTo(expected[idx].y, 1);
+        expect(this.shape.segments[idx].point.x).toBeCloseTo(expected[idx].x, 6);
+        expect(this.shape.segments[idx].point.y).toBeCloseTo(expected[idx].y, 6);
       }
     });
 
@@ -328,9 +413,9 @@ describe('Ellipse', function() {
       this.ellipse.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
-      expect(overlay.segment).toBe(this.shape.segments[4]);
+      expect(overlay.segment).toBe(this.shape.segments[6]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toBe('move');
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       this.ellipse.onMouseDown(event, overlay);
 
@@ -339,13 +424,112 @@ describe('Ellipse', function() {
       expect(overlay.path).toBeNull();
 
       event = getEvent({}, {
-        'x': this.initialPoint.x,
+        'x': this.initialPoint.x + diagonalSize - 1,
         'y': this.initialPoint.y - 1
       });
       this.ellipse.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
-      expect(overlay.segment).toBe(this.shape.segments[3]);
+      expect(overlay.segment).toBe(this.shape.segments[5]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x,
+        'y': this.initialPoint.y - 2
+      });
+      this.ellipse.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[4]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 1,
+        'y': this.initialPoint.y - diagonalSize - 1
+      });
+      this.ellipse.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[1]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 2,
+        'y': this.initialPoint.y - 2
+      });
+      this.ellipse.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[0]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 1,
+        'y': this.initialPoint.y + diagonalSize - 1
+      });
+      this.ellipse.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[7]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 2,
+        'y': this.initialPoint.y
+      });
+      this.ellipse.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[8]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - diagonalSize - 1,
+        'y': this.initialPoint.y - 1
+      });
+      this.ellipse.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[9]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 1,
+        'y': this.initialPoint.y - diagonalSize - 21
+      });
+      this.ellipse.updateSelection(true, this.shape, overlay);
+      this.ellipse.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBeNull();
       expect(overlay.path).toBe(this.shape);
       expect(document.body.style.cursor).toContain('data:image/png;base64');
 
@@ -376,5 +560,36 @@ describe('Ellipse', function() {
 
       expect(document.body.style.cursor).toBe('default');
     });
+
+    it('should change stroke when hovering ellipse',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.ellipse.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering ellipse',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.ellipse.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.ellipse.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
+    });
+
   });
 });

--- a/spec/annotations/osd-svg-freehand.test.js
+++ b/spec/annotations/osd-svg-freehand.test.js
@@ -102,6 +102,52 @@ describe('Freehand', function() {
       delete this.freehand;
     });
 
+    it('should update selection', function() {
+      var ellipseTool = new Mirador.Ellipse();
+      var initialPoint = {
+        'x': 987,
+        'y': 654
+      };
+      var ellipse = ellipseTool.createShape(initialPoint, overlay);
+      this.freehand.updateSelection(true, ellipse, overlay);
+
+      expect(this.shape.selected).toBe(false);
+
+      this.freehand.updateSelection(true, this.shape, overlay);
+
+      expect(this.shape.selected).toBe(true);
+    });
+
+    it('should change stroke when hovering freehand',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.freehand.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering freehand',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.freehand.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.freehand.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
+    });
+
     it('should do nothing', function() {
       var event = getEvent({
         'x': 100,

--- a/spec/annotations/osd-svg-overlay.test.js
+++ b/spec/annotations/osd-svg-overlay.test.js
@@ -91,27 +91,25 @@ describe('Overlay', function() {
       'fillColorAlpha': 0.0
     };
     var state = new Mirador.SaveController({eventEmitter: this.eventEmitter});
-    /*
-    
-    TODO RADOSLAV
-     getStateProperty: function(key) {
+
+     state.getStateProperty = function(key) {
      if (key === 'drawingToolsSettings') {
-     return {
-     'doubleClickReactionTime': 300,
-     'strokeColor': 'deepSkyBlue',
-     'fillColor': 'deepSkyBlue',
-     'fillColorAlpha': 0.0
-     };
+       return {
+         'doubleClickReactionTime': 300,
+         'strokeColor': 'deepSkyBlue',
+         'fillColor': 'deepSkyBlue',
+         'fillColorAlpha': 0.0
+       };
      }
      if (key === 'availableAnnotationDrawingTools') {
-     return [];
+       return [];
      }
      if (key === 'availableExternalCommentsPanel') {
-     return false;
+       return false;
      }
-     return null;
-     }
-     */
+       return null;
+     };
+
     this.overlay = new Mirador.Overlay(this.viewerMock, this.windowObjMock.viewer.id, this.windowObjMock.windowId, state, this.eventEmitter);
   });
 
@@ -440,7 +438,7 @@ describe('Overlay', function() {
   });
 
   it('parseSVG', function() {
-    var svg = '<svg xmlns="http://www.w3.org/2000/svg"><g><path d="M207.55023,187.98214l143.12613,0l143.12613,0l0,97.81055l0,97.81055l-143.12613,0l-143.12613,0l0,-97.81055z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="rectangle_154807a4-4121-43f0-a920-5e6792523959" fill-opacity="0.5" fill="#008000" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" mix-blend-mode="normal"/><path xmlns="http://www.w3.org/2000/svg" d="M465.02563,80.868c27.12902,-14.80678 65.56711,-23.45636 103.98969,-23.45148c38.42258,0.00488 76.82965,8.66424 103.98969,23.45148c27.16004,14.78724 43.07305,35.70236 43.07394,56.61687c0.00089,20.91451 -15.91035,41.82842 -43.07394,56.61687c-27.16359,14.78845 -66.01382,23.21455 -103.98969,23.45148c-37.97587,0.23693 -76.58764,-8.53597 -103.98969,-23.45148c-27.40205,-14.91551 -43.17951,-35.75374 -43.07394,-56.61687c0.10556,-20.86313 15.94492,-41.81009 43.07394,-56.61687z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="circle_3c667714-d8cf-4b52-80eb-d22e863cf486" fill-opacity="0.5" fill="#008000" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" mix-blend-mode="normal"></path></g></svg>'
+    var svg = '<svg xmlns="http://www.w3.org/2000/svg"><g><path d="M207.55023,187.98214l143.12613,0l143.12613,0l0,97.81055l0,97.81055l-143.12613,0l-143.12613,0l0,-97.81055z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="rectangle_154807a4-4121-43f0-a920-5e6792523959" fill-opacity="0.5" fill="#008000" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" mix-blend-mode="normal"/><path xmlns="http://www.w3.org/2000/svg" d="M465.02563,80.868c27.12902,-14.80678 65.56711,-23.45636 103.98969,-23.45148c38.42258,0.00488 76.82965,8.66424 103.98969,23.45148c27.16004,14.78724 43.07305,35.70236 43.07394,56.61687c0.00089,20.91451 -15.91035,41.82842 -43.07394,56.61687c-27.16359,14.78845 -66.01382,23.21455 -103.98969,23.45148c-37.97587,0.23693 -76.58764,-8.53597 -103.98969,-23.45148c-27.40205,-14.91551 -43.17951,-35.75374 -43.07394,-56.61687c0.10556,-20.86313 15.94492,-41.81009 43.07394,-56.61687z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="circle_3c667714-d8cf-4b52-80eb-d22e863cf486" fill-opacity="0.5" fill="#008000" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" mix-blend-mode="normal"></path></g></svg>';
     var annotation = {};
     var result = this.overlay.parseSVG(svg, annotation);
 
@@ -451,7 +449,7 @@ describe('Overlay', function() {
 
   // set of tests for both import and export functionality. Simulates load and store of annotation shapes.
   it('getSVGString1', function() {
-    var svg = '<svg xmlns=\'http://www.w3.org/2000/svg\'><g><path d="M207.55023,187.98214l143.12613,0l143.12613,0l0,97.81055l0,97.81055l-143.12613,0l-143.12613,0l0,-97.81055z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="rectangle_154807a4-4121-43f0-a920-5e6792523959" fill-opacity="0.5" fill="#008000" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" mix-blend-mode="normal"></path><path d="M465.02563,80.868c27.12902,-14.80678 65.56711,-23.45636 103.98969,-23.45148c38.42258,0.00488 76.82965,8.66424 103.98969,23.45148c27.16004,14.78724 43.07305,35.70236 43.07394,56.61687c0.00089,20.91451 -15.91035,41.82842 -43.07394,56.61687c-27.16359,14.78845 -66.01382,23.21455 -103.98969,23.45148c-37.97587,0.23693 -76.58764,-8.53597 -103.98969,-23.45148c-27.40205,-14.91551 -43.17951,-35.75374 -43.07394,-56.61687c0.10556,-20.86313 15.94492,-41.81009 43.07394,-56.61687z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="circle_3c667714-d8cf-4b52-80eb-d22e863cf486" fill-opacity="0.5" fill="#008000" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" mix-blend-mode="normal"></path></g></svg>';
+    var svg='<svg xmlns=\'http://www.w3.org/2000/svg\'><g><path d="M207.55023,187.98214l143.12613,0l0,0l143.12613,0l0,97.81055l0,97.81055l-143.12613,0l-143.12613,0l0,-97.81055z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="rectangle_154807a4-4121-43f0-a920-5e6792523959" fill-opacity="0.5" fill="#008000" fill-rule="nonzero" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" style="mix-blend-mode: normal"></path><path d="M465.02563,80.868c27.12902,-14.80678 65.56711,-23.45636 103.98969,-23.45148c38.42258,0.00488 76.82965,8.66424 103.98969,23.45148c27.16004,14.78724 43.07305,35.70236 43.07394,56.61687c0.00089,20.91451 -15.91035,41.82842 -43.07394,56.61687c-27.16359,14.78845 -66.01382,23.21455 -103.98969,23.45148c-37.97587,0.23693 -76.58764,-8.53597 -103.98969,-23.45148c-27.40205,-14.91551 -43.17951,-35.75374 -43.07394,-56.61687c0.10556,-20.86313 15.94492,-41.81009 43.07394,-56.61687z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="circle_3c667714-d8cf-4b52-80eb-d22e863cf486" fill-opacity="0.5" fill="#008000" fill-rule="nonzero" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" style="mix-blend-mode: normal"></path></g></svg>'
     var annotation = {};
     var result = this.overlay.parseSVG(svg, annotation);
     var exportedSVG = this.overlay.getSVGString(result);
@@ -460,7 +458,7 @@ describe('Overlay', function() {
   });
 
   it('getSVGString2', function() {
-    var svgTestTwo = '<svg xmlns=\'http://www.w3.org/2000/svg\'><path d="M207.55023,187.98214l143.12613,0l143.12613,0l0,97.81055l0,97.81055l-143.12613,0l-143.12613,0l0,-97.81055z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="rectangle_154807a4-4121-43f0-a920-5e6792523959" fill-opacity="0.5" fill="#008000" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" mix-blend-mode="normal"></path></svg>';
+    var svgTestTwo = '<svg xmlns=\'http://www.w3.org/2000/svg\'><path d="M207.55023,187.98214l143.12613,0l0,0l143.12613,0l0,97.81055l0,97.81055l-143.12613,0l-143.12613,0l0,-97.81055z" data-paper-data="{&quot;rotation&quot;:0,&quot;annotation&quot;:null}" id="rectangle_154807a4-4121-43f0-a920-5e6792523959" fill-opacity="0.5" fill="#008000" fill-rule="nonzero" stroke="#ff0000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="sans-serif" font-weight="normal" font-size="12" text-anchor="start" style="mix-blend-mode: normal"></path></svg>';
     var annotation = {};
     var result = this.overlay.parseSVG(svgTestTwo, annotation);
     var exportedSVGTestTwo = this.overlay.getSVGString(result);

--- a/spec/annotations/osd-svg-pin.test.js
+++ b/spec/annotations/osd-svg-pin.test.js
@@ -75,7 +75,7 @@ describe('Pin', function() {
 
     expect(shape.name).toBe(this.pin.idPrefix + '1');
 
-    expect(shape.segments.length).toBe(1);
+    expect(shape.segments.length).toBe(5);
 
     expect(shape.segments[0].point.x).toBe(initialPoint.x);
     expect(shape.segments[0].point.y).toBe(initialPoint.y);
@@ -97,6 +97,63 @@ describe('Pin', function() {
     afterEach(function() {
       delete this.shape;
       delete this.pin;
+    });
+
+    it('should update selection', function() {
+      var ellipseTool = new Mirador.Ellipse();
+      var initialPoint = {
+        'x': 987,
+        'y': 654
+      };
+      var ellipse = ellipseTool.createShape(initialPoint, overlay);
+      this.pin.updateSelection(true, ellipse, overlay);
+
+      expect(this.shape.selected).toBe(false);
+
+      var event = getEvent(initialPoint);
+
+      this.pin.onMouseUp(event, overlay);
+      this.pin.updateSelection(true, this.shape, overlay);
+
+      var redColor = {
+        red:1,
+        green: 0,
+        blue:0
+      };
+
+      expect(this.shape.strokeColor.red).toBe(redColor.red);
+      expect(this.shape.strokeColor.green).toBe(redColor.green);
+      expect(this.shape.strokeColor.blue).toBe(redColor.blue);
+    });
+
+    it('should change stroke when hovering pin',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.pin.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering pin',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.pin.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.pin.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
     });
 
     it('should do nothing', function() {

--- a/spec/annotations/osd-svg-polygon.test.js
+++ b/spec/annotations/osd-svg-polygon.test.js
@@ -102,6 +102,52 @@ describe('Polygon', function() {
       delete this.polygon;
     });
 
+    it('should update selection', function() {
+      var ellipseTool = new Mirador.Ellipse();
+      var initialPoint = {
+        'x': 987,
+        'y': 654
+      };
+      var ellipse = ellipseTool.createShape(initialPoint, overlay);
+      this.polygon.updateSelection(true, ellipse, overlay);
+
+      expect(this.shape.selected).toBe(false);
+
+      this.polygon.updateSelection(true, this.shape, overlay);
+
+      expect(this.shape.selected).toBe(true);
+    });
+
+    it('should change stroke when hovering polygon',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.polygon.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering polygon',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.polygon.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.polygon.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
+    });
+
     it('should do nothing', function() {
       var event = getEvent({
         'x': 100,

--- a/spec/annotations/osd-svg-rectangle.test.js
+++ b/spec/annotations/osd-svg-rectangle.test.js
@@ -21,7 +21,7 @@ describe('Rectangle', function() {
       'viewZoom': 1,
       'hitOptions': {
         'fill': true,
-        'stroke': true,
+        'handles': true,
         'segments': true,
         'tolerance': 0
       },
@@ -38,10 +38,10 @@ describe('Rectangle', function() {
     this.canvas.attr('id', 'paperId');
     jasmine.getFixtures().set(this.canvas);
     paper.setup(this.canvas.attr('id'));
-    this.rect = new Mirador.Rectangle();
+    this.rectangle = new Mirador.Rectangle();
   });
   afterAll(function() {
-    delete this.rect;
+    delete this.rectangle;
   });
 
   it('should create rectangular shape', function() {
@@ -50,11 +50,11 @@ describe('Rectangle', function() {
       'y': 456
     };
     var overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, null, null, null);
-    var shape = this.rect.createShape(initialPoint, overlay);
+    var shape = this.rectangle.createShape(initialPoint, overlay);
 
     expect(overlay.mode).toBe('create');
 
-    expect(overlay.segment).toBe(shape.segments[4]);
+    expect(overlay.segment).toBe(shape.segments[5]);
 
     expect(shape.strokeColor.red).toBe(1);
     expect(shape.strokeColor.green).toBe(0);
@@ -72,9 +72,9 @@ describe('Rectangle', function() {
 
     expect(shape.fullySelected).toBe(true);
 
-    expect(shape.name).toBe(this.rect.idPrefix + '1');
+    expect(shape.name).toBe(this.rectangle.idPrefix + '1');
 
-    expect(shape.segments.length).toBe(8);
+    expect(shape.segments.length).toBe(9);
 
     expect(shape.segments[0].point.x).toBe(initialPoint.x - 2);
     expect(shape.segments[0].point.y).toBe(initialPoint.y - 2);
@@ -82,23 +82,26 @@ describe('Rectangle', function() {
     expect(shape.segments[1].point.x).toBe(initialPoint.x - 1);
     expect(shape.segments[1].point.y).toBe(initialPoint.y - 2);
 
-    expect(shape.segments[2].point.x).toBe(initialPoint.x);
+    expect(shape.segments[2].point.x).toBe(initialPoint.x - 1);
     expect(shape.segments[2].point.y).toBe(initialPoint.y - 2);
 
     expect(shape.segments[3].point.x).toBe(initialPoint.x);
-    expect(shape.segments[3].point.y).toBe(initialPoint.y - 1);
+    expect(shape.segments[3].point.y).toBe(initialPoint.y - 2);
 
     expect(shape.segments[4].point.x).toBe(initialPoint.x);
-    expect(shape.segments[4].point.y).toBe(initialPoint.y);
+    expect(shape.segments[4].point.y).toBe(initialPoint.y - 1);
 
-    expect(shape.segments[5].point.x).toBe(initialPoint.x - 1);
+    expect(shape.segments[5].point.x).toBe(initialPoint.x);
     expect(shape.segments[5].point.y).toBe(initialPoint.y);
 
-    expect(shape.segments[6].point.x).toBe(initialPoint.x - 2);
+    expect(shape.segments[6].point.x).toBe(initialPoint.x - 1);
     expect(shape.segments[6].point.y).toBe(initialPoint.y);
 
     expect(shape.segments[7].point.x).toBe(initialPoint.x - 2);
-    expect(shape.segments[7].point.y).toBe(initialPoint.y - 1);
+    expect(shape.segments[7].point.y).toBe(initialPoint.y);
+
+    expect(shape.segments[8].point.x).toBe(initialPoint.x - 2);
+    expect(shape.segments[8].point.y).toBe(initialPoint.y - 1);
   });
 
   describe('Rectangle Mouse Tool', function() {
@@ -106,17 +109,70 @@ describe('Rectangle', function() {
 
     beforeEach(function() {
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
-      this.rect = new Mirador.Rectangle();
+      this.rectangle = new Mirador.Rectangle();
       this.initialPoint = {
         'x': 987,
         'y': 654
       };
-      this.shape = this.rect.createShape(this.initialPoint, overlay);
+      this.shape = this.rectangle.createShape(this.initialPoint, overlay);
     });
 
     afterEach(function() {
       delete this.shape;
-      delete this.rect;
+      delete this.rectangle;
+    });
+
+    it('should update selection', function() {
+      this.shape.fullySelected = false;
+      var ellipseTool = new Mirador.Ellipse();
+      var initialPoint = {
+        'x': 987,
+        'y': 654
+      };
+      var ellipse = ellipseTool.createShape(initialPoint, overlay);
+      this.rectangle.updateSelection(true, ellipse, overlay);
+
+      expect(this.shape.fullySelected).toBe(false);
+
+      this.rectangle.updateSelection(true, this.shape, overlay);
+
+      expect(this.shape.fullySelected).toBe(true);
+
+      this.shape.scale(-10);
+
+      this.rectangle.updateSelection(true, this.shape, overlay);
+
+      expect(this.shape.fullySelected).toBe(true);
+    });
+
+    it('should change stroke when hovering rectangle',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.rectangle.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering rectangle',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.rectangle.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.rectangle.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
     });
 
     it('should do nothing', function() {
@@ -133,7 +189,7 @@ describe('Rectangle', function() {
         };
         expected.push(point);
       }
-      this.rect.onMouseDrag(event, overlay);
+      this.rectangle.onMouseDrag(event, overlay);
 
       expect(this.shape.segments.length).toBe(expected.length);
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
@@ -148,7 +204,7 @@ describe('Rectangle', function() {
         'y': -3
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'translate', this.shape, null);
-      this.rect.onMouseDrag(event, overlay);
+      this.rectangle.onMouseDrag(event, overlay);
 
       expect(this.shape.segments[0].point.x - event.delta.x).toBe(this.initialPoint.x - 2);
       expect(this.shape.segments[0].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
@@ -156,95 +212,166 @@ describe('Rectangle', function() {
       expect(this.shape.segments[1].point.x - event.delta.x).toBe(this.initialPoint.x - 1);
       expect(this.shape.segments[1].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
-      expect(this.shape.segments[2].point.x - event.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[2].point.x - event.delta.x).toBe(this.initialPoint.x - 1);
       expect(this.shape.segments[2].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
       expect(this.shape.segments[3].point.x - event.delta.x).toBe(this.initialPoint.x);
-      expect(this.shape.segments[3].point.y - event.delta.y).toBe(this.initialPoint.y - 1);
+      expect(this.shape.segments[3].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
       expect(this.shape.segments[4].point.x - event.delta.x).toBe(this.initialPoint.x);
-      expect(this.shape.segments[4].point.y - event.delta.y).toBe(this.initialPoint.y);
+      expect(this.shape.segments[4].point.y - event.delta.y).toBe(this.initialPoint.y - 1);
 
-      expect(this.shape.segments[5].point.x - event.delta.x).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[5].point.x - event.delta.x).toBe(this.initialPoint.x);
       expect(this.shape.segments[5].point.y - event.delta.y).toBe(this.initialPoint.y);
 
-      expect(this.shape.segments[6].point.x - event.delta.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[6].point.x - event.delta.x).toBe(this.initialPoint.x - 1);
       expect(this.shape.segments[6].point.y - event.delta.y).toBe(this.initialPoint.y);
 
       expect(this.shape.segments[7].point.x - event.delta.x).toBe(this.initialPoint.x - 2);
-      expect(this.shape.segments[7].point.y - event.delta.y).toBe(this.initialPoint.y - 1);
+      expect(this.shape.segments[7].point.y - event.delta.y).toBe(this.initialPoint.y);
+
+      expect(this.shape.segments[8].point.x - event.delta.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[8].point.y - event.delta.y).toBe(this.initialPoint.y - 1);
     });
 
     it('should resize the whole rectangular shape', function() {
       var event = getEvent({
         'x': 10,
-        'y': -100
+        'y': 100
+      });
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[5]);
+      this.rectangle.onMouseDrag(event, overlay);
+
+      expect(this.shape.segments[0].point.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[0].point.y).toBe(this.initialPoint.y - 2);
+
+      expect(this.shape.segments[1].point.x - event.delta.x / 2).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[1].point.y).toBe(this.initialPoint.y - 2);
+
+      expect(this.shape.segments[2].point.x - event.delta.x / 2).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[2].point.y).toBe(this.initialPoint.y - 2);
+
+      expect(this.shape.segments[3].point.x - event.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[3].point.y).toBe(this.initialPoint.y - 2);
+
+      expect(this.shape.segments[4].point.x - event.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[4].point.y - event.delta.y / 2).toBe(this.initialPoint.y - 1);
+
+      expect(this.shape.segments[5].point.x - event.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[5].point.y - event.delta.y).toBe(this.initialPoint.y);
+
+      expect(this.shape.segments[6].point.x - event.delta.x / 2).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[6].point.y - event.delta.y).toBe(this.initialPoint.y);
+
+      expect(this.shape.segments[7].point.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[7].point.y - event.delta.y).toBe(this.initialPoint.y);
+
+      expect(this.shape.segments[8].point.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[8].point.y - event.delta.y / 2).toBe(this.initialPoint.y - 1);
+
+      var event2 = getEvent({
+        'x': 100,
+        'y': 10
+      });
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[0]);
+      this.rectangle.onMouseDrag(event2, overlay);
+
+      expect(this.shape.segments[0].point.x - event2.delta.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[0].point.y - event2.delta.y).toBe(this.initialPoint.y - 2);
+
+      expect(this.shape.segments[1].point.x - event.delta.x / 2 - event2.delta.x / 2).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[1].point.y - event2.delta.y).toBe(this.initialPoint.y - 2);
+
+      expect(this.shape.segments[2].point.x - event.delta.x / 2 - event2.delta.x / 2).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[2].point.y - event2.delta.y).toBe(this.initialPoint.y - 2);
+
+      expect(this.shape.segments[3].point.x - event.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[3].point.y - event2.delta.y).toBe(this.initialPoint.y - 2);
+
+      expect(this.shape.segments[4].point.x - event.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[4].point.y - event.delta.y / 2 - event2.delta.y / 2).toBe(this.initialPoint.y - 1);
+
+      expect(this.shape.segments[5].point.x - event.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[5].point.y - event.delta.y).toBe(this.initialPoint.y);
+
+      expect(this.shape.segments[6].point.x - event.delta.x / 2 - event2.delta.x / 2).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[6].point.y - event.delta.y).toBe(this.initialPoint.y);
+
+      expect(this.shape.segments[7].point.x - event2.delta.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[7].point.y - event.delta.y).toBe(this.initialPoint.y);
+
+      expect(this.shape.segments[8].point.x - event2.delta.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[8].point.y - event.delta.y / 2 - event2.delta.y / 2).toBe(this.initialPoint.y - 1);
+    });
+
+    it('should resize the whole rectangular shape 2', function() {
+      var event = getEvent({
+        'x': 10,
+        'y': 100
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[2]);
-      this.rect.onMouseDrag(event, overlay);
+      this.rectangle.onMouseDrag(event, overlay);
 
-      expect(this.shape.segments[0].point.x + event.delta.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[0].point.x).toBe(this.initialPoint.x - 2);
       expect(this.shape.segments[0].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
       expect(this.shape.segments[1].point.x).toBe(this.initialPoint.x - 1);
       expect(this.shape.segments[1].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
-      expect(this.shape.segments[2].point.x - event.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[2].point.x).toBe(this.initialPoint.x - 1);
       expect(this.shape.segments[2].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
-      expect(this.shape.segments[3].point.x - event.delta.x).toBe(this.initialPoint.x);
-      expect(this.shape.segments[3].point.y).toBe(this.initialPoint.y - 1);
+      expect(this.shape.segments[3].point.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[3].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
-      expect(this.shape.segments[4].point.x - event.delta.x).toBe(this.initialPoint.x);
-      expect(this.shape.segments[4].point.y + event.delta.y).toBe(this.initialPoint.y);
+      expect(this.shape.segments[4].point.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[4].point.y - event.delta.y / 2).toBe(this.initialPoint.y - 1);
 
-      expect(this.shape.segments[5].point.x).toBe(this.initialPoint.x - 1);
-      expect(this.shape.segments[5].point.y + event.delta.y).toBe(this.initialPoint.y);
+      expect(this.shape.segments[5].point.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[5].point.y).toBe(this.initialPoint.y);
 
-      expect(this.shape.segments[6].point.x + event.delta.x).toBe(this.initialPoint.x - 2);
-      expect(this.shape.segments[6].point.y + event.delta.y).toBe(this.initialPoint.y);
+      expect(this.shape.segments[6].point.x).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[6].point.y).toBe(this.initialPoint.y);
 
-      expect(this.shape.segments[7].point.x + event.delta.x).toBe(this.initialPoint.x - 2);
-      expect(this.shape.segments[7].point.y).toBe(this.initialPoint.y - 1);
+      expect(this.shape.segments[7].point.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[7].point.y).toBe(this.initialPoint.y);
 
-      event = getEvent({
-        'x': 10,
-        'y': 100
+      expect(this.shape.segments[8].point.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[8].point.y - event.delta.y / 2).toBe(this.initialPoint.y - 1);
+
+      var event2 = getEvent({
+        'x': 100,
+        'y': 10
       });
-      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'create', this.shape, null);
-      var expected = [];
-      for (var idx = 0; idx < this.shape.segments.length; idx++) {
-        var point = {
-          'x': this.shape.segments[idx].point.x,
-          'y': this.shape.segments[idx].point.y
-        };
-        expected.push(point);
-      }
-      this.rect.onMouseDrag(event, overlay);
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[4]);
+      this.rectangle.onMouseDrag(event2, overlay);
 
-      expect(this.shape.segments[0].point.x).toBe(expected[0].x);
-      expect(this.shape.segments[0].point.y).toBe(expected[0].y);
+      expect(this.shape.segments[0].point.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[0].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
-      expect(this.shape.segments[1].point.x).toBe(expected[1].x + event.delta.x / 2);
-      expect(this.shape.segments[1].point.y).toBe(expected[1].y);
+      expect(this.shape.segments[1].point.x - event2.delta.x / 2).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[1].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
-      expect(this.shape.segments[2].point.x).toBe(expected[2].x + event.delta.x);
-      expect(this.shape.segments[2].point.y).toBe(expected[2].y);
+      expect(this.shape.segments[2].point.x - event2.delta.x / 2).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[2].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
-      expect(this.shape.segments[3].point.x).toBe(expected[3].x + event.delta.x);
-      expect(this.shape.segments[3].point.y).toBe(expected[3].y + event.delta.y / 2);
+      expect(this.shape.segments[3].point.x - event2.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[3].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
 
-      expect(this.shape.segments[4].point.x).toBe(expected[4].x + event.delta.x);
-      expect(this.shape.segments[4].point.y).toBe(expected[4].y + event.delta.y);
+      expect(this.shape.segments[4].point.x - event2.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[4].point.y - event.delta.y / 2).toBe(this.initialPoint.y - 1);
 
-      expect(this.shape.segments[5].point.x).toBe(expected[5].x + event.delta.x / 2);
-      expect(this.shape.segments[5].point.y).toBe(expected[5].y + event.delta.y);
+      expect(this.shape.segments[5].point.x - event2.delta.x).toBe(this.initialPoint.x);
+      expect(this.shape.segments[5].point.y).toBe(this.initialPoint.y);
 
-      expect(this.shape.segments[6].point.x).toBe(expected[6].x);
-      expect(this.shape.segments[6].point.y).toBe(expected[6].y + event.delta.y);
+      expect(this.shape.segments[6].point.x - event2.delta.x / 2).toBe(this.initialPoint.x - 1);
+      expect(this.shape.segments[6].point.y).toBe(this.initialPoint.y);
 
-      expect(this.shape.segments[7].point.x).toBe(expected[7].x);
-      expect(this.shape.segments[7].point.y).toBe(expected[7].y + event.delta.y / 2);
+      expect(this.shape.segments[7].point.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[7].point.y).toBe(this.initialPoint.y);
+
+      expect(this.shape.segments[8].point.x).toBe(this.initialPoint.x - 2);
+      expect(this.shape.segments[8].point.y - event.delta.y / 2).toBe(this.initialPoint.y - 1);
     });
 
     function rotatePoint(point, initialPoint, angle) {
@@ -255,14 +382,7 @@ describe('Rectangle', function() {
       };
     }
 
-    function scalePoint(point, initialPoint, scale) {
-      return {
-        x: scale * (point.x - initialPoint.x) + initialPoint.x,
-        y: scale * (point.y - initialPoint.y) + initialPoint.y
-      };
-    }
-
-    it('should rotate and scale the whole rectangular shape', function() {
+    it('should rotate the whole rectangular shape', function() {
       var size = {
         'x': 1,
         'y': 1
@@ -271,22 +391,24 @@ describe('Rectangle', function() {
       var rotationAngle = -90;
       // -90 degrees rotation + scale
       var event = getEvent({
-        'x': -size.x * scale,
+        'x': -size.x,
         'y': size.y
+      }, {
+        'x': this.shape.position.x,
+        'y': this.shape.position.y - size.y
       });
       var localCenterPoint = {
-        'x': this.initialPoint.x - size.x,
-        'y': this.initialPoint.y - size.y
+        'x': this.shape.position.x,
+        'y': this.shape.position.y
       };
-      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[1]);
+      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, null);
       var expected = [];
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
         var point = this.shape.segments[idx].point;
-        point = scalePoint(point, localCenterPoint, scale);
         point = rotatePoint(point, localCenterPoint, rotationAngle);
         expected.push(point);
       }
-      this.rect.onMouseDrag(event, overlay);
+      this.rectangle.onMouseDrag(event, overlay);
 
       expect(this.shape.segments.length).toBe(expected.length);
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
@@ -302,17 +424,17 @@ describe('Rectangle', function() {
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
       spyOn(overlay, 'onDrawFinish');
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.path).not.toBeNull();
       expect(overlay.onDrawFinish.calls.count()).toEqual(0);
 
-      this.rect.onMouseUp(event, overlay);
+      this.rectangle.onMouseUp(event, overlay);
 
       expect(overlay.onDrawFinish.calls.count()).toEqual(1);
 
       overlay.mode = '';
-      this.rect.onMouseUp(event, overlay);
+      this.rectangle.onMouseUp(event, overlay);
 
       expect(overlay.onDrawFinish.calls.count()).toEqual(1);
     });
@@ -323,14 +445,14 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y - 1
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('translate');
       expect(overlay.segment).toBeNull();
       expect(overlay.path).toBe(this.shape);
       expect(document.body.style.cursor).toBe('move');
 
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('');
       expect(overlay.segment).toBeNull();
@@ -341,14 +463,14 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
-      expect(overlay.segment).toBe(this.shape.segments[4]);
+      expect(overlay.segment).toBe(this.shape.segments[5]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toBe('move');
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('');
       expect(overlay.segment).toBeNull();
@@ -358,10 +480,109 @@ describe('Rectangle', function() {
         'x': this.initialPoint.x,
         'y': this.initialPoint.y - 1
       });
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[4]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x,
+        'y': this.initialPoint.y - 2
+      });
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[3]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 1,
+        'y': this.initialPoint.y - 2
+      });
+      this.rectangle.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[1]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 2,
+        'y': this.initialPoint.y - 2
+      });
+      this.rectangle.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[0]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 1,
+        'y': this.initialPoint.y
+      });
+      this.rectangle.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[6]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 2,
+        'y': this.initialPoint.y
+      });
+      this.rectangle.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[7]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 2,
+        'y': this.initialPoint.y - 1
+      });
+      this.rectangle.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBe(this.shape.segments[8]);
+      expect(overlay.path).toBe(this.shape);
+      expect(document.body.style.cursor).toContain('data:image/png;base64');
+
+      overlay.mode = '';
+      overlay.segment = null;
+      overlay.path = null;
+      event = getEvent({}, {
+        'x': this.initialPoint.x - 1,
+        'y': this.initialPoint.y - 22
+      });
+      this.rectangle.updateSelection(true, this.shape, overlay);
+      this.rectangle.onMouseDown(event, overlay);
+
+      expect(overlay.mode).toBe('deform');
+      expect(overlay.segment).toBeNull();
       expect(overlay.path).toBe(this.shape);
       expect(document.body.style.cursor).toContain('data:image/png;base64');
 
@@ -370,7 +591,7 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y - 1
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'translate', null, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(document.body.style.cursor).toBe('default');
 
@@ -379,7 +600,7 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y + 100
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(document.body.style.cursor).toBe('default');
 
@@ -388,7 +609,7 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y - 100
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', this.shape, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(document.body.style.cursor).toBe('default');
     });


### PR DESCRIPTION
Mark all annotation's shapes as 'active' when hovering one of them

You can configure hover color by:

 `'drawingToolsSettings': {
      'hoverColor': 'yellow'
    },`

color can be anything from http://paperjs.org/reference/color/