### PR TITLE
remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "scripts": {
     "start": "bower install && grunt",
     "test": "./node_modules/grunt-cli/bin/grunt cover jshint coveralls --verbose --full",
-    "postinstall": "grunt default",
     "travis": "./node_modules/grunt-cli/bin/grunt ci --verbose --force"
   },
   "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "start": "bower install && grunt",
     "test": "./node_modules/grunt-cli/bin/grunt cover jshint coveralls --verbose --full",
-    "postinstall": "./node_modules/grunt/bin/grunt default",
+    "postinstall": "./node_modules/grunt-cli/bin/grunt default",
     "travis": "./node_modules/grunt-cli/bin/grunt ci --verbose --force"
   },
   "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   "scripts": {
     "start": "bower install && grunt",
     "test": "./node_modules/grunt-cli/bin/grunt cover jshint coveralls --verbose --full",
-    "travis": "./node_modules/grunt-cli/bin/grunt ci --verbose --force",
-    "postinstall": "./node_modules/grunt-cli/bin/grunt githooks"
+    "travis": "./node_modules/grunt-cli/bin/grunt ci --verbose --force"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "start": "bower install && grunt",
     "test": "./node_modules/grunt-cli/bin/grunt cover jshint coveralls --verbose --full",
-    "postinstall": "./node_modules/grunt-cli/bin/grunt default",
+    "postinstall": "grunt default",
     "travis": "./node_modules/grunt-cli/bin/grunt ci --verbose --force"
   },
   "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "start": "bower install && grunt",
     "test": "./node_modules/grunt-cli/bin/grunt cover jshint coveralls --verbose --full",
+    "postinstall": "./node_modules/grunt/bin/grunt default",
     "travis": "./node_modules/grunt-cli/bin/grunt ci --verbose --force"
   },
   "dependencies": {}


### PR DESCRIPTION
fixes https://github.com/IIIF/mirador/issues/821#issuecomment-238626079, allowing users to install mirador via `npm` like so: `npm install --save IIIF/mirador#release2.1`