### PR TITLE
Deletes shape when clicked on the trash can icon.

### DIFF
--- a/js/src/annotations/annotation-utils.js
+++ b/js/src/annotations/annotation-utils.js
@@ -121,8 +121,7 @@
   };
   DeleteActionIcon.prototype.setOnMouseDownListener = function (overlay) {
     this.mouseDown = function () {
-      console.log('SHOULD DELETE_SHAPE');
-      overlay.eventEmitter.publish('deleteShape.' + overlay.windowId, '');
+      overlay.eventEmitter.publish('deleteShape.' + overlay.windowId, this.getData('parent'));
     };
   };
   DeleteActionIcon.prototype.rotate = function(angle,pivot){

--- a/js/src/annotations/annotationTooltip.js
+++ b/js/src/annotations/annotationTooltip.js
@@ -94,7 +94,9 @@
 
             jQuery(selector + ' a.save').on("click", function(event) {
               event.preventDefault();
-
+              if(!params.onSaveClickCheck()){
+                return;
+              }
               var annotation = _this.activeEditor.createAnnotation();
               if (params.onAnnotationCreated) { params.onAnnotationCreated(annotation); }
               // return to pointer mode
@@ -239,6 +241,11 @@
         var display = jQuery(this).parents('.annotation-editor');
         var id = display.attr('data-anno-id');
         var oaAnno = viewerParams.getAnnoFromRegion(id)[0];
+
+        if(!viewerParams.onSaveClickCheck(oaAnno)){
+          return;
+        }
+
         _this.activeEditor.updateAnnotation(oaAnno);
         viewerParams.onAnnotationSaved(oaAnno);
         _this.unFreezeQtip(api, oaAnno, viewerParams);

--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -90,7 +90,21 @@
         container: windowElement,
         viewport: windowElement,
         getAnnoFromRegion: _this.getAnnoFromRegion.bind(this),
+        onSaveClickCheck: function (oaAnno) {
+
+          if (!_this.svgOverlay.draftPaths.length) {
+            // TODO use global notification system
+            return window.confirm('There are no shapes related to this annotation. Saving the annotation will delete it.');
+          }
+          return true;
+        },
         onAnnotationSaved: function(oaAnno) {
+
+          if(!_this.svgOverlay.draftPaths.length){
+            _this.eventEmitter.publish('annotationDeleted.' + _this.windowId, [oaAnno['@id']]);
+            return;
+          }
+
           var svg = _this.svgOverlay.getSVGString(_this.svgOverlay.draftPaths);
           oaAnno.on = {
             "@type": "oa:SpecificResource",

--- a/js/src/annotations/osd-svg-ellipse.js
+++ b/js/src/annotations/osd-svg-ellipse.js
@@ -4,7 +4,6 @@
       name: 'Ellipse',
       logoClass: 'radio_button_unchecked',
       idPrefix: 'ellipse_',
-      partOfPrefix:'_partOf',
       tooltip: 'ellipseTooltip'
     }, options);
 

--- a/js/src/annotations/osd-svg-freehand.js
+++ b/js/src/annotations/osd-svg-freehand.js
@@ -5,7 +5,6 @@
       logoClass: 'gesture',
       idPrefix: 'smooth_path_',
       tooltip: 'freehandTooltip',
-      partOfPrefix:'_partOf'
     }, options);
 
     this.init();

--- a/js/src/annotations/osd-svg-pin.js
+++ b/js/src/annotations/osd-svg-pin.js
@@ -5,7 +5,6 @@
       logoClass: 'room',
       idPrefix: 'pin_',
       tooltip: 'pinTooltip',
-      partOfPrefix:'_partOf'
     }, options);
 
     this.init();

--- a/js/src/annotations/osd-svg-polygon.js
+++ b/js/src/annotations/osd-svg-polygon.js
@@ -4,8 +4,7 @@
       name: 'Polygon',
       logoClass: 'timeline',
       idPrefix: 'rough_path_',
-      tooltip: 'polygonTooltip',
-      partOfPrefix:'_partOf'
+      tooltip: 'polygonTooltip'
     }, options);
 
     this.init();
