### PR TITLE
Mark all annotation's shapes as 'active' when hovering one of them

### DIFF
--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -171,18 +171,30 @@
         stroke: true,
         segments: true
       };
+      var hoverColor = this.state.getStateProperty('drawingToolsSettings').hoverColor;
       var annotations = [];
       for (var key in _this.annotationsToShapesMap) {
         if (_this.annotationsToShapesMap.hasOwnProperty(key)) {
           var shapeArray = _this.annotationsToShapesMap[key];
           for (var idx = 0; idx < shapeArray.length; idx++) {
+            var shapeTool = this.svgOverlay.getTool(shapeArray[idx]);
             if (shapeArray[idx].hitTest(location, hitOptions)) {
               annotations.push(shapeArray[idx].data.annotation);
+              if(shapeTool.onHover){
+                for(var k=0;k<shapeArray.length;k++){
+                  shapeTool.onHover(true,shapeArray[k],hoverColor);
+                }
+              }
               break;
+            }else{
+              if(shapeTool.onHover){
+                shapeTool.onHover(false,shapeArray[idx]);
+              }
             }
           }
         }
       }
+      this.svgOverlay.paperScope.view.draw();
       if (_this.svgOverlay.availableExternalCommentsPanel) {
         _this.eventEmitter.publish('annotationMousePosition.' + _this.parent.windowId, [annotations]);
         return;

--- a/js/src/annotations/osd-svg-ellipse.js
+++ b/js/src/annotations/osd-svg-ellipse.js
@@ -52,7 +52,7 @@
       this.updateSelection(true, shape, overlay);
       return shape;
     },
-
+    
     updateSelection: function(selected, item, overlay) {
       if (item._name.toString().indexOf(this.idPrefix) != -1) {
         if (item.segments.length > 10) {
@@ -82,6 +82,21 @@
         } else {
           item.segments[2].handleOut = new overlay.paperScope.Point(0, 0);
         }
+      }
+    },
+
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
       }
     },
 

--- a/js/src/annotations/osd-svg-freehand.js
+++ b/js/src/annotations/osd-svg-freehand.js
@@ -31,7 +31,20 @@
         item.selected = selected;
       }
     },
