### PR TITLE
border and fill dropdowns are disabled (and their tooltips) when a us…

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1076,7 +1076,10 @@ li.highlight {
   font-size: 18px;
   z-index:2;
 }
-.hud-control:hover {
+.hud-control.hud-disabled {
+  opacity: 0.3;
+}
+.hud-control:not(.hud-disabled):hover {
   /*transition: all 0.3s ease;*/
   cursor: pointer;
   opacity: 1;
@@ -1208,6 +1211,7 @@ li.highlight {
   border-color: #ccc;
   height: 11px;
   border-radius: 3px;
+  cursor: default;
 }
 
 .mirador-osd-color-picker .material-icons {

--- a/js/src/widgets/contextControls.js
+++ b/js/src/widgets/contextControls.js
@@ -18,10 +18,18 @@
 
     init: function() {
       var _this = this;
-      var showStrokeStyle = false;
-      this.availableAnnotationStylePickers.forEach(function(picker){
-        if(picker == 'StrokeType'){
+      var showStrokeStyle = false,
+      showStrokeColor = false,
+      showFillColor = false;
+      this.availableAnnotationStylePickers.forEach(function(picker) {
+        if (picker === 'StrokeType') {
           showStrokeStyle = true;
+        }
+        if (picker === 'FillColor') {
+          showFillColor = true;
+        }
+        if (picker === 'StrokeColor') {
+          showStrokeColor = true;
         }
       });
       var annotationProperties = this.canvasControls.annotations;
@@ -31,6 +39,8 @@
           tools : _this.availableAnnotationTools,
           showEdit : annotationProperties.annotationCreation,
           showStrokeStyle: showStrokeStyle,
+          showStrokeColor: showStrokeColor,
+          showFillColor: showFillColor,
           showRefresh : annotationProperties.annotationRefresh
         })).appendTo(this.container.find('.mirador-osd-annotation-controls'));
         this.annotationElement.hide();
@@ -109,19 +119,6 @@
       setBackground.solid(this.container.find('.mirador-line-type .solid'));
       setBackground.dashed(this.container.find('.mirador-line-type .dashed'));
       setBackground.dotdashed(this.container.find('.mirador-line-type .dotdashed'));
-
-      this.container.find('.mirador-line-type').on('mouseenter', function() {
-        _this.container.find('.type-list').stop().slideFadeToggle(300);
-      });
-      this.container.find('.mirador-line-type').on('mouseleave', function() {
-        _this.container.find('.type-list').stop().slideFadeToggle(300);
-      });
-      this.container.find('.mirador-line-type').find('ul li').on('click', function() {
-        var className = jQuery(this).find('i').attr('class').replace(/fa/, '').replace(/ /, '');
-        _this.removeBackgroundImage(_this.container.find('.mirador-line-type .border-type-image'));
-        setBackground[className](_this.container.find('.mirador-line-type .border-type-image'));
-        _this.eventEmitter.publish('toggleBorderType.' + _this.windowId, className);
-      });
     },
 
     setBorderFillColorPickers: function() {
@@ -146,6 +143,9 @@
           _this.eventEmitter.publish('changeBorderColor.' + _this.windowId, color.toHexString());
           jQuery(this).spectrum("set", color.toHexString());
         },
+        move: function(color) {
+          _this.eventEmitter.publish('changeBorderColor.' + _this.windowId, color.toHexString());
+        },
         maxSelectionSize: 4,
         color: defaultBorderColor,
         palette: [
@@ -164,7 +164,6 @@
         showPalette: true,
         showButtons: false,
         showSelectionPalette: true,
-        hideAfterPaletteSelect: true,
         appendTo: 'parent',
         clickoutFiresChange: true,
         containerClassName: 'fillColorPickerPop'+_this.windowId,
@@ -172,6 +171,9 @@
         hide: function(color) {
           _this.eventEmitter.publish('changeFillColor.' + _this.windowId, [color.toHexString(), color.getAlpha()]);
           jQuery(this).spectrum("set", color);
+        },
+        move: function(color) {
+          _this.eventEmitter.publish('changeFillColor.' + _this.windowId, [color.toHexString(), color.getAlpha()]);
         },
         maxSelectionSize: 4,
         color: colorObj,
@@ -203,6 +205,19 @@
 
     bindEvents: function() {
       var _this = this;
+
+      this.container.find('.mirador-line-type.hud-enabled').on('mouseenter', function() {
+        _this.container.find('.type-list').stop().slideFadeToggle(300);
+      });
+      this.container.find('.mirador-line-type.hud-enabled').on('mouseleave', function() {
+        _this.container.find('.type-list').stop().slideFadeToggle(300);
+      });
+      this.container.find('.mirador-line-type.hud-enabled').find('ul li').on('click', function() {
+        var className = jQuery(this).find('i').attr('class').replace(/fa/, '').replace(/ /, '');
+        _this.removeBackgroundImage(_this.container.find('.mirador-line-type .border-type-image'));
+        setBackground[className](_this.container.find('.mirador-line-type .border-type-image'));
+        _this.eventEmitter.publish('toggleBorderType.' + _this.windowId, className);
+      });
     },
 
     annotationTemplate: Handlebars.compile([
@@ -216,7 +231,7 @@
                                    '</a>',
                                    '{{/each}}',
                                    '{{#if showStrokeStyle}}',
-                                   '<a class="hud-control mirador-line-type" role="button" aria-label="{{t "borderTypeTooltip"}}" title="{{t "borderTypeTooltip"}}">',
+                                   '<a class="hud-control hud-dropdown hud-disabled mirador-line-type" aria-label="{{t "borderTypeTooltip"}}" title="{{t "borderTypeTooltip"}}">',
                                    '<i class="material-icons mirador-border-icon">create</i>',
                                    '<i class="border-type-image solid"></i>',
                                    '<i class="fa fa-caret-down dropdown-icon"></i>',
@@ -227,12 +242,16 @@
                                    '</ul>',
                                    '</a>',
                                    '{{/if}}',
-                                   '<a class="hud-control mirador-osd-color-picker" title="{{t "borderColorTooltip"}}">',
+                                   '{{#if showStrokeColor}}',
+                                   '<a class="hud-control hud-dropdown hud-disabled mirador-osd-color-picker" title="{{t "borderColorTooltip"}}">',
                                    '<input type="text" class="borderColorPicker"/>',
                                    '</a>',
-                                   '<a class="hud-control mirador-osd-color-picker" title="{{t "fillColorTooltip"}}">',
+                                   '{{/if}}',
+                                   '{{#if showFillColor}}',
+                                   '<a class="hud-control hud-dropdown hud-disabled mirador-osd-color-picker" title="{{t "fillColorTooltip"}}">',
                                    '<input type="text" class="fillColorPicker"/>',
                                    '</a>',
+                                   '{{/if}}',
                                    '{{#if showRefresh}}',
                                      '<a class="hud-control mirador-osd-refresh-mode">',
                                      '<i class="fa fa-lg fa-refresh"></i>',

--- a/js/src/widgets/hud.js
+++ b/js/src/widgets/hud.js
@@ -42,7 +42,19 @@
         });
       }
 
+      this.listenForActions();
       this.bindEvents();
+    },
+
+    listenForActions: function() {
+      var _this = this;
+      this.eventEmitter.subscribe('DISABLE_TOOLTIPS_BY_CLASS.' + this.windowId, function(event, className) {
+        _this.element.find(className).qtip('disable');
+      });
+
+      this.eventEmitter.subscribe('ENABLE_TOOLTIPS_BY_CLASS.' + this.windowId, function(event, className) {
+        _this.element.find(className).qtip('enable');
+      });
     },
 
     bindEvents: function() {
@@ -80,6 +92,8 @@
             }
             _this.eventEmitter.publish('modeChange.' + _this.windowId, 'displayAnnotations');
             _this.eventEmitter.publish('HUD_ADD_CLASS.'+_this.windowId, ['.mirador-osd-pointer-mode', 'selected']);
+            _this.eventEmitter.publish('HUD_ADD_CLASS.'+_this.windowId, ['.hud-dropdown', 'hud-disabled']);
+            _this.eventEmitter.publish('DISABLE_TOOLTIPS_BY_CLASS.'+_this.windowId, '.hud-dropdown');
             _this.eventEmitter.publish('DEFAULT_CURSOR.' + _this.windowId);
             _this.eventEmitter.publish(('windowUpdated'), {
               id: _this.windowId,
@@ -103,6 +117,8 @@
           onchoosePointer: function(event, from, to) {
             _this.eventEmitter.publish('HUD_REMOVE_CLASS.'+_this.windowId, ['.mirador-osd-edit-mode', 'selected']);
             _this.eventEmitter.publish('HUD_ADD_CLASS.'+_this.windowId, ['.mirador-osd-pointer-mode', 'selected']);
+            _this.eventEmitter.publish('HUD_ADD_CLASS.'+_this.windowId, ['.hud-dropdown', 'hud-disabled']);
+            _this.eventEmitter.publish('DISABLE_TOOLTIPS_BY_CLASS.'+_this.windowId, '.hud-dropdown');
             _this.eventEmitter.publish('CANCEL_ACTIVE_ANNOTATIONS.'+_this.windowId);
             _this.eventEmitter.publish('modeChange.' + _this.windowId, 'displayAnnotations');
             _this.eventEmitter.publish('DEFAULT_CURSOR.' + _this.windowId);
@@ -114,6 +130,8 @@
           onchooseShape: function(event, from, to, shape) {
             _this.eventEmitter.publish('HUD_REMOVE_CLASS.'+_this.windowId, ['.mirador-osd-pointer-mode', 'selected']);
             _this.eventEmitter.publish('HUD_REMOVE_CLASS.'+_this.windowId, ['.mirador-osd-edit-mode', 'selected']);
+            _this.eventEmitter.publish('HUD_REMOVE_CLASS.'+_this.windowId, ['.hud-dropdown', 'hud-disabled']);
+            _this.eventEmitter.publish('ENABLE_TOOLTIPS_BY_CLASS.'+_this.windowId, '.hud-dropdown');
             _this.eventEmitter.publish('HUD_ADD_CLASS.'+_this.windowId, ['.mirador-osd-'+shape+'-mode', 'selected']);
             _this.eventEmitter.publish('modeChange.' + _this.windowId, 'creatingAnnotation');
             _this.eventEmitter.publish('CROSSHAIR_CURSOR.' + _this.windowId);
@@ -127,6 +145,8 @@
           onchangeShape: function(event, from, to, shape) {
             _this.eventEmitter.publish('HUD_REMOVE_CLASS.'+_this.windowId, ['.mirador-osd-pointer-mode', 'selected']);
             _this.eventEmitter.publish('HUD_REMOVE_CLASS.'+_this.windowId, ['.mirador-osd-edit-mode', 'selected']);
+            _this.eventEmitter.publish('HUD_REMOVE_CLASS.'+_this.windowId, ['.hud-dropdown', 'hud-disabled']);
+            _this.eventEmitter.publish('ENABLE_TOOLTIPS_BY_CLASS.'+_this.windowId, '.hud-dropdown');
             _this.eventEmitter.publish('HUD_ADD_CLASS.'+_this.windowId, ['.mirador-osd-'+shape+'-mode', 'selected']);
             _this.eventEmitter.publish('CROSSHAIR_CURSOR.' + _this.windowId);
             //don't need to trigger a mode change, just change tool

--- a/js/src/widgets/imageView.js
+++ b/js/src/widgets/imageView.js
@@ -164,6 +164,9 @@
       _this.eventEmitter.subscribe('CROSSHAIR_CURSOR.' + _this.windowId, function(event) {
         jQuery(_this.osd.canvas).css("cursor", "crosshair");
       });
+      _this.eventEmitter.subscribe('POINTER_CURSOR.' + _this.windowId, function(event) {
+        jQuery(_this.osd.canvas).css("cursor", "pointer");
+      });
       //Related to Annotations HUD
     },
 


### PR DESCRIPTION
…er hasn't actively selected an existing shape or drawing a new shape. Update the fill color of an annotation as a user is dragging.  also make sure a user can draw multiple of the same shape without having to re-select it.  better cursor feedback as well during annotation drawing and editing.

closes #1066, addresses part of #1067