### PR TITLE
Refactor tools to handle new edit workflow

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -2009,3 +2009,11 @@ a.mirador-icon-window-menu, a.mirador-icon-view-type {
 .mce-edit-area iframe {
   height: 75px !important;
 }
+
+/* Disable outlines when canvas is focused
+---------------------------------------------------------------------------- */
+canvas {
+  outline: none;
+  -webkit-tap-highlight-color: rgba(255, 255, 255, 0); /* mobile webkit */
+}
+

--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -96,7 +96,7 @@
           var onAnnotationSaved = jQuery.Deferred();
 
           if (!_this.svgOverlay.draftPaths.length) {
-            new $.DialogBuilder().dialog({
+            new $.DialogBuilder(_this.svgOverlay.slotWindowElement).dialog({
               message: i18n.t('editModalSaveAnnotationWithNoShapesMsg'),
               buttons: {
                 success: {

--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -28,9 +28,11 @@
     },
 
     enterCreateShapeMode: function() {
-      this.osdViewer.setMouseNavEnabled(false);
-      this.svgOverlay.show();
-      this.svgOverlay.enable();
+      if(!this.svgOverlay.inEditMode){
+        this.osdViewer.setMouseNavEnabled(false);
+        this.svgOverlay.show();
+        this.svgOverlay.enable();
+      }
     },
 
     enterEditMode: function() {
@@ -122,6 +124,7 @@
               }
 
             });
+
           } else {
             var svg = _this.svgOverlay.getSVGString(_this.svgOverlay.draftPaths);
             oaAnno.on = {

--- a/js/src/annotations/osd-svg-ellipse.js
+++ b/js/src/annotations/osd-svg-ellipse.js
@@ -424,10 +424,8 @@
         if (overlay.mode != 'deform' && overlay.mode != 'translate' && overlay.mode != 'create') {
 
           if (hitResult.item._name.toString().indexOf(this.partOfPrefix) !== -1) {
-
             hitResult.item.data.self.onMouseDown();
             return;
-
           }
 
           if (hitResult.type === 'segment') {

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -757,6 +757,7 @@
       // Set special style for newly created shapes
       var newlyCreatedStrokeFactor = this.drawingToolsSettings.newlyCreatedShapeStrokeWidthFactor || 5;
       shape.data.newlyCreated = true;
+      shape.data.currentStrokeValue *= newlyCreatedStrokeFactor;
       shape.strokeWidth *= newlyCreatedStrokeFactor;
 
       this.hoveredPath = shape;
@@ -793,6 +794,7 @@
             for(var i=0;i<_this.draftPaths.length;i++){
               if(_this.draftPaths[i].data && _this.draftPaths[i].data.newlyCreated){
                 _this.draftPaths[i].strokeWidth /= newlyCreatedStrokeFactor;
+                _this.draftPaths[i].data.currentStrokeValue /=newlyCreatedStrokeFactor;
                 delete _this.draftPaths[i].data.newlyCreated;
               }
             }

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -63,7 +63,7 @@
     this.viewer.canvas.appendChild(this.canvas);
 
     var _this = this;
-    this.slotWindowElement = jQuery('#' + osdViewerId).parents('.window');
+    this.slotWindowElement = state.getWindowElement(this.windowId);
     this.state = state;
     this.eventEmitter = eventEmitter;
     var _thisResize = function() {

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -83,6 +83,10 @@
 
     this.viewer.addHandler('close',_thisDestroy);
 
+    _this.eventEmitter.subscribe('modeChange.' + _this.windowId,function(event,newMode){
+      _this.currentTool = '';
+    });
+
     _this.eventEmitter.subscribe('toggleDrawingTool.' + _this.windowId, function(event, tool) {
       //qtip code should NOT be here
       if (_this.disabled) {
@@ -857,6 +861,7 @@
       this.eventEmitter.unsubscribe('changeFillColor.' + this.windowId);
       this.eventEmitter.unsubscribe('changeBorderColor.' + this.windowId);
       this.eventEmitter.unsubscribe('SET_OVERLAY_TOOLTIP.' + this.windowId);
+      this.eventEmitter.unsubscribe('modeChange.' + this.windowId);
 
       this.viewer.removeAllHandlers('animation');
       this.viewer.removeAllHandlers('open');

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -56,13 +56,14 @@
     this.viewer = viewer;
     this.canvas = document.createElement('canvas');
     // workaround to remove focus from editor
-    jQuery(this.canvas).attr("tabindex", "0").mousedown(function(){ jQuery(this).focus();});
+    jQuery(this.canvas).attr('tabindex', '0').mousedown(function(){ jQuery(this).focus();});
     this.canvas.id = 'draw_canvas_' + this.windowId;
     // Drawing of overlay border during development.
     // this.canvas.style.border = '1px solid yellow';
     this.viewer.canvas.appendChild(this.canvas);
 
     var _this = this;
+    this.slotWindowElement = jQuery('#' + osdViewerId).parents('.window');
     this.state = state;
     this.eventEmitter = eventEmitter;
     var _thisResize = function() {
@@ -88,7 +89,7 @@
         jQuery('.qtip' + _this.windowId).qtip('hide');
         return;
       }
-      jQuery('#' + osdViewerId).parents(".window").find(".qtip-viewer").hide();
+      jQuery('#' + osdViewerId).parents('.window').find('.qtip-viewer').hide();
       _this.currentTool = null;
       for (var i = 0; i < _this.tools.length; i++) {
         if (_this.tools[i].logoClass === tool) {
@@ -103,7 +104,7 @@
         jQuery('.qtip' + _this.windowId).qtip('hide');
         return;
       }
-      jQuery('#' + osdViewerId).parents(".window").find(".qtip-viewer").hide();
+      jQuery('#' + osdViewerId).parents('.window').find('.qtip-viewer').hide();
       _this.currentTool = null;
       for (var i = 0; i < _this.availableAnnotationDrawingTools.length; i++) {
         for (var j = 0; j < _this.tools.length; j++) {
@@ -207,7 +208,7 @@
 
     handleDeleteShapeEvent: function (event, shape) {
       var _this = this;
-      new $.DialogBuilder().confirm(i18n.t('deleteShape'), function (result) {
+      new $.DialogBuilder(this.slotWindowElement).confirm(i18n.t('deleteShape'), function (result) {
         if (result) {
           _this.deleteShape(shape);
         }
@@ -276,9 +277,9 @@
       if (!this.overlay.disabled) {
         // We are in drawing mode
         if (this.overlay.paperScope.project.hitTest(event.point, this.overlay.hitOptions)) {
-          document.body.style.cursor = "pointer";
+          document.body.style.cursor = 'pointer';
         } else {
-          document.body.style.cursor = "default";
+          document.body.style.cursor = 'default';
         }
         event.stopPropagation();
         if (this.overlay.currentTool) {
@@ -417,8 +418,8 @@
       this.canvas.style.WebkitTransform = transform;
       this.canvas.style.msTransform = transform;
       this.canvas.style.transform = transform;
-      this.canvas.style.marginLeft = "0px";
-      this.canvas.style.marginTop = "0px";
+      this.canvas.style.marginLeft = '0px';
+      this.canvas.style.marginTop = '0px';
       if (this.paperScope && this.paperScope.view) {
         this.paperScope.view.viewSize = new this.paperScope.Size(this.canvas.width, this.canvas.height);
         this.paperScope.view.zoom = this.viewer.viewport.viewportToImageZoom(this.viewer.viewport.getZoom(true));
@@ -599,7 +600,7 @@
       var paperItems = [];
       var svgParser = new DOMParser();
       var svgDOM = svgParser.parseFromString(svg, "text/xml");
-      if (svgDOM.documentElement.nodeName == "parsererror") {
+      if (svgDOM.documentElement.nodeName == 'parsererror') {
         return; // if svg is not valid XML structure - backward compatibility.
       }
       var svgTag = this.paperScope.project.importSVG(svg);

--- a/js/src/annotations/osd-svg-pin.js
+++ b/js/src/annotations/osd-svg-pin.js
@@ -29,7 +29,10 @@
       var shape = new overlay.paperScope.Path(pathData);
       shape.name = overlay.getName(_this);
       shape.dashArray = overlay.dashArray;
-      shape.strokeWidth = 1 / overlay.paperScope.view.zoom;
+      shape.data.defaultStrokeValue = 1;
+      shape.data.editStrokeValue = 5;
+      shape.data.currentStrokeValue = shape.data.defaultStrokeValue;
+      shape.strokeWidth = shape.data.currentStrokeValue / overlay.paperScope.view.zoom;
       shape.strokeColor = overlay.strokeColor;
       shape.fillColor = overlay.fillColor;
       shape.fillColor.alpha = overlay.fillColorAlpha;

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -123,6 +123,7 @@
       'fillColorAlpha': 0.0,
       'shapeHandleSize':10,
       'fixedShapeSize':10,
+      'newlyCreatedShapeStrokeWidthFactor':5,
       'hoverColor':'yellow'
     },
 

--- a/js/src/utils/dialog-builder.js
+++ b/js/src/utils/dialog-builder.js
@@ -1,14 +1,32 @@
 (function ($) {
-  $.DialogBuilder = function (config) {
+  $.DialogBuilder = function (container) {
+    this.container = container || jQuery('.window');
 
+    bootbox.setDefaults({
+      container: this.container
+    });
   };
 
   $.DialogBuilder.prototype = {
     confirm: function (message, callback) {
-      return bootbox.confirm(message, callback);
+      return this._attachEvents(bootbox.confirm(message, callback));
     },
     dialog: function(opts){
-      return bootbox.dialog(opts);
+      this._attachEvents(bootbox.dialog(opts));
+    },
+    _attachEvents:function(el){
+      var _this = this;
+      jQuery(el).on("shown.bs.modal",function(){
+        // set bigger z-index that one used in qtip
+        var zIndex = 20000;
+
+        jQuery(el).css('z-index',zIndex);
+        // workaround because bootstap does not support external configuration for backdrop parent
+        jQuery('.modal-backdrop').prependTo(_this.container).css('z-index',zIndex);
+      });
+      jQuery(el).on("hidden.bs.modal",function(){
+        jQuery('.modal-backdrop').remove();
+      });
     }
   };
 

--- a/spec/annotations/osd-svg-freehand.test.js
+++ b/spec/annotations/osd-svg-freehand.test.js
@@ -152,7 +152,7 @@ describe('Freehand', function() {
         'y': -3
       });
       this.freehand.updateSelection(true,this.shape,overlay);
-      overlay.mode = 'edit';
+      overlay.mode = 'translate';
       overlay.path = this.shape;
       var expected = [];
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
@@ -172,7 +172,7 @@ describe('Freehand', function() {
 
       var selectedPointIndex = 1;
       overlay = MockOverlay.getOverlay(paper);
-      overlay.mode = 'edit';
+      overlay.mode = 'deform';
       overlay.path = this.shape;
       overlay.segment  = this.shape.segments[selectedPointIndex];
       expected = [];
@@ -233,6 +233,7 @@ describe('Freehand', function() {
       this.freehand.onMouseUp(event, overlay);
     });
 
+    // TODO this should be refactored
     it('should select freehand shape', function() {
       var event = TestUtils.getEvent({}, {
         'x': this.initialPoint.x - 100,
@@ -244,7 +245,6 @@ describe('Freehand', function() {
       expect(overlay.mode).toBe('create');
       expect(overlay.segment).toBeNull();
       expect(overlay.path).not.toBe(this.shape);
-      expect(document.body.style.cursor).toBe('default');
 
       event = TestUtils.getEvent({}, {
         'x': this.initialPoint.x - 100,
@@ -270,17 +270,14 @@ describe('Freehand', function() {
         expect(this.shape.segments[idx].point.y).toBeCloseTo(expected[idx].y, 6);
       }
 
-      expect(document.body.style.cursor).toBe('default');
-
       overlay = MockOverlay.getOverlay(paper);
-      overlay.mode = 'edit';
+      overlay.mode = 'translate';
       this.freehand.onMouseDown(event, overlay);
 
       expect(overlay.segment.point.x).toBe(event.point.x);
       expect(overlay.segment.point.y).toBe(event.point.y);
 
       expect(overlay.path).not.toBe(this.shape);
-      expect(document.body.style.cursor).toBe('move');
 
       overlay = MockOverlay.getOverlay(paper);
       overlay.mode = 'translate';
@@ -346,7 +343,7 @@ describe('Freehand', function() {
       });
 
       MockOverlay.getOverlay(paper);
-      overlay.mode='edit'
+      overlay.mode='edit';
       overlay.path = this.shape;
 
       expected = [];

--- a/spec/annotations/osd-svg-overlay.test.js
+++ b/spec/annotations/osd-svg-overlay.test.js
@@ -331,6 +331,37 @@ describe('Overlay', function() {
     expect(this.rectangle.onDoubleClick.calls.count()).toEqual(1);
   });
 
+  it('should not select non editable item',function(){
+    var stubbedTool = {
+      onMouseDown : jasmine.createSpy(),
+      onDoubleClick: jasmine.createSpy()
+    };
+
+    var event = getEvent({
+      'x': 100,
+      'y': 100
+    }, {
+      'x': 100,
+      'y': 100
+    });
+
+    var date = new Date();
+    this.overlay.latestMouseDownTime = date.getTime()  -2 * this.overlay.doubleClickReactionTime;
+    this.overlay.overlay = this.overlay;
+    this.overlay.disabled = false;
+
+    var rectangle = new Mirador.Rectangle();// TODO should use stubbed tool // should stub the hitTest
+    this.overlay.currentTool = rectangle;
+
+    event.item = rectangle.createShape(event.point, this.overlay);
+    this.overlay.mode = '';
+
+    this.overlay.onMouseDown(event);
+
+    expect(stubbedTool.onMouseDown.calls.count()).toEqual(0);
+    expect(stubbedTool.onDoubleClick.calls.count()).toEqual(0);
+  });
+
   it('onMouseDown', function() {
     this.rectangle = new Mirador.Rectangle(); // TODO should use stubbed tool
     spyOn(this.rectangle, 'onMouseDown');
@@ -346,6 +377,10 @@ describe('Overlay', function() {
     this.overlay.latestMouseDownTime = date.getTime();
     this.overlay.overlay = this.overlay;
     this.overlay.disabled = true;
+
+    this.overlay.currentTool = this.rectangle;
+    this.overlay.mode = 'create';
+
     this.overlay.onMouseDown(event);
 
     expect(this.rectangle.onMouseDown.calls.count()).toEqual(0);
@@ -353,12 +388,15 @@ describe('Overlay', function() {
 
     this.overlay.currentTool = this.rectangle;
     this.overlay.disabled = false;
+    this.overlay.mode = 'create';
+
     this.overlay.onMouseDown(event);
 
     expect(this.rectangle.onMouseDown.calls.count()).toEqual(0);
     expect(this.rectangle.onDoubleClick.calls.count()).toEqual(1);
 
     this.overlay.latestMouseDownTime -= 2 * this.overlay.doubleClickReactionTime;
+
     this.overlay.onMouseDown(event);
 
     expect(this.rectangle.onMouseDown.calls.count()).toEqual(1);
@@ -374,6 +412,7 @@ describe('Overlay', function() {
 
     // hover item
     event.item = this.rectangle.createShape(event.point, this.overlay);
+    event.item.data.editable = true;
     this.overlay.latestMouseDownTime -= 2 * this.overlay.doubleClickReactionTime;
     this.overlay.currentTool = this.rectangle;
     this.overlay.onMouseDown(event);
@@ -381,22 +420,25 @@ describe('Overlay', function() {
     expect(this.rectangle.onMouseDown.calls.count()).toEqual(2);
     expect(this.rectangle.onDoubleClick.calls.count()).toEqual(1);
 
-    // hover new item and add to edited paths
-    event.item = this.rectangle.createShape(event.point, this.overlay);
-    this.overlay.latestMouseDownTime -= 2 * this.overlay.doubleClickReactionTime;
-    this.overlay.mode = 'translate';
-    this.overlay.path = event.item;
-    this.overlay.path.data.annotation = '<svg>stored svg</svg>';
-    this.overlay.onMouseDown(event);
-
-    expect(this.rectangle.onMouseDown.calls.count()).toEqual(3);
-    expect(this.rectangle.onDoubleClick.calls.count()).toEqual(1);
+    // // hover new item and add to edited paths
+    this.overlay.currentTool = this.rectangle;
+     event.item = this.rectangle.createShape(event.point, this.overlay); // TODO SEEMS TO BE OUTDATED test
+     event.item.data.editable = true;
+    // this.overlay.latestMouseDownTime -= 2 * this.overlay.doubleClickReactionTime;
+    // this.overlay.mode = 'translate';
+    // this.overlay.path = event.item;
+    // this.overlay.path.data.annotation = '<svg>stored svg</svg>';
+    // this.overlay.onMouseDown(event);
+    //
+    // expect(this.rectangle.onMouseDown.calls.count()).toEqual(3);
+    // expect(this.rectangle.onDoubleClick.calls.count()).toEqual(1);
 
     // hover new item
     this.overlay.latestMouseDownTime -= 2 * this.overlay.doubleClickReactionTime;
+
     this.overlay.onMouseDown(event);
 
-    expect(this.rectangle.onMouseDown.calls.count()).toEqual(4);
+    expect(this.rectangle.onMouseDown.calls.count()).toEqual(3);
     expect(this.rectangle.onDoubleClick.calls.count()).toEqual(1);
 
     this.overlay.restoreEditedShapes();
@@ -413,8 +455,9 @@ describe('Overlay', function() {
       'x': 1000,
       'y': 1000
     });
-    this.ellipse = new Mirador.Ellipse();
+    this.ellipse = new Mirador.Ellipse(); // TODO SHOULD STUB
     var newShape = this.ellipse.createShape(event.point, this.overlay);
+    newShape.data.editable = true;
     this.overlay.mode = '';
 
     this.overlay.onMouseDown(event);

--- a/spec/annotations/osd-svg-polygon.test.js
+++ b/spec/annotations/osd-svg-polygon.test.js
@@ -169,7 +169,7 @@ describe('Polygon', function() {
         'y': -3
       });
       this.polygon.updateSelection(true,this.shape,overlay);
-      overlay.mode = 'edit';
+      overlay.mode = 'translate';
       overlay.path = this.shape;
 
       var expected = [];
@@ -190,7 +190,7 @@ describe('Polygon', function() {
 
       var selectedPointIndex = 1;
       overlay = MockOverlay.getOverlay(paper);
-      overlay.mode = 'edit';
+      overlay.mode = 'deform';
       overlay.path = this.shape;
       overlay.segment = this.shape.segments[selectedPointIndex];
 
@@ -224,7 +224,7 @@ describe('Polygon', function() {
         'x': 100,
         'y': 100
       });
-      overlay.mode = '';
+      overlay.mode = 'create';
       var expected = [];
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
         var point = {
@@ -243,6 +243,7 @@ describe('Polygon', function() {
 
       overlay = MockOverlay.getOverlay(paper);
       overlay.path = this.shape;
+      overlay.mode = 'create';
       this.polygon.onDoubleClick(event, overlay);
 
       for (var idx = 0; idx < this.shape.segments.length; idx++) {
@@ -259,6 +260,7 @@ describe('Polygon', function() {
       overlay.hitOptions.stroke = false;
       overlay.hitOptions.segments = false;
       overlay.hitOptions.tolerance = 5;
+      overlay.mode = 'create';
 
       expected.push(this.initialPoint);
       this.shape.add(this.initialPoint);

--- a/spec/utils/dialog-builder.test.js
+++ b/spec/utils/dialog-builder.test.js
@@ -1,18 +1,29 @@
 describe('Dialog Builder', function () {
 
-  // stub bootbox.js ( DialogBuilder is wrapper)
-
-  bootbox = jasmine.createSpy();
-
   beforeEach(function () {
+    // stub bootbox.js ( DialogBuilder is wrapper)
+    bootbox = jasmine.createSpy();
+    bootbox.confirm = jasmine.createSpy();
+    bootbox.dialog = jasmine.createSpy();
+    bootbox.setDefaults = jasmine.createSpy();
+
     this.dialogBuilder = new Mirador.DialogBuilder();
   });
 
-  it('should call underlying lib method', function () {
-    bootbox.confirm = jasmine.createSpy();
+  it('should call setDefaults',function(){
+    expect(bootbox.setDefaults).toHaveBeenCalled();
+  });
+
+  it('should call underlying confirm method', function () {
     var onConfirm = function(){};
     this.dialogBuilder.confirm('msg',onConfirm);
     expect(bootbox.confirm).toHaveBeenCalledWith('msg',onConfirm);
+  });
+
+  it('should call underlying dialog method',function(){
+    var opts = {};
+    this.dialogBuilder.dialog(opts);
+    expect(bootbox.dialog).toHaveBeenCalledWith(opts);
   })
 
 });


### PR DESCRIPTION
@rsinghal @beaudet
# This pull request adds :

## Main feature

Refactor pin tool / Refactor polygon tool / Refactor freehand tool to handle to be visually highlighted in edit mode

Fix deletion of only one point (freehand and polygon tool) https://github.com/IIIF/mirador/issues/986

Disable shape selecting when out of edit mode or create new annotation mode

## Additional features
Add stroke width change on newly created shapes

@rsinghal I have commented some code in order to review it and tell me if you agree on removing it 

# What should be done in other pull requests
Have appropriate cursor change (remove awsome cursor lib, and use only native) [generalize the solution for all shapes]

Change blue doth (for rotation) to rotate icon ( Which one do you suggest to use. I like the one in the mock ups but I cannot find it)


Refactor the whole osd-overlay test suite (after we all agree on the features and workings of the annotations)
Check out the whole annotation functionality for code/memory improvements (should have good coverage and really working tests first (not only blind covering) (we have them almost) )

---


With this pull request I think that https://github.com/IIIF/mirador/issues/881 is rather done (except the rotate icon and the cursors changes?

@rsinghal @beaudet Please share with me if I am missing something or you suggest any improvements.

---
### Found issues that will be fixed as part of this pull request:


- [x] https://github.com/IIIF/mirador/issues/1028 
- [x] https://github.com/IIIF/mirador/issues/1031
- [x] 
> Have an existing annotation for the image.
On that image, create an annotation wth one shape (in this case, I chose polygon) and save it.
Edit that new annotation and delete the shape.
Click Save and choose to delete the annotation in the modal (I can't test this with Saving the annotation without shapes because of the first bug).
Click to edit the existing annotation
Click anywhere on the image (not on one of the existing shapes), it starts drawing the points of a polygon, rather than doing nothing.

- [x] Styles for newly created shapes is not preserved when going to fullscreen mode