@@ -159,7 +158,7 @@
 
     onMouseDown: function(event, overlay) {
       var hitResult = overlay.paperScope.project.hitTest(event.point, overlay.hitOptions);
-      if (hitResult && hitResult.item._name.toString().indexOf(this.idPrefix) != -1) {
+      if (hitResult && hitResult.item._name.toString().indexOf(this.idPrefix) !== -1) {
 
         if (hitResult.item._name.toString().indexOf(this.partOfPrefix) !== -1) {
           hitResult.item.data.self.onMouseDown();

--- a/js/src/annotations/osd-svg-rectangle.js
+++ b/js/src/annotations/osd-svg-rectangle.js
@@ -4,10 +4,8 @@
       name: 'Rectangle',
       logoClass: 'check_box_outline_blank',
       idPrefix: 'rectangle_',
-      partOfPrefix:'_partOf',
       tooltip: 'rectangleTooltip'
     }, options);
-
     this.init();
   };
 

--- a/spec/annotations/annotation-utils.stub.js
+++ b/spec/annotations/annotation-utils.stub.js
@@ -11,6 +11,7 @@
     click: jasmine.createSpy(),
     setOnMouseDownListener: jasmine.createSpy(),
     onMouseDown: jasmine.createSpy(),
+    resize:jasmine.createSpy(),
     remove: jasmine.createSpy(),
     rotate: jasmine.createSpy(),
     getWidth: jasmine.createSpy(),
@@ -49,7 +50,8 @@
 
   AnnotationUtilsStub.prototype = {
     Icon: MockItem,
-    DeleteActionIcon: MockItem,
+    PointText:MockItem,
+    DeleteActionIcon:MockItem,
     Group: MockGroup
   };
 

--- a/spec/annotations/osd-svg-ellipse.test.js
+++ b/spec/annotations/osd-svg-ellipse.test.js
@@ -538,5 +538,30 @@ describe('Ellipse', function() {
       expect(item.selected).toBeUndefined();
     });
 
+    it('should resize the trash can icon when resized',function(){
+      var _this = this;
+      var item = {
+        '_name':{
+          toString:function(){
+            return _this.ellipse.idPrefix + _this.ellipse.partOfPrefix + 'delete';
+          }
+        },
+        data:{
+          self:new overlay.annotationUtils.DeleteActionIcon(),
+          parent:{ // should use mock shape
+            data:{
+              rotation:1
+            },
+            contains:jasmine.createSpy().and.returnValue(true)
+          }
+        }
+      };
+
+      this.ellipse.onResize(item,overlay);
+
+      expect(item.data.self.resize).toHaveBeenCalledWith(24);
+      expect(item.data.self.rotate).toHaveBeenCalledWith(180);
+    });
+
   });
 });

--- a/spec/annotations/osd-svg-freehand.test.js
+++ b/spec/annotations/osd-svg-freehand.test.js
@@ -441,5 +441,30 @@ describe('Freehand', function() {
         expect(this.shape.segments[idx].point.y).toBeCloseTo(expected[idx].y, 6);
       }
     });
+
+    it('should resize the trash can icon when resized',function(){
+      var _this = this;
+      var item = {
+        '_name':{
+          toString:function(){
+            return _this.freehand.idPrefix + _this.freehand.partOfPrefix + 'delete';
+          }
+        },
+        data:{
+          self:new overlay.annotationUtils.DeleteActionIcon(),
+          parent:{ // should use mock shape
+            data:{
+              rotation:1
+            },
+            contains:jasmine.createSpy().and.returnValue(true)
+          }
+        }
+      };
+
+      this.freehand.onResize(item,overlay);
+
+      expect(item.data.self.resize).toHaveBeenCalledWith(24);
+    });
+
   });
 });

--- a/spec/annotations/osd-svg-overlay.test.js
+++ b/spec/annotations/osd-svg-overlay.test.js
@@ -455,4 +455,23 @@ describe('Overlay', function() {
     //expect(svgTestTwo).toEqual(exportedSVGTestTwo);
   });
 
+  it('should delete shape',function(){
+
+    var mockShape = {
+      '_name': {
+        toString: function () {
+
+        }
+      },
+      remove:jasmine.createSpy()
+    };
+
+    this.overlay.draftPaths = [mockShape];
+
+    this.overlay.deleteShape(mockShape);
+
+    expect(this.overlay.draftPaths.length).toBe(0);
+    expect(mockShape.remove.calls.any()).toBe(true);
+  });
+
 });

