### PR TITLE
Fix exception thrown when entering in fullscreen mode

### DIFF
--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -350,7 +350,7 @@
       });
 
       jQuery(document).on("webkitfullscreenchange mozfullscreenchange fullscreenchange", function() {
-        _this.fullScreen();
+        _this.toggleFullScreen();
       });
 
     },
@@ -817,7 +817,7 @@
       }
     },
 
-    fullScreen: function() {
+    toggleFullScreen: function() {
       var _this = this;
       if (!OpenSeadragon.isFullScreen()) {
         this.element.find('.mirador-osd-fullscreen i').removeClass('fa-compress').addClass('fa-expand');


### PR DESCRIPTION
Rename the function because it seems the same variable name has already been used to hold to bool state