### PR TITLE
Fixed missing background on manifest loading screen

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -233,7 +233,7 @@ a {
   top: 0;
   display: none;
   overflow: hidden;
-  z-index: 18000; // Must be higher than Qtip elements.
+  z-index: 18000; /* Must be higher than Qtip elements. */
   background-color: #fff;
   box-shadow: 0 0 6px #333;
 }


### PR DESCRIPTION
This pull request restores the background colour lost in commit [5b0eb0b](https://github.com/IIIF/mirador/commit/5b0eb0beee02b30ceef2ec87b85062d0c8f750a9). Both Chrome and Firefox treated the `//` comment as invalid CSS and ignored the two properties below it.