-
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
+      }
+    },
     onMouseUp: function(event, overlay) {
       if (overlay.path) {
         overlay.path.simplify();

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -31,7 +31,8 @@
       availableAnnotationDrawingTools: availableAnnotationDrawingTools,
       availableExternalCommentsPanel: availableExternalCommentsPanel,
       dashArray: [],
-      fixedShapeSize: 10,
+      fixedShapeSize: drawingToolsSettings.fixedShapeSize,
+      shapeHandleSize:drawingToolsSettings.shapeHandleSize,
       hitOptions: {
         handles: true,
         stroke: true,
@@ -375,18 +376,24 @@
       this.removeFocus();
     },
 
+    // get the tool which controls given shape
+    getTool:function(shape){
+      for(var i=0;i<this.tools.length;i++){
+        if(shape.name.toString().indexOf(this.tools[i].idPrefix) !== -1){
+          return this.tools[i];
+        }
+      }
+    },
+
     // replaces paper.js objects with the required properties only.
     // 'shapes' coordinates are image coordiantes
     replaceShape: function(shape, annotation) {
-      var _this = this;
+
       //backward compatibility when changing shapes points
-      this.tools.forEach(function(tool,index){
-        if(shape.name.toString().indexOf(tool.idPrefix) !== -1){
-          if(_this.tools[index].SEGMENT_POINTS_COUNT && _this.tools[index].SEGMENT_POINTS_COUNT !== shape.segments.length){
-            _this.tools[index].adaptSegments(shape,_this);
-          }
-        }
-      });
+      var shapeTool = this.getTool(shape);
+      if(shapeTool && shapeTool.SEGMENT_POINTS_COUNT && shapeTool.SEGMENT_POINTS_COUNT !== shape.segments.length){
+        shapeTool.adaptSegments(shape,this);
+      }
 
       var cloned = new this.paperScope.Path({
         segments: shape.segments,
@@ -614,7 +621,7 @@
         eventEmitter: this.eventEmitter,
         windowId: this.windowId
       });
-
+      
       if (this.availableExternalCommentsPanel) {
         this.eventEmitter.publish('annotationShapeCreated.' + this.windowId, [this, shape]);
         return;

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -423,13 +423,12 @@
     // creating shapes used for backward compatibility.
     // shape coordinates are viewport coordinates.
     createRectangle: function(shape, annotation) {
-      var scale = this.viewer.viewport.contentSize.x;
       var paperItems = [];
       var rect = new $.Rectangle();
       var newShape = this.viewer.viewport.viewportToImageRectangle(shape);
       var initialPoint = {
-        'x': newShape.x * scale,
-        'y': newShape.y * scale
+        'x': newShape.x,
+        'y': newShape.y
       };
       var currentMode = this.mode;
       var currentPath = this.path;
@@ -443,8 +442,8 @@
       this.path = rect.createShape(initialPoint, this);
       var eventData = {
         'delta': {
-          'x': newShape.width * scale,
-          'y': newShape.height * scale
+          'x': newShape.width,
+          'y': newShape.height
         }
       };
       rect.onMouseDrag(eventData, this);

--- a/js/src/annotations/osd-svg-pin.js
+++ b/js/src/annotations/osd-svg-pin.js
@@ -48,6 +48,21 @@
         }
       }
     },
+    
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
+      }
+    },
 
     onMouseUp: function(event, overlay) {
       // Empty block.

--- a/js/src/annotations/osd-svg-polygon.js
+++ b/js/src/annotations/osd-svg-polygon.js
@@ -32,6 +32,21 @@
       }
     },
 
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
+      }
+    },
+
     onMouseUp: function(event, overlay) {
       // Empty block.
     },

--- a/js/src/annotations/osd-svg-rectangle.js
+++ b/js/src/annotations/osd-svg-rectangle.js
@@ -73,6 +73,21 @@
         }
       }
     },
+    //TODO Radoslav unit test
+    onHover:function(activate,shape,hoverColor){
+      // shape needs to have hovered styles
+      if(activate && !shape.data.hovered){
+        shape.data.nonHoverStroke = shape.strokeColor.clone();
+        shape.data.hovered = true;
+        shape.strokeColor = hoverColor;
+      }
+      // shape is not longer hovered
+      if(!activate && shape.data.hovered){
+        shape.strokeColor = shape.data.nonHoverStroke.clone();
+        delete shape.data.nonHoverStroke;
+        delete shape.data.hovered;
+      }
+    },
 
     // Old rectangle shapes does not have rotation handle point
     // add it manually for old shapes

--- a/js/src/annotations/osd-svg-rectangle.js
+++ b/js/src/annotations/osd-svg-rectangle.js
@@ -73,7 +73,7 @@
         }
       }
     },
-    //TODO Radoslav unit test
+    
     onHover:function(activate,shape,hoverColor){
       // shape needs to have hovered styles
       if(activate && !shape.data.hovered){

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -109,11 +109,15 @@
       'doubleClickReactionTime': 300,
       'strokeColor': 'deepSkyBlue',
       'fillColor': 'deepSkyBlue',
-      'fillColorAlpha': 0.0
+      'fillColorAlpha': 0.0,
+      'shapeHandleSize':10,
+      'fixedShapeSize':10,
+      'hoverColor':'yellow'
     },
 
     'availableExternalCommentsPanel': false,
     'shapeHandleSize':10,
+
 
     'availableCanvasTools': [
 

--- a/spec/annotations/osd-svg-ellipse.test.js
+++ b/spec/annotations/osd-svg-ellipse.test.js
@@ -560,5 +560,36 @@ describe('Ellipse', function() {
 
       expect(document.body.style.cursor).toBe('default');
     });
+
+    it('should change stroke when hovering ellipse',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.ellipse.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering ellipse',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.ellipse.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.ellipse.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
+    });
+
   });
 });

