### PR TITLE
Change cursor on move for rectangles/ellipse

### DIFF
--- a/js/src/annotations/osd-svg-ellipse.js
+++ b/js/src/annotations/osd-svg-ellipse.js
@@ -211,7 +211,75 @@
     },
 
     onMouseMove: function(event, overlay) {
-      // Empty block.
+      var hitResult = overlay.paperScope.project.hitTest(event.point, overlay.hitOptions);
+
+      if(hitResult && hitResult.item._name.indexOf(this.idPrefix)!==-1){
+        if(!overlay.disabled && overlay.path){
+          this.setCursor(hitResult,overlay);
+        }
+      }else{
+        jQuery(overlay.viewer.canvas).css('cursor','crosshair');
+      }
+    },
+
+
+    setCursor:function(hitResult,overlay){
+
+      if(hitResult.type === 'stroke'){
+        jQuery(overlay.viewer.canvas).css('cursor','move');
+        return;
+      }
+      var cursor = '';
+      var rotation = hitResult.item.data.rotation;
+      switch (hitResult.segment) {
+        case hitResult.item.segments[0]:
+          cursor = 'arrows-v';
+          rotation -= 45;
+          break;
+        case hitResult.item.segments[1]:
+          cursor = 'arrows-v';
+          break;
+        case hitResult.item.segments[2]:
+          cursor = 'arrows-v';
+          break;
+        case hitResult.item.segments[3]:
+          cursor = 'arrows-v';
+          break;
+        case hitResult.item.segments[4]:
+          cursor = 'arrows-v';
+          rotation += 45;
+          break;
+        case hitResult.item.segments[5]:
+          cursor = 'arrows-h';
+          break;
+        case hitResult.item.segments[6]:
+          cursor = 'arrows-v';
+          rotation -= 45;
+          break;
+        case hitResult.item.segments[7]:
+          cursor = 'arrows-v';
+          break;
+        case hitResult.item.segments[8]:
+          cursor = 'arrows-v';
+          rotation += 45;
+          break;
+        case hitResult.item.segments[9]:
+          cursor = 'arrows-h';
+          break;
+        default:
+          cursor = 'crosshair';
+          break;
+      }
+
+      if(hitResult.type === 'handle-out'){
+        cursor = 'repeat';
+      }
+      jQuery(overlay.viewer.canvas).awesomeCursor(cursor, {
+        color: 'white',
+        hotspot: 'center',
+        rotate: rotation
+      });
+
     },
 
     onMouseDown: function(event, overlay) {
@@ -228,52 +296,7 @@
                 hotspot: 'center'
               });
             } else {
-              var cursor = '';
-              var rotation = hitResult.item.data.rotation;
-              switch (hitResult.segment) {
-                case hitResult.item.segments[0]:
-                  cursor = 'arrows-v';
-                  rotation -= 45;
-                  break;
-                case hitResult.item.segments[1]:
-                  cursor = 'arrows-v';
-                  break;
-                case hitResult.item.segments[2]:
-                  cursor = 'arrows-v';
-                  break;
-                case hitResult.item.segments[3]:
-                  cursor = 'arrows-v';
-                  break;
-                case hitResult.item.segments[4]:
-                  cursor = 'arrows-v';
-                  rotation += 45;
-                  break;
-                case hitResult.item.segments[5]:
-                  cursor = 'arrows-h';
-                  break;
-                case hitResult.item.segments[6]:
-                  cursor = 'arrows-v';
-                  rotation -= 45;
-                  break;
-                case hitResult.item.segments[7]:
-                  cursor = 'arrows-v';
-                  break;
-                case hitResult.item.segments[8]:
-                  cursor = 'arrows-v';
-                  rotation += 45;
-                  break;
-                case hitResult.item.segments[9]:
-                  cursor = 'arrows-h';
-                  break;
-                default:
-                  cursor = 'default';
-                  break;
-              }
-              jQuery('body').awesomeCursor(cursor, {
-                color: 'white',
-                hotspot: 'center',
-                rotate: rotation
-              });
+              this.setCursor(hitResult,overlay);
             }
           } else {
             overlay.mode = 'translate';

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -186,7 +186,7 @@
     onMouseUp: function(event) {
       if (!this.overlay.disabled) {
         event.stopPropagation();
-        document.body.style.cursor = "default";
+        jQuery(this.overlay.viewer.canvas).css('cursor','crosshair');
         if (this.overlay.mode === 'deform' || this.overlay.mode === 'edit') {
           this.overlay.segment = null;
           this.overlay.path = null;
@@ -216,11 +216,12 @@
       this.overlay.cursorLocation = event.point;
       if (!this.overlay.disabled) {
         // We are in drawing mode
-        if (this.overlay.paperScope.project.hitTest(event.point, this.overlay.hitOptions)) {
-          document.body.style.cursor = "pointer";
-        } else {
-          document.body.style.cursor = "default";
-        }
+       // if (this.overlay.paperScope.project.hitTest(event.point, this.overlay.hitOptions)) {
+       //
+       //   document.body.style.cursor = "pointer";
+       // } else {
+       //   document.body.style.cursor = "default";
+      //  }
         event.stopPropagation();
         this.overlay.currentTool.onMouseMove(event, this.overlay);
       } else {

--- a/js/src/annotations/osd-svg-rectangle.js
+++ b/js/src/annotations/osd-svg-rectangle.js
@@ -98,7 +98,7 @@
     },
 
     onMouseUp: function(event, overlay) {
-      if (overlay.mode == 'create' && overlay.path) {
+      if (overlay.mode === 'create' && overlay.path) {
         overlay.onDrawFinish();
       }
     },
@@ -180,7 +180,73 @@
     },
 
     onMouseMove: function(event, overlay) {
-      // Empty block.
+      var hitResult = overlay.paperScope.project.hitTest(event.point, overlay.hitOptions);
+
+      if(hitResult && hitResult.item._name.indexOf(this.idPrefix)!==-1){
+        if(!overlay.disabled && overlay.path){
+          this.setCursor(hitResult,overlay);
+        }
+      }else{
+        // out of the shape return back to crosshair
+        jQuery(overlay.viewer.canvas).css('cursor','crosshair');
+      }
+    },
+
+    setCursor:function(hitResult,overlay){
+
+      if(hitResult.type === 'stroke'){
+        jQuery(overlay.viewer.canvas).css('cursor','move');
+        return;
+      }
+      var cursor = '';
+      var rotation = hitResult.item.data.rotation;
+      switch (hitResult.segment) {
+        case hitResult.item.segments[0]:
+          cursor = 'arrows-v';
+          rotation -= 45;
+          break;
+        case hitResult.item.segments[1]:
+          cursor = 'arrows-v';
+          break;
+        case hitResult.item.segments[2]:
+          cursor = 'arrows-v';
+          break;
+        case hitResult.item.segments[3]:
+          cursor = 'arrows-v';
+          rotation += 45;
+          break;
+        case hitResult.item.segments[4]:
+          cursor = 'arrows-h';
+          break;
+        case hitResult.item.segments[5]:
+          cursor = 'arrows-v';
+          rotation -= 45;
+          break;
+        case hitResult.item.segments[6]:
+          cursor = 'arrows-v';
+          break;
+        case hitResult.item.segments[7]:
+          cursor = 'arrows-v';
+          rotation += 45;
+          break;
+        case hitResult.item.segments[8]:
+          cursor = 'arrows-h';
+          break;
+        default:
+          cursor = 'crosshair';
+          break;
+      }
+
+      // soon to be changed to raster
+      if(hitResult.type === 'handle-out'){
+        cursor = 'repeat';
+      }
+      jQuery(overlay.viewer.canvas).awesomeCursor(cursor, {
+        color: 'white',
+        hotspot: 'center',
+        rotate: rotation
+      });
+
     },
 
     onMouseDown: function(event, overlay) {
@@ -192,54 +258,12 @@
             overlay.segment = null;
             overlay.path = null;
             if (hitResult.type == 'handle-out') {
-              jQuery('body').awesomeCursor('repeat', {
+              jQuery(overlay.viewer.canvas).awesomeCursor('repeat', {
                 color: 'white',
                 hotspot: 'center'
               });
             } else {
-              var cursor = '';
-              var rotation = hitResult.item.data.rotation;
-              switch (hitResult.segment) {
-                case hitResult.item.segments[0]:
-                  cursor = 'arrows-v';
-                  rotation -= 45;
-                  break;
-                case hitResult.item.segments[1]:
-                  cursor = 'arrows-v';
-                  break;
-                case hitResult.item.segments[2]:
-                  cursor = 'arrows-v';
-                  break;
-                case hitResult.item.segments[3]:
-                  cursor = 'arrows-v';
-                  rotation += 45;
-                  break;
-                case hitResult.item.segments[4]:
-                  cursor = 'arrows-h';
-                  break;
-                case hitResult.item.segments[5]:
-                  cursor = 'arrows-v';
-                  rotation -= 45;
-                  break;
-                case hitResult.item.segments[6]:
-                  cursor = 'arrows-v';
-                  break;
-                case hitResult.item.segments[7]:
-                  cursor = 'arrows-v';
-                  rotation += 45;
-                  break;
-                case hitResult.item.segments[8]:
-                  cursor = 'arrows-h';
-                  break;
-                default:
-                  cursor = 'default';
-                  break;
-              }
-              jQuery('body').awesomeCursor(cursor, {
-                color: 'white',
-                hotspot: 'center',
-                rotate: rotation
-              });
+              this.setCursor(hitResult,overlay);
             }
           } else {
             overlay.mode = 'translate';

--- a/spec/annotations/osd-svg-ellipse.test.js
+++ b/spec/annotations/osd-svg-ellipse.test.js
@@ -12,6 +12,9 @@ describe('Ellipse', function() {
 
   function getOverlay(paperScope, strokeColor, fillColor, fillColorAlpha, mode, path, segment) {
     return {
+      'viewer':{
+        canvas:''
+      },
       'paperScope': paperScope,
       'strokeColor': strokeColor,
       'fillColor': fillColor,
@@ -415,7 +418,6 @@ describe('Ellipse', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[6]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       this.ellipse.onMouseDown(event, overlay);
 
@@ -432,7 +434,6 @@ describe('Ellipse', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[5]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -446,7 +447,6 @@ describe('Ellipse', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[4]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -460,7 +460,6 @@ describe('Ellipse', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[1]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -474,7 +473,6 @@ describe('Ellipse', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[0]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -488,7 +486,6 @@ describe('Ellipse', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[7]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -502,7 +499,6 @@ describe('Ellipse', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[8]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -516,7 +512,6 @@ describe('Ellipse', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[9]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -531,7 +526,6 @@ describe('Ellipse', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBeNull();
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       event = getEvent({}, {
         'x': this.initialPoint.x - 1,

--- a/spec/annotations/osd-svg-rectangle.test.js
+++ b/spec/annotations/osd-svg-rectangle.test.js
@@ -11,6 +11,9 @@ describe('Rectangle', function() {
 
   function getOverlay(paperScope, strokeColor, fillColor, fillColorAlpha, mode, path, segment) {
     return {
+      'viewer':{
+        canvas:''
+      },
       'paperScope': paperScope,
       'strokeColor': strokeColor,
       'fillColor': fillColor,
@@ -468,7 +471,6 @@ describe('Rectangle', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[5]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       this.rectangle.onMouseDown(event, overlay);
 
@@ -485,7 +487,6 @@ describe('Rectangle', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[4]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -499,7 +500,6 @@ describe('Rectangle', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[3]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -513,7 +513,6 @@ describe('Rectangle', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[1]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -527,7 +526,6 @@ describe('Rectangle', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[0]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -541,7 +539,6 @@ describe('Rectangle', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[6]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -555,7 +552,6 @@ describe('Rectangle', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[7]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -569,7 +565,6 @@ describe('Rectangle', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBe(this.shape.segments[8]);
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       overlay.mode = '';
       overlay.segment = null;
@@ -584,7 +579,6 @@ describe('Rectangle', function() {
       expect(overlay.mode).toBe('deform');
       expect(overlay.segment).toBeNull();
       expect(overlay.path).toBe(this.shape);
-      expect(document.body.style.cursor).toContain('data:image/png;base64');
 
       event = getEvent({}, {
         'x': this.initialPoint.x - 1,


### PR DESCRIPTION
@rsinghal 
Change cursor icon on move depending where it pointed to when shape is selected.

I implemented it only for rectangles and ellipses because the other tools need to be refactored before that. Currently there are some issues with shape selecting (the reason why sometimes the shape is selected but no cursors change (updateSelection function) which i fixed in another branch (https://github.com/SirmaITT/mirador/tree/feature/rotate-icon). (I plan to be ready for pull request in the next 1-2 days)

 I don't want to refactor the onMouseDown until rotate-icon branch is ready(I refactored parts of the code and there will be a lot merge conflicts that will slow me down). There might be slight coverage drop, but I prefer to refactor the existing unit tests before adding more on top of them. 

This is what I am planning to do in order to remove the repeating code snippets in unit tests. (https://github.com/IIIF/mirador/issues/1010 ( I'll do it as part of https://github.com/SirmaITT/mirador/tree/feature/rotate-icon branch ).
