### PR TITLE
Reset current tool after each click

### DIFF
--- a/js/src/annotations/annotation-utils.js
+++ b/js/src/annotations/annotation-utils.js
@@ -158,6 +158,7 @@
   DeleteActionIcon.prototype.setOnMouseDownListener = function (overlay) {
     this.mouseDown = function () {
       overlay.eventEmitter.publish('deleteShape.' + overlay.windowId, [this.getData('parent')]);
+      overlay.mode = 'delete';
     };
   };
 

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -98,6 +98,7 @@
       }
       jQuery('#' + osdViewerId).parents('.window').find('.qtip-viewer').hide();
       _this.currentTool = null;
+      _this.mode = '';
       for (var i = 0; i < _this.tools.length; i++) {
         if (_this.tools[i].logoClass === tool) {
           _this.currentTool = _this.tools[i];
@@ -492,10 +493,9 @@
           //if the user (re)clicked on an editable shape, the currentTool gets set below
           //if the user has clicked on "empty" space, return and don't do anything more
         //}
-
-        if(this.overlay.mode !== 'create'){
+        if(this.overlay.mode !== 'create' && this.overlay.mode !==''){
           this.overlay.mode = '';
-          this.currentTool = null;
+          this.overlay.currentTool = null;
         }
 
         if (hitResult && this.overlay.mode !== 'create') {
@@ -937,6 +937,7 @@
       this.segment = null;
       this.path = null;
       this.mode = '';
+      this.currentTool =null;
       this.draftPaths.push(shape);
 
       shape.data.editable = true;
@@ -952,7 +953,7 @@
       }
 
       if (this.availableExternalCommentsPanel) {
-        this.eventEmitter.publish('annotationShapeCreated.' + this.windowId, [this, shape]);//ne trbqva toq this
+        this.eventEmitter.publish('annotationShapeCreated.' + this.windowId, [this, shape]);
         return;
       }
       var _this = this;


### PR DESCRIPTION
@rsinghal 

Create one shape per tool selection. Reset current tool on every mousedown except when creating shape.

This is what we talked in https://github.com/IIIF/mirador/pull/1043.
I think this pull request fixes the issue.Check it out please and tell me if this is what we are looking for :)