--- a/spec/annotations/osd-svg-freehand.test.js
+++ b/spec/annotations/osd-svg-freehand.test.js
@@ -118,6 +118,36 @@ describe('Freehand', function() {
       expect(this.shape.selected).toBe(true);
     });
 
+    it('should change stroke when hovering freehand',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.freehand.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering freehand',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.freehand.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.freehand.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
+    });
+
     it('should do nothing', function() {
       var event = getEvent({
         'x': 100,

--- a/spec/annotations/osd-svg-pin.test.js
+++ b/spec/annotations/osd-svg-pin.test.js
@@ -126,6 +126,36 @@ describe('Pin', function() {
       expect(this.shape.strokeColor.blue).toBe(redColor.blue);
     });
 
+    it('should change stroke when hovering pin',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.pin.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering pin',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.pin.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.pin.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
+    });
+
     it('should do nothing', function() {
       var event = getEvent({
         'x': 100,

--- a/spec/annotations/osd-svg-polygon.test.js
+++ b/spec/annotations/osd-svg-polygon.test.js
@@ -118,6 +118,36 @@ describe('Polygon', function() {
       expect(this.shape.selected).toBe(true);
     });
 
+    it('should change stroke when hovering polygon',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.polygon.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering polygon',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.polygon.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.polygon.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
+    });
+
     it('should do nothing', function() {
       var event = getEvent({
         'x': 100,

--- a/spec/annotations/osd-svg-rectangle.test.js
+++ b/spec/annotations/osd-svg-rectangle.test.js
@@ -38,10 +38,10 @@ describe('Rectangle', function() {
     this.canvas.attr('id', 'paperId');
     jasmine.getFixtures().set(this.canvas);
     paper.setup(this.canvas.attr('id'));
-    this.rect = new Mirador.Rectangle();
+    this.rectangle = new Mirador.Rectangle();
   });
   afterAll(function() {
-    delete this.rect;
+    delete this.rectangle;
   });
 
   it('should create rectangular shape', function() {
@@ -50,7 +50,7 @@ describe('Rectangle', function() {
       'y': 456
     };
     var overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, null, null, null);
-    var shape = this.rect.createShape(initialPoint, overlay);
+    var shape = this.rectangle.createShape(initialPoint, overlay);
 
     expect(overlay.mode).toBe('create');
 
@@ -72,7 +72,7 @@ describe('Rectangle', function() {
 
     expect(shape.fullySelected).toBe(true);
 
-    expect(shape.name).toBe(this.rect.idPrefix + '1');
+    expect(shape.name).toBe(this.rectangle.idPrefix + '1');
 
     expect(shape.segments.length).toBe(9);
 
@@ -109,17 +109,17 @@ describe('Rectangle', function() {
 
     beforeEach(function() {
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
-      this.rect = new Mirador.Rectangle();
+      this.rectangle = new Mirador.Rectangle();
       this.initialPoint = {
         'x': 987,
         'y': 654
       };
-      this.shape = this.rect.createShape(this.initialPoint, overlay);
+      this.shape = this.rectangle.createShape(this.initialPoint, overlay);
     });
 
     afterEach(function() {
       delete this.shape;
-      delete this.rect;
+      delete this.rectangle;
     });
 
     it('should update selection', function() {
@@ -130,19 +130,49 @@ describe('Rectangle', function() {
         'y': 654
       };
       var ellipse = ellipseTool.createShape(initialPoint, overlay);
-      this.rect.updateSelection(true, ellipse, overlay);
+      this.rectangle.updateSelection(true, ellipse, overlay);
 
       expect(this.shape.fullySelected).toBe(false);
 
-      this.rect.updateSelection(true, this.shape, overlay);
+      this.rectangle.updateSelection(true, this.shape, overlay);
 
       expect(this.shape.fullySelected).toBe(true);
 
       this.shape.scale(-10);
 
-      this.rect.updateSelection(true, this.shape, overlay);
+      this.rectangle.updateSelection(true, this.shape, overlay);
 
       expect(this.shape.fullySelected).toBe(true);
+    });
+
+    it('should change stroke when hovering rectangle',function(){
+      var red = {
+        r:1,
+        g:0,
+        b:0
+      };
+      this.rectangle.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.hovered).toBe(true);
+      expect(this.shape.strokeColor.red).toBe(red.r);
+      expect(this.shape.strokeColor.green).toBe(red.g);
+      expect(this.shape.strokeColor.blue).toBe(red.b);
+    });
+
+    it('should change stroke back to original when not hovering rectangle',function(){
+
+      var oldColor = this.shape.strokeColor;
+      this.rectangle.onHover(true,this.shape,'red');
+
+      expect(this.shape.data.nonHoverStroke.red).toBe(oldColor.red);
+      expect(this.shape.data.nonHoverStroke.green).toBe(oldColor.green);
+      expect(this.shape.data.nonHoverStroke.blue).toBe(oldColor.blue);
+
+      this.rectangle.onHover(false,this.shape);
+      expect(this.shape.data.hovered).toBe(undefined);
+      expect(this.shape.strokeColor.red).toBe(oldColor.red);
+      expect(this.shape.strokeColor.green).toBe(oldColor.green);
+      expect(this.shape.strokeColor.blue).toBe(oldColor.blue);
     });
 
     it('should do nothing', function() {
@@ -159,7 +189,7 @@ describe('Rectangle', function() {
         };
         expected.push(point);
       }
-      this.rect.onMouseDrag(event, overlay);
+      this.rectangle.onMouseDrag(event, overlay);
 
       expect(this.shape.segments.length).toBe(expected.length);
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
@@ -174,7 +204,7 @@ describe('Rectangle', function() {
         'y': -3
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'translate', this.shape, null);
-      this.rect.onMouseDrag(event, overlay);
+      this.rectangle.onMouseDrag(event, overlay);
 
       expect(this.shape.segments[0].point.x - event.delta.x).toBe(this.initialPoint.x - 2);
       expect(this.shape.segments[0].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
@@ -210,7 +240,7 @@ describe('Rectangle', function() {
         'y': 100
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[5]);
-      this.rect.onMouseDrag(event, overlay);
+      this.rectangle.onMouseDrag(event, overlay);
 
       expect(this.shape.segments[0].point.x).toBe(this.initialPoint.x - 2);
       expect(this.shape.segments[0].point.y).toBe(this.initialPoint.y - 2);
@@ -244,7 +274,7 @@ describe('Rectangle', function() {
         'y': 10
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[0]);
-      this.rect.onMouseDrag(event2, overlay);
+      this.rectangle.onMouseDrag(event2, overlay);
 
       expect(this.shape.segments[0].point.x - event2.delta.x).toBe(this.initialPoint.x - 2);
       expect(this.shape.segments[0].point.y - event2.delta.y).toBe(this.initialPoint.y - 2);
@@ -280,7 +310,7 @@ describe('Rectangle', function() {
         'y': 100
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[2]);
-      this.rect.onMouseDrag(event, overlay);
+      this.rectangle.onMouseDrag(event, overlay);
 
       expect(this.shape.segments[0].point.x).toBe(this.initialPoint.x - 2);
       expect(this.shape.segments[0].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
@@ -314,7 +344,7 @@ describe('Rectangle', function() {
         'y': 10
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', this.shape, this.shape.segments[4]);
-      this.rect.onMouseDrag(event2, overlay);
+      this.rectangle.onMouseDrag(event2, overlay);
 
       expect(this.shape.segments[0].point.x).toBe(this.initialPoint.x - 2);
       expect(this.shape.segments[0].point.y - event.delta.y).toBe(this.initialPoint.y - 2);
@@ -378,7 +408,7 @@ describe('Rectangle', function() {
         point = rotatePoint(point, localCenterPoint, rotationAngle);
         expected.push(point);
       }
-      this.rect.onMouseDrag(event, overlay);
+      this.rectangle.onMouseDrag(event, overlay);
 
       expect(this.shape.segments.length).toBe(expected.length);
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
@@ -394,17 +424,17 @@ describe('Rectangle', function() {
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
       spyOn(overlay, 'onDrawFinish');
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.path).not.toBeNull();
       expect(overlay.onDrawFinish.calls.count()).toEqual(0);
 
-      this.rect.onMouseUp(event, overlay);
+      this.rectangle.onMouseUp(event, overlay);
 
       expect(overlay.onDrawFinish.calls.count()).toEqual(1);
 
       overlay.mode = '';
-      this.rect.onMouseUp(event, overlay);
+      this.rectangle.onMouseUp(event, overlay);
 
       expect(overlay.onDrawFinish.calls.count()).toEqual(1);
     });
@@ -415,14 +445,14 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y - 1
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('translate');
       expect(overlay.segment).toBeNull();
       expect(overlay.path).toBe(this.shape);
       expect(document.body.style.cursor).toBe('move');
 
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('');
       expect(overlay.segment).toBeNull();
@@ -433,14 +463,14 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[5]);
       expect(overlay.path).toBe(this.shape);
       expect(document.body.style.cursor).toContain('data:image/png;base64');
 
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('');
       expect(overlay.segment).toBeNull();
@@ -450,7 +480,7 @@ describe('Rectangle', function() {
         'x': this.initialPoint.x,
         'y': this.initialPoint.y - 1
       });
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[4]);
@@ -464,7 +494,7 @@ describe('Rectangle', function() {
         'x': this.initialPoint.x,
         'y': this.initialPoint.y - 2
       });
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[3]);
@@ -478,7 +508,7 @@ describe('Rectangle', function() {
         'x': this.initialPoint.x - 1,
         'y': this.initialPoint.y - 2
       });
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[1]);
@@ -492,7 +522,7 @@ describe('Rectangle', function() {
         'x': this.initialPoint.x - 2,
         'y': this.initialPoint.y - 2
       });
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[0]);
@@ -506,7 +536,7 @@ describe('Rectangle', function() {
         'x': this.initialPoint.x - 1,
         'y': this.initialPoint.y
       });
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[6]);
@@ -520,7 +550,7 @@ describe('Rectangle', function() {
         'x': this.initialPoint.x - 2,
         'y': this.initialPoint.y
       });
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[7]);
@@ -534,7 +564,7 @@ describe('Rectangle', function() {
         'x': this.initialPoint.x - 2,
         'y': this.initialPoint.y - 1
       });
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[8]);
@@ -548,8 +578,8 @@ describe('Rectangle', function() {
         'x': this.initialPoint.x - 1,
         'y': this.initialPoint.y - 22
       });
-      this.rect.updateSelection(true, this.shape, overlay);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.updateSelection(true, this.shape, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBeNull();
@@ -561,7 +591,7 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y - 1
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'translate', null, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(document.body.style.cursor).toBe('default');
 
@@ -570,7 +600,7 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y + 100
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', null, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(document.body.style.cursor).toBe('default');
 
@@ -579,7 +609,7 @@ describe('Rectangle', function() {
         'y': this.initialPoint.y - 100
       });
       overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, '', this.shape, null);
-      this.rect.onMouseDown(event, overlay);
+      this.rectangle.onMouseDown(event, overlay);
 
       expect(document.body.style.cursor).toBe('default');
     });


### PR DESCRIPTION
Mark all annotation's shapes as 'active' when hovering one of them

You can configure hover color by:

'drawingToolsSettings': { 'hoverColor': 'yellow' },

color can be anything from http://paperjs.org/reference/color/