--- a/spec/annotations/osd-svg-pin.test.js
+++ b/spec/annotations/osd-svg-pin.test.js
@@ -64,7 +64,7 @@ describe('Pin', function() {
       delete this.pin;
     });
 
-    it('should update selection', function() {
+    it('should update selection to true', function() {
       var initialPoint = {
         'x': 987,
         'y': 654
@@ -72,7 +72,6 @@ describe('Pin', function() {
 
       var event = TestUtils.getEvent(initialPoint);
 
-      this.pin.onMouseUp(event, overlay);
       this.pin.updateSelection(true, this.shape, overlay);
 
       var redColor = {
@@ -84,6 +83,31 @@ describe('Pin', function() {
       expect(this.shape.strokeColor.red).toBe(redColor.red);
       expect(this.shape.strokeColor.green).toBe(redColor.green);
       expect(this.shape.strokeColor.blue).toBe(redColor.blue);
+      expect(this.shape.data.deleteIcon).not.toBeUndefined;
+    });
+
+    it('should update selection to false', function() {
+      var initialPoint = {
+        'x': 987,
+        'y': 654
+      };
+
+      var event = TestUtils.getEvent(initialPoint);
+
+      this.pin.updateSelection(true, this.shape, overlay);
+
+      this.pin.updateSelection(false, this.shape, overlay);
+
+      var redColor = {
+        red:1,
+        green: 0,
+        blue:0
+      };
+
+      expect(this.shape.strokeColor.red).toBe(redColor.red);
+      expect(this.shape.strokeColor.green).toBe(redColor.green);
+      expect(this.shape.strokeColor.blue).toBe(redColor.blue);
+      expect(this.shape.data.deleteIcon).toBeUndefined;
     });
 
     it('should change stroke when hovering pin',function(){
@@ -224,39 +248,31 @@ describe('Pin', function() {
 
       expect(overlay.mode).toBe('create');
     });
-/*
-      TODO Will fix it when refactoring the ping tool
-      event = TestUtils.getEvent({}, {
-        'x': this.initialPoint.x + 100,
-        'y': this.initialPoint.y + 100
-      });
-      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'translate', null, null);
-      this.pin.onMouseDown(event, overlay);
 
-      expect(overlay.mode).toBe('translate');
-      expect(overlay.segment).toBeNull();
-      expect(overlay.path).toBeNull();
 
-      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'deform', null, null);
-      this.pin.onMouseDown(event, overlay);
+    it('should resize the trash can icon',function(){
+      var _this = this;
+      var item = {
+        '_name':{
+          toString:function(){
+            return _this.pin.idPrefix + _this.pin.partOfPrefix + 'delete';
+          }
+        },
+        data:{
+          self:new overlay.annotationUtils.DeleteActionIcon(),
+          parent:{ // should use mock shape
+            data:{
+              rotation:1
+            },
+            contains:jasmine.createSpy().and.returnValue(true)
+          }
+        }
+      };
 
-      expect(overlay.mode).toBe('deform');
-      expect(overlay.segment).toBeNull();
-      expect(overlay.path).toBeNull();
+      this.pin.onResize(item,overlay);
 
-      event = TestUtils.getEvent({}, {
-        'x': this.initialPoint.x,
-        'y': this.initialPoint.y
-      });
-      overlay = getOverlay(paper, '#ff0000', '#00ff00', 1.0, 'translate', this.shape, null);
-      this.pin.onMouseDown(event, overlay);
-
-      expect(overlay.mode).toBe('');
-      expect(overlay.segment).toBeNull();
-      expect(overlay.path).toBeNull();
-      expect(document.body.style.cursor).toBe('default');
-
-      */
+      expect(item.data.self.resize).toHaveBeenCalledWith(24);
+    });
 
   });
 

--- a/spec/annotations/osd-svg-polygon.test.js
+++ b/spec/annotations/osd-svg-polygon.test.js
@@ -81,6 +81,22 @@ describe('Polygon', function() {
       expect(this.shape.selected).toBe(true);
     });
 
+    it('should update selection to true', function() {
+      this.polygon.updateSelection(true, this.shape, overlay);
+
+      expect(this.shape.selected).toBe(true);
+      expect(this.shape.data.deleteIcon).not.toBeUndefined;
+    });
+
+    it('should update selection to false', function() {
+      this.polygon.updateSelection(true, this.shape, overlay);
+      this.polygon.updateSelection(false, this.shape, overlay);
+
+      expect(this.shape.selected).toBe(false);
+      expect(this.shape.data.deleteIcon).toBeUndefined;
+    });
+
+
     it('should change stroke when hovering polygon',function(){
       var red = {
         r:1,
@@ -473,6 +489,32 @@ describe('Polygon', function() {
         expect(this.shape.segments[idx].point.y).toBeCloseTo(expected[idx].y, 6);
       }
     });
+
+    it('should resize the trash can icon when resized',function(){
+      var _this = this;
+      var item = {
+        '_name':{
+          toString:function(){
+            return _this.polygon.idPrefix + _this.polygon.partOfPrefix + 'delete';
+          }
+        },
+        data:{
+          self:new overlay.annotationUtils.DeleteActionIcon(),
+          parent:{ // should use mock shape
+            data:{
+              rotation:1
+            },
+            contains:jasmine.createSpy().and.returnValue(true)
+          }
+        }
+      };
+
+      this.polygon.onResize(item,overlay);
+
+      expect(item.data.self.resize).toHaveBeenCalledWith(24);
+    });
+
+
   });
 
 });

--- a/spec/annotations/osd-svg-rectangle.test.js
+++ b/spec/annotations/osd-svg-rectangle.test.js
@@ -574,6 +574,31 @@ describe('Rectangle', function() {
 
     });
 
+    it('should resize the trash can icon',function(){
+      var _this = this;
+      var item = {
+        '_name':{
+          toString:function(){
+            return _this.rectangle.idPrefix + _this.rectangle.partOfPrefix + 'delete';
+          }
+        },
+        data:{
+          self:new overlay.annotationUtils.DeleteActionIcon(),
+          parent:{ // should use mock shape
+            data:{
+              rotation:1
+            },
+            contains:jasmine.createSpy().and.returnValue(true)
+          }
+        }
+      };
+
+      this.rectangle.onResize(item,overlay);
+
+      expect(item.data.self.resize).toHaveBeenCalledWith(24);
+      expect(item.data.self.rotate).toHaveBeenCalledWith(180);
+    });
+
   });
   
 });

--- a/spec/annotations/overlay.stub.js
+++ b/spec/annotations/overlay.stub.js
@@ -3,7 +3,7 @@
     getOverlay: function (paperScope) {
       return {
         viewer: {
-          canvas: ''
+          canvas: '',
         },
         paperScope: paperScope,
         strokeColor: 'red',
@@ -22,11 +22,7 @@
         selectedColor:'red',
         fitFixedSizeShapes: jasmine.createSpy(),
         fixedShapeSize: 5,
-        annotationUtils: {
-          Icon: MockItem,
-          DeleteActionIcon:MockItem,
-          Group: MockGroup
-        },
+        annotationUtils: new AnnotationUtilsStub(),
         state: {
           getStateProperty: jasmine.createSpy()
         },


### PR DESCRIPTION
@rsinghal 
## This pr fixes:

Implement single shape delete action.
Deletes shape action is triggered when you click the trash can icon.
Confirmation message appears.

Add check if you try to create annotation without any shapes.

Add check if you edit annotation and you have deleted all shapes.
In case you have no shapes and you try to save it triggers confirmation that the annotation will be deleted.

Unsubscribe from all events in the osd overlay when the osd is closed (This should fix some large memory leaks)

## What will be fixed in future pr: (DONE (waiting to merge this pr in order to rebase on top of it and I'll send pr) )
@rsinghal @beaudet
All confirmation dialogs/popups will be modal implemented with the help of [http://bootboxjs.com/#](http://bootboxjs.com/#)
All messages displayed will be configured from the i18n langs

Refactor overlay to keep track of subscribed events in order to unsubscribe from all of them when needed (write unit test to watch for event subscription memory leaks